### PR TITLE
Change kops node size to allow for greater memory use

### DIFF
--- a/kops/cloud-platform-live-0.yaml
+++ b/kops/cloud-platform-live-0.yaml
@@ -265,7 +265,7 @@ metadata:
   name: nodes
 spec:
   image: kope.io/k8s-1.8-debian-jessie-amd64-hvm-ebs-2018-01-14
-  machineType: c4.xlarge
+  machineType: c4.2xlarge
   maxSize: 6
   minSize: 6
   role: Node


### PR DESCRIPTION
**Overview**
---
It has come to light that our current node size on live-0 is far too small. Whilst investigating a Prometheus issue a node size of 7.5MiB is far too small. Prometheus itself is asking for ~4.5. 

This causes scheduling problems when a node reaches a certain limit and cannot be resolved by horizontally scaling. 

**Implementation**
---
The implementation has already taken place and is now active in Live-0. This PR is to record the change and the state. 