### PR TITLE
Kops template label change

### DIFF
--- a/terraform/cloud-platform/templates/kops.yaml.tpl
+++ b/terraform/cloud-platform/templates/kops.yaml.tpl
@@ -313,10 +313,8 @@ spec:
   maxSize: 1
   minSize: 1
   cloudLabels:
-    application: justice-cloud-platform
-    business-unit: hq
-    component: master
-    infrastructure-support: platforms@digital.justice.gov.uk
+    application: moj-cloud-platform
+    business-unit: platforms
     is-production: true
     kops.k8s.io/instancegroup: master-eu-west-1a
     owner: cloud-platform:platforms@digital.justice.gov.uk
@@ -340,10 +338,8 @@ spec:
   maxSize: 1
   minSize: 1
   cloudLabels:
-    application: justice-cloud-platform
-    business-unit: hq
-    component: master
-    infrastructure-support: platforms@digital.justice.gov.uk
+    application: moj-cloud-platform
+    business-unit: platforms
     is-production: true
     kops.k8s.io/instancegroup: master-eu-west-1b
     owner: cloud-platform:platforms@digital.justice.gov.uk
@@ -367,10 +363,8 @@ spec:
   maxSize: 1
   minSize: 1
   cloudLabels:
-    application: justice-cloud-platform
-    business-unit: hq
-    component: master
-    infrastructure-support: platforms@digital.justice.gov.uk
+    application: moj-cloud-platform
+    business-unit: platforms
     is-production: true
     kops.k8s.io/instancegroup: master-eu-west-1c
     owner: cloud-platform:platforms@digital.justice.gov.uk
@@ -394,10 +388,8 @@ spec:
   maxSize: 6
   minSize: 6
   cloudLabels:
-    application: justice-cloud-platform
-    business-unit: hq
-    component: node
-    infrastructure-support: platforms@digital.justice.gov.uk
+    application: moj-cloud-platform
+    business-unit: platforms
     is-production: true
     kops.k8s.io/instancegroup: nodes
     owner: cloud-platform:platforms@digital.justice.gov.uk


### PR DESCRIPTION
**Overview**
---
Following on from PR #112 the below request was made. This PR encompasses that request along with the removal of the `component` tag, as this was duplicated.

```
stevemarshall [19:06]
@jasonb That’s ace! One minor thing: `business-unit` should be `platforms`. Also, I might argue for `MOJ Cloud Platform` for `application`, and `infrastructure-support` is optional (for cases like this).
So that was three things, actually. Still: thanks for doing this so quickly!
```