### PR TITLE
Add second pod for Kuberos app

### DIFF
--- a/terraform/cloud-platform-components/kuberos.tf
+++ b/terraform/cloud-platform-components/kuberos.tf
@@ -34,6 +34,11 @@ resource "helm_release" "kuberos" {
     value = "${data.terraform_remote_state.cluster.oidc_client_secret}"
   }
 
+  set {
+    name  = "replicaCount"
+    value = "2"
+  }
+
   depends_on = ["null_resource.deploy"]
 
   lifecycle {


### PR DESCRIPTION
This PR changes the replica count for the kuberos app from 1 to 2 so there is redundancy if one of the pods fails for any reason. 