### PR TITLE
Kubelet updates

### DIFF
--- a/terraform/cloud-platform/templates/kops.yaml.tpl
+++ b/terraform/cloud-platform/templates/kops.yaml.tpl
@@ -222,6 +222,7 @@ spec:
     legacy: false
   kubelet:
     anonymousAuth: false
+    readOnlyPort: 0
   kubeAPIServer:
     oidcClientID: ${oidc_client_id}
     oidcIssuerURL: ${oidc_issuer_url}

--- a/terraform/cloud-platform/templates/kops.yaml.tpl
+++ b/terraform/cloud-platform/templates/kops.yaml.tpl
@@ -223,6 +223,7 @@ spec:
   kubelet:
     anonymousAuth: false
     readOnlyPort: 0
+    authenticationTokenWebhook: true
   kubeAPIServer:
     oidcClientID: ${oidc_client_id}
     oidcIssuerURL: ${oidc_issuer_url}


### PR DESCRIPTION
* disable read-only port
* enable `authentication-token-webhook` (allows prom to properly scrape kubelets and authenticated users to hit the api, see [here](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet-authentication-authorization/#kubelet-authentication))