### PR TITLE
Replace list() with splat syntax

### DIFF
--- a/haproxy/cloudwatch.tf
+++ b/haproxy/cloudwatch.tf
@@ -85,7 +85,7 @@ module "alb_alarms" {
   alb_arn_suffix                 = "${aws_lb.haproxy_alb.arn_suffix}"
   target_group_name              = "${aws_lb_target_group.haproxy_alb_target.name}"
   target_group_arn_suffix        = "${aws_lb_target_group.haproxy_alb_target.arn_suffix}"
-  notify_arns                    = "${concat(var.sns_arns, list(aws_sns_topic.c2s.arn))}"
+  notify_arns                    = "${compact(concat(var.sns_arns, aws_sns_topic.c2s.*.arn))}"
   target_3xx_count_threshold     = "-1"
   target_response_time_threshold = "2"
   treat_missing_data             = "ignore"


### PR DESCRIPTION
Fixes an error when the count is zero.