### PR TITLE
Kiam cluster component

### DIFF
--- a/terraform/cloud-platform-components/README.md
+++ b/terraform/cloud-platform-components/README.md
@@ -1,0 +1,53 @@
+# cloud-platform-components
+
+## kiam
+
+Example of IAM policy for a user application:
+
+```hcl
+data "aws_caller_identity" "current" {}
+
+resource "aws_iam_role" "app" {
+  name = "app_role"
+  path = "/"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "AWS": [
+          "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/nodes.${data.terraform_remote_state.cluster.cluster_domain_name}"
+        ]
+      },
+      "Effect": "Allow"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "app" {
+  name = "policy"
+  role = "${aws_iam_role.app.id}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DescribeInstances"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+```
+
+This can easily be configured as part of a user environment's resources, along with the required namespace annotation (see the [kiam docs](https://github.com/uswitch/kiam#overview)).

--- a/terraform/cloud-platform-components/kiam.tf
+++ b/terraform/cloud-platform-components/kiam.tf
@@ -105,10 +105,11 @@ data "template_file" "kiam" {
 }
 
 resource "helm_release" "kiam" {
-  name      = "kiam"
-  chart     = "stable/kiam"
-  namespace = "kiam"
-  version   = "2.0.0-rc3"
+  name          = "kiam"
+  chart         = "stable/kiam"
+  namespace     = "kiam"
+  version       = "2.0.0-rc3"
+  recreate_pods = "true"
 
   values = [
     "${data.template_file.kiam.rendered}",

--- a/terraform/cloud-platform-components/kiam.tf
+++ b/terraform/cloud-platform-components/kiam.tf
@@ -177,3 +177,14 @@ resource "kubernetes_service" "agent-metrics" {
     }
   }
 }
+
+resource "null_resource" "kiam_servicemonitor" {
+  provisioner "local-exec" {
+    command = "kubectl apply -f ${path.module}/resources/kiam-servicemonitor.yaml"
+  }
+
+  provisioner "local-exec" {
+    when    = "destroy"
+    command = "kubectl delete -f ${path.module}/resources/kiam-servicemonitor.yaml"
+  }
+}

