### PR TITLE
Update nginx-ingress to helm v1.1.4

### DIFF
--- a/terraform/cloud-platform-components/nginx-ingress.tf
+++ b/terraform/cloud-platform-components/nginx-ingress.tf
@@ -2,7 +2,7 @@ resource "helm_release" "nginx_ingress" {
   name      = "nginx-ingress"
   chart     = "stable/nginx-ingress"
   namespace = "ingress-controllers"
-  version   = "v0.29.0"
+  version   = "v1.1.4"
 
   values = [<<EOF
 controller:


### PR DESCRIPTION
**WHAT**
Update the helm chart for nginx-ingress to v1.1.4

**WHY**
We want to try to always use the latest chart, or at the very least not fall too far behind and make use of latest features

**What this PR does?**
This PR simply changes the version on the terraform to use v1.1.4 of the chart