### PR TITLE
Add manage_dns variable for haproxy module

### DIFF
--- a/haproxy/dns.tf
+++ b/haproxy/dns.tf
@@ -1,7 +1,12 @@
 resource "aws_route53_record" "www" {
+  count   = "${var.manage_alias ? 1 : 0}"
   zone_id = "${var.parent_zone}"
   name    = "${var.haproxy_domain}"
-  type    = "CNAME"
-  records = ["${aws_lb.haproxy_alb.dns_name}"]
-  ttl     = "300"
+  type    = "A"
+
+  alias {
+    name                   = "${aws_lb.haproxy_alb.dns_name}"
+    zone_id                = "${aws_lb.haproxy_alb.zone_id}"
+    evaluate_target_health = false
+  }
 }

--- a/haproxy/outputs.tf
+++ b/haproxy/outputs.tf
@@ -7,7 +7,7 @@ output "alb-dns" {
 }
 
 output "haproxy-dns" {
-  value = "${aws_route53_record.www.name}"
+  value = "${var.haproxy_domain}"
 }
 
 output "public-ips" {

--- a/haproxy/variables.tf
+++ b/haproxy/variables.tf
@@ -63,3 +63,7 @@ variable "sns_arns" {
   type    = "list"
   default = []
 }
+
+variable "manage_alias" {
+  default = false
+}


### PR DESCRIPTION
This is a boolean value to determine whether the module will manage the top-level DNS record. This is for cases where this record is already managed (eg. cloudformation) and we don't want to manage it in two places.