--- a/terraform/cloud-platform-components/kiam.tf
+++ b/terraform/cloud-platform-components/kiam.tf
@@ -129,6 +129,8 @@ resource "helm_release" "kiam" {
 }
 
 resource "kubernetes_service" "server-metrics" {
+  depends_on = ["helm_release.kiam"]
+
   metadata {
     name      = "kiam-server-metrics"
     namespace = "kiam"
@@ -154,6 +156,8 @@ resource "kubernetes_service" "server-metrics" {
 }
 
 resource "kubernetes_service" "agent-metrics" {
+  depends_on = ["helm_release.kiam"]
+
   metadata {
     name      = "kiam-agent-metrics"
     namespace = "kiam"
@@ -179,6 +183,8 @@ resource "kubernetes_service" "agent-metrics" {
 }
 
 resource "null_resource" "kiam_servicemonitor" {
+  depends_on = ["helm_release.kiam", "helm_release.kube_prometheus"]
+
   provisioner "local-exec" {
     command = "kubectl apply -f ${path.module}/resources/kiam-servicemonitor.yaml"
   }

--- a/terraform/cloud-platform-components/kiam.tf
+++ b/terraform/cloud-platform-components/kiam.tf
@@ -104,6 +104,12 @@ data "template_file" "kiam" {
   }
 }
 
+resource "null_resource" "kube_system_kiam_annotation" {
+  provisioner "local-exec" {
+    command = "kubectl annotate --overwrite namespace kube-system 'iam.amazonaws.com/permitted=.*'"
+  }
+}
+
 resource "helm_release" "kiam" {
   name          = "kiam"
   chart         = "stable/kiam"

--- a/terraform/cloud-platform-components/kiam.tf
+++ b/terraform/cloud-platform-components/kiam.tf
@@ -1,0 +1,122 @@
+resource "tls_private_key" "ca" {
+  algorithm   = "ECDSA"
+  ecdsa_curve = "P384"
+}
+
+resource "tls_self_signed_cert" "ca" {
+  key_algorithm     = "${tls_private_key.ca.algorithm}"
+  private_key_pem   = "${tls_private_key.ca.private_key_pem}"
+  is_ca_certificate = true
+
+  validity_period_hours = 87600 // 10 years
+  early_renewal_hours   = 720   // 1 month
+
+  subject {
+    common_name = "Kiam CA"
+  }
+
+  allowed_uses = [
+    "cert_signing",
+    "crl_signing",
+  ]
+}
+
+resource "tls_private_key" "agent" {
+  algorithm   = "ECDSA"
+  ecdsa_curve = "P384"
+}
+
+resource "tls_cert_request" "agent" {
+  key_algorithm   = "${tls_private_key.agent.algorithm}"
+  private_key_pem = "${tls_private_key.agent.private_key_pem}"
+
+  subject {
+    common_name = "Kiam Agent"
+  }
+}
+
+resource "tls_locally_signed_cert" "agent" {
+  cert_request_pem   = "${tls_cert_request.agent.cert_request_pem }"
+  ca_key_algorithm   = "${tls_private_key.ca.algorithm}"
+  ca_private_key_pem = "${tls_private_key.ca.private_key_pem}"
+  ca_cert_pem        = "${tls_self_signed_cert.ca.cert_pem}"
+
+  validity_period_hours = 87600 // 1 year
+  early_renewal_hours   = 720   // 1 month
+
+  allowed_uses = [
+    "key_encipherment",
+    "digital_signature",
+    "client_auth",
+    "server_auth",
+  ]
+}
+
+resource "tls_private_key" "server" {
+  algorithm   = "ECDSA"
+  ecdsa_curve = "P384"
+}
+
+resource "tls_cert_request" "server" {
+  key_algorithm   = "${tls_private_key.server.algorithm}"
+  private_key_pem = "${tls_private_key.server.private_key_pem}"
+
+  subject {
+    common_name = "Kiam Server"
+  }
+
+  dns_names = [
+    "kiam-server",
+  ]
+
+  ip_addresses = [
+    "127.0.0.1",
+  ]
+}
+
+resource "tls_locally_signed_cert" "server" {
+  cert_request_pem   = "${tls_cert_request.server.cert_request_pem }"
+  ca_key_algorithm   = "${tls_private_key.ca.algorithm}"
+  ca_private_key_pem = "${tls_private_key.ca.private_key_pem}"
+  ca_cert_pem        = "${tls_self_signed_cert.ca.cert_pem}"
+
+  validity_period_hours = 87600 // 1 year
+  early_renewal_hours   = 720   // 1 month
+
+  allowed_uses = [
+    "key_encipherment",
+    "digital_signature",
+    "client_auth",
+    "server_auth",
+  ]
+}
+
+data "template_file" "kiam" {
+  template = "${file("${path.module}/templates/kiam.yaml.tpl")}"
+
+  vars = {
+    kiam_version = "v3.0"
+    ca           = "${base64encode(tls_self_signed_cert.ca.cert_pem)}"
+    agent_cert   = "${base64encode(tls_locally_signed_cert.agent.cert_pem)}"
+    agent_key    = "${base64encode(tls_private_key.agent.private_key_pem)}"
+    server_cert  = "${base64encode(tls_locally_signed_cert.server.cert_pem)}"
+    server_key   = "${base64encode(tls_private_key.server.private_key_pem)}"
+  }
+}
+
+resource "helm_release" "kiam" {
+  name      = "kiam"
+  chart     = "stable/kiam"
+  namespace = "kiam"
+  version   = "2.0.0-rc3"
+
+  values = [
+    "${data.template_file.kiam.rendered}",
+  ]
+
+  depends_on = ["null_resource.deploy"]
+
+  lifecycle {
+    ignore_changes = ["keyring"]
+  }
+}

--- a/terraform/cloud-platform-components/kiam.tf
+++ b/terraform/cloud-platform-components/kiam.tf
@@ -41,8 +41,8 @@ resource "tls_locally_signed_cert" "agent" {
   ca_private_key_pem = "${tls_private_key.ca.private_key_pem}"
   ca_cert_pem        = "${tls_self_signed_cert.ca.cert_pem}"
 
-  validity_period_hours = 87600 // 1 year
-  early_renewal_hours   = 720   // 1 month
+  validity_period_hours = 8760 // 1 year
+  early_renewal_hours   = 720  // 1 month
 
   allowed_uses = [
     "key_encipherment",
@@ -80,8 +80,8 @@ resource "tls_locally_signed_cert" "server" {
   ca_private_key_pem = "${tls_private_key.ca.private_key_pem}"
   ca_cert_pem        = "${tls_self_signed_cert.ca.cert_pem}"
 
-  validity_period_hours = 87600 // 1 year
-  early_renewal_hours   = 720   // 1 month
+  validity_period_hours = 8760 // 1 year
+  early_renewal_hours   = 720  // 1 month
 
   allowed_uses = [
     "key_encipherment",

--- a/terraform/cloud-platform-components/kiam.tf
+++ b/terraform/cloud-platform-components/kiam.tf
@@ -127,3 +127,53 @@ resource "helm_release" "kiam" {
     ignore_changes = ["keyring"]
   }
 }
+
+resource "kubernetes_service" "server-metrics" {
+  metadata {
+    name      = "kiam-server-metrics"
+    namespace = "kiam"
+
+    labels {
+      app       = "kiam"
+      component = "server-metrics"
+    }
+  }
+
+  spec {
+    selector {
+      component = "server"
+    }
+
+    port {
+      name        = "metrics"
+      port        = 9621
+      target_port = 9621
+      protocol    = "TCP"
+    }
+  }
+}
+
+resource "kubernetes_service" "agent-metrics" {
+  metadata {
+    name      = "kiam-agent-metrics"
+    namespace = "kiam"
+
+    labels {
+      app       = "kiam"
+      component = "agent-metrics"
+    }
+  }
+
+  spec {
+    selector {
+      component = "agent"
+    }
+
+    port {
+      name        = "metrics"
+      port        = 9620
+      target_port = 9620
+      protocol    = "TCP"
+    }
+  }
+}

--- a/terraform/cloud-platform-components/resources/kiam-servicemonitor.yaml
+++ b/terraform/cloud-platform-components/resources/kiam-servicemonitor.yaml
@@ -1,0 +1,35 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: kiam-server
+  namespace: kiam
+spec:
+  jobLabel: app
+  selector:
+    matchLabels:
+      app: kiam
+      component: server-metrics
+  namespaceSelector:
+    matchNames:
+      - kiam
+  endpoints:
+    - port: metrics
+      interval: 30s
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: kiam-agent
+  namespace: kiam
+spec:
+  jobLabel: app
+  selector:
+    matchLabels:
+      app: kiam
+      component: agent-metrics
+  namespaceSelector:
+    matchNames:
+      - kiam
+  endpoints:
+    - port: metrics
+      interval: 30s

--- a/terraform/cloud-platform-components/templates/kiam.yaml.tpl
+++ b/terraform/cloud-platform-components/templates/kiam.yaml.tpl
@@ -51,10 +51,9 @@ server:
   ## Pod tolerations
   ## Ref https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   ##
-  ## XXX OA:
+  tolerations: []
   # - key: node-role.kubernetes.io/master
   #   effect: NoSchedule
-  tolerations: []
 
   ## Additional container hostPath mounts
   ##

--- a/terraform/cloud-platform-components/templates/kiam.yaml.tpl
+++ b/terraform/cloud-platform-components/templates/kiam.yaml.tpl
@@ -1,0 +1,70 @@
+extraArgs: {}
+
+agent:
+  image:
+    tag: ${ kiam_version }
+
+  gatewayTimeoutCreation: 500ms
+
+  ## Host networking settings
+  ##
+  host:
+    iptables: true
+    port: 8181
+    interface: cali+
+
+  ## Node labels for pod assignment
+  ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector:
+    # kubernetes.io/role: node
+
+  ## Additional container hostPath mounts
+  ##
+  extraHostPathMounts:
+  - name: ssl-certs
+    mountPath: /etc/ssl/certs
+    hostPath: /etc/ssl/certs
+    readOnly: true
+
+  ## Base64-encoded PEM values for agent's CA certificate(s), certificate and private key
+  ##
+  tlsFiles:
+    ca: ${ ca }
+    cert: ${ agent_cert }
+    key: ${ agent_key }
+
+server:
+  image:
+    tag: ${ kiam_version }
+
+  probes:
+    serverAddress: 127.0.0.1
+
+  gatewayTimeoutCreation: 500ms
+
+  nodeSelector: {}
+    # kubernetes.io/role: master
+
+  ## Pod tolerations
+  ## Ref https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  ## XXX OA:
+  # - key: node-role.kubernetes.io/master
+  #   effect: NoSchedule
+  tolerations: []
+
+  ## Additional container hostPath mounts
+  ##
+  extraHostPathMounts:
+  - name: ssl-certs
+    mountPath: /etc/ssl/certs
+    hostPath: /etc/ssl/certs
+    readOnly: true
+
+  ## Base64-encoded PEM values for server's CA certificate(s), certificate and private key
+  ##
+  tlsFiles:
+    ca: ${ ca }
+    cert: ${ server_cert }
+    key: ${ server_key }

--- a/terraform/cloud-platform-components/templates/kiam.yaml.tpl
+++ b/terraform/cloud-platform-components/templates/kiam.yaml.tpl
@@ -35,6 +35,8 @@ agent:
     key: ${ agent_key }
 
 server:
+  useHostNetwork: true
+
   image:
     tag: ${ kiam_version }
 

--- a/terraform/cloud-platform-components/templates/kiam.yaml.tpl
+++ b/terraform/cloud-platform-components/templates/kiam.yaml.tpl
@@ -69,3 +69,6 @@ server:
     ca: ${ ca }
     cert: ${ server_cert }
     key: ${ server_key }
+
+  prometheus:
+    port: 9621

--- a/terraform/cloud-platform/kops.tf
+++ b/terraform/cloud-platform/kops.tf
@@ -8,7 +8,6 @@ data "template_file" "kops" {
 
   vars {
     cluster_domain_name                  = "${local.cluster_base_domain_name}"
-    hosted_zone_id                       = "${module.cluster_dns.cluster_dns_zone_id}"
     kops_state_store                     = "${data.terraform_remote_state.global.kops_state_store}"
     oidc_issuer_url                      = "${local.oidc_issuer_url}"
     oidc_client_id                       = "${auth0_client.kubernetes.client_id}"

--- a/terraform/cloud-platform/templates/kops.yaml.tpl
+++ b/terraform/cloud-platform/templates/kops.yaml.tpl
@@ -170,29 +170,6 @@ spec:
   api:
     loadBalancer:
       type: Public
-  additionalPolicies:
-    node: |
-      [
-        {
-          "Effect": "Allow",
-          "Action": [
-            "route53:ChangeResourceRecordSets"
-          ],
-          "Resource": [
-            "arn:aws:route53:::hostedzone/${hosted_zone_id}"
-          ]
-        },
-        {
-          "Effect": "Allow",
-          "Action": [
-            "route53:ListHostedZones",
-            "route53:ListResourceRecordSets"
-          ],
-          "Resource": [
-            "*"
-          ]
-        }
-      ]
   authorization:
     rbac: {}
   channel: stable


### PR DESCRIPTION
Connects to https://github.com/ministryofjustice/cloud-platform/issues/564

In order to simplify the setup, kiam agent `Pods` run only on node hosts. This allows other `Pods` running on master hosts to assume the host's IAM role as before and avoids breaking any of the kubernetes components. We do not intent to run user workload on master nodes so this should be safe. However, it is probably now worth enabling the [`PodTolerationRestriction` admission controller](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#podtolerationrestriction) to actually prevent user workload from being scheduled on a master node.

Because the trust (assume) policy uses an instance role as a principal (see the example in the README), we need to run kiam server `Pods` on a specific set of hosts (masters or nodes). This implementation places kiam server `Pods` on node hosts alongside the agents. Alternatively, based on [this document](https://github.com/uswitch/kiam/blob/master/docs/IAM.md) kiam-server can be assigned a dedicated role that it will assume before requesting credentials for any other `Pod`. This has not been implemented here, to reduce complexity.

Although seemingly not critical to the operation of kiam, the latest version of the chart does not include [this fix](https://github.com/uswitch/kiam/pull/174) which causes some error to appear in the kiam-server logs.