### PR TITLE
Add OIDC Proxy Helm Chart

### DIFF
--- a/helm-charts/oidc-proxy/.helmignore
+++ b/helm-charts/oidc-proxy/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/helm-charts/oidc-proxy/Chart.yaml
+++ b/helm-charts/oidc-proxy/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: oidc-proxy
+version: 0.1.0
+home: https://github.com/ministryofjustice/oidc-proxy

--- a/helm-charts/oidc-proxy/README.md
+++ b/helm-charts/oidc-proxy/README.md
@@ -1,0 +1,46 @@
+# OIDC Proxy Helm Chart
+
+Installing this chart will deploy an OIDC Proxy into your cluster, fronting your
+defined application via an ingress rule.
+
+## Installing the Chart
+
+To install the chart:
+
+```bash
+helm install . \
+  --name $APPLICATION_NAME \
+  --namespace $NAMESPACE
+  --set application.hostName=$APPLICATION_HOSTNAME \
+  --set application.port=$APPLICATION_PORT \
+  --set application.serviceName=$APPLICATION_SVC \
+  --set oidc.clientId=$OIDC_CLIENT \
+  --set oidc.clientSecret=$OIDC_SECRET \
+  --set oidc.sessionSecret=$OIDC_SESSION_SECRET
+```
+
+## Configuration
+
+The following table lists the configurable parameters of the oidc-proxy chart and their default values.
+
+| Parameter | Description | Default |
+| - | - | - |
+| fullnameOverride | Override the full name of the deployment | `""` |
+| replicaCount | The number of replicas in the oidc-proxy `Deployment` | `1` |
+| image.repository | Docker image repository for the `oidc-proxy` image | `evry/oidc-proxy` |
+| image.tag | Docker image tag | `v1.3.0` |
+| image.pullPolicy | The container's `imagePullPolicy` | `Always` |
+| service.type | oidc-proxy `Service` type | `ClusterIP` |
+| service.port | oidc-proxy `Service` port | `80` |
+| application.hostName | The application `Ingress` hostname e.g. `prometheus.cluster.net`| `kuberos.cluster.local` |
+| application.serviceName | The application `Service` name e.g. `kube-prometheus` | `""` |
+| application.healthCheck.enabled | Application healthchecks are enabled | `false` |
+| application.healthCheck.path | Healthcheck path | `""` |
+| oidc.issuerUrl | OIDC Issuer URL | `""` |
+| oidc.clientId | OIDC Client ID | `""` |
+| oidc.clientSecret | OIDC Client Secret | `""` |
+| oidc.sessionSecret | OIDC Cookie Secret. To generate a cookie-secret use: `head -c 32 /dev/urandom | base64` | `""` |
+| oidc.discovery  | OIDC configutation URL | `https://moj-cloud-platforms-dev.eu.auth0.com/.well-known/openid-configuration` |
+| oidc.renewToken  | OIDC Enable silent renew of access token | `false` |
+| oidc.sessionName  | OIDC session name| `oidc_proxy` |
+

--- a/helm-charts/oidc-proxy/templates/NOTES.txt
+++ b/helm-charts/oidc-proxy/templates/NOTES.txt
@@ -1,0 +1,15 @@
+1. Get the application URL by running these commands:
+{{- if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "oidc-proxy.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ include "oidc-proxy.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "oidc-proxy.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "oidc-proxy.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:80
+{{- end }}

--- a/helm-charts/oidc-proxy/templates/_helpers.tpl
+++ b/helm-charts/oidc-proxy/templates/_helpers.tpl
@@ -1,0 +1,45 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "oidc-proxy.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "oidc-proxy.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "oidc-proxy.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the names of ConfigMaps and Secrets.
+*/}}
+{{- define "oidc-proxy.configmapNameConfig" -}}
+{{- printf "%s-%s" (include "oidc-proxy.fullname" .) "config" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- define "oidc-proxy.configmapNameAuth" -}}
+{{- printf "%s-%s" (include "oidc-proxy.fullname" .) "auth" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- define "oidc-proxy.secretName" -}}
+{{- printf "%s-%s" (include "oidc-proxy.fullname" .) "secret" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/helm-charts/oidc-proxy/templates/configmaps.yaml
+++ b/helm-charts/oidc-proxy/templates/configmaps.yaml
@@ -1,0 +1,92 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "oidc-proxy.configmapNameAuth" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "oidc-proxy.name" . }}
+    helm.sh/chart: {{ include "oidc-proxy.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  # this is based on the upstream authentication script with added bits to limit
+  # access to the webops team
+  # https://github.com/evry/docker-oidc-proxy/blob/master/nginx/lua/auth.lua
+  auth.lua: |
+    local opts = {
+        redirect_uri_path = os.getenv("OID_REDIRECT_PATH") or "/redirect_uri",
+        discovery = os.getenv("OID_DISCOVERY"),
+        client_id = os.getenv("OID_CLIENT_ID"),
+        client_secret = os.getenv("OID_CLIENT_SECRET"),
+        token_endpoint_auth_method = os.getenv("OIDC_AUTH_METHOD") or "client_secret_basic",
+        renew_access_token_on_expiry = os.getenv("OIDC_RENEW_ACCESS_TOKEN_ON_EXPIERY"),
+        refresh_session_interval = os.getenv("OIDC_REFRESH_INTERVAL"),
+        access_token_expires_in = os.getenv("OIDC_TOKEN_EXIRE_TIME"),
+        scope = os.getenv("OIDC_AUTH_SCOPE") or "openid",
+        iat_slack = 600,
+    }
+
+    -- call authenticate for OpenID Connect user authentication
+    local res, err, _target, session = require("resty.openidc").authenticate(opts)
+    if err then
+        ngx.log(ngx.DEBUG, tostring(err))
+        ngx.exit(ngx.HTTP_FORBIDDEN)
+    end
+
+    ngx.log(ngx.DEBUG, "Authentication successful, setting Auth header...")
+
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "oidc-proxy.configmapNameConfig" . }}
+  labels:
+    app: {{ include "oidc-proxy.name" . }}
+    chart: {{ include "oidc-proxy.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  # .common is based on the default proxy configuration of the image
+  # https://github.com/evry/docker-oidc-proxy/blob/master/nginx/conf/sites/proxy.conf
+  .common.conf: |
+    listen 80;
+
+    error_log /dev/stdout info;
+
+    large_client_header_buffers 8 64k;
+    client_header_buffer_size 64k;
+    set_by_lua $session_secret 'return os.getenv("OID_SESSION_SECRET")';
+    set_by_lua $session_check_ssi 'return os.getenv("OID_SESSION_CHECK_SSI")';
+    set_by_lua $session_name 'return os.getenv("OID_SESSION_NAME")';
+
+    location /favicon.ico {
+      return 404;
+    }
+
+    location /healthz {
+      return 201;
+    }
+
+    location / {
+      access_by_lua_file  lua/auth.lua;
+      proxy_set_header    Host $http_host;
+      proxy_pass          http://$upstream;
+    }
+
+    error_page 500 502 503 504 /50x.html;
+    location = /50x.html {
+        root html;
+    }
+
+  00-http.conf: |
+    server_names_hash_bucket_size 128;
+
+  10-application.conf: |
+    upstream app {
+        server {{ .Values.application.serviceName }}:{{ .Values.application.port }};
+    }
+    server {
+        server_name {{ .Values.application.hostName }};
+        set $upstream app;
+        include sites/.common.conf;
+    }

--- a/helm-charts/oidc-proxy/templates/deployment.yaml
+++ b/helm-charts/oidc-proxy/templates/deployment.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ include "oidc-proxy.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "oidc-proxy.name" . }}
+    helm.sh/chart: {{ include "oidc-proxy.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "oidc-proxy.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "oidc-proxy.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      containers:
+      - name: {{ .Chart.Name }}
+        env:
+        - name: OID_CLIENT_ID
+          value: {{ .Values.oidc.clientId | quote }}
+        - name: OID_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "oidc-proxy.secretName" . }}
+              key: clientSecret
+        - name: OID_DISCOVERY
+          value: {{ .Values.oidc.discovery | quote }}
+        - name: OIDC_RENEW_ACCESS_TOKEN_ON_EXPIERY
+          value: {{ .Values.oidc.renewToken | quote }}
+        - name: OID_SESSION_NAME
+          value: {{ .Values.oidc.sessionName | quote }}
+        - name: OID_SESSION_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "oidc-proxy.secretName" . }}
+              key: sessionSecret
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        resources:
+          requests:
+            cpu: {{ .Values.resources.requests.cpu }}
+            memory: {{ .Values.resources.requests.memory }}
+          limits:
+            cpu: {{ .Values.resources.limits.cpu }}
+            memory: {{ .Values.resources.limits.memory }}
+        ports:
+          - containerPort: 80
+            protocol: TCP
+        volumeMounts:
+        - name: config
+          mountPath: /usr/local/openresty/nginx/conf/sites/
+        - name: auth-script
+          mountPath: /usr/local/openresty/nginx/lua
+      volumes:
+      - name: config
+        configMap:
+          name: {{ include "oidc-proxy.configmapNameConfig" . }}
+      - name: auth-script
+        configMap:
+          name: {{ include "oidc-proxy.configmapNameAuth" . }}

--- a/helm-charts/oidc-proxy/templates/ingress.yaml
+++ b/helm-charts/oidc-proxy/templates/ingress.yaml
@@ -1,0 +1,19 @@
+{{- $fullName := include "oidc-proxy.fullname" . -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+spec:
+  rules:
+  - host: {{ .Values.application.hostName }}
+    http:
+      paths:
+      - backend:
+          serviceName: {{ $fullName }}
+          servicePort: 80
+      {{- if .Values.application.healthCheck.enabled }}
+      - path: {{ .Values.application.healthCheck.path }}
+        backend:
+          serviceName: {{ .Values.application.serviceName }}
+          servicePort: {{ .Values.application.port }}
+      {{- end}}

--- a/helm-charts/oidc-proxy/templates/secret.yaml
+++ b/helm-charts/oidc-proxy/templates/secret.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "oidc-proxy.secretName" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "oidc-proxy.name" . }}
+    helm.sh/chart: {{ include "oidc-proxy.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+type: Opaque
+data:
+  clientSecret: {{ .Values.oidc.clientSecret | b64enc | quote }}
+  sessionSecret: {{ .Values.oidc.sessionSecret | b64enc | quote }}
+

--- a/helm-charts/oidc-proxy/templates/service.yaml
+++ b/helm-charts/oidc-proxy/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "oidc-proxy.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "oidc-proxy.name" . }}
+    helm.sh/chart: {{ include "oidc-proxy.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 80
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "oidc-proxy.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/helm-charts/oidc-proxy/values.yaml
+++ b/helm-charts/oidc-proxy/values.yaml
@@ -1,0 +1,44 @@
+# Default values for oidc-proxy.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: evry/oidc-proxy
+  tag: latest
+  pullPolicy: Always
+
+nameOverride: ""
+fullnameOverride: ""
+
+# OIDC service
+service:
+  type: ClusterIP
+  port: 80
+
+# Application
+application:
+  serviceName: ""
+  port: ""
+  hostName: kuberos.cluster.local
+  healthCheck:
+    enabled: false
+    path: ""
+
+resources:
+  limits:
+    cpu: 5m
+    memory: 64Mi
+  requests:
+    cpu: 5m
+    memory: 64Mi
+
+# OIDC prvider
+oidc:
+  clientId: ""
+  clientSecret: ""
+  discovery: ""
+  renewToken: ""
+  sessionName: ""
+  sessionSecret: ""

--- a/helm-charts/oidc-proxy/values.yaml
+++ b/helm-charts/oidc-proxy/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: evry/oidc-proxy
-  tag: latest
+  tag: v1.3.0
   pullPolicy: Always
 
 nameOverride: ""
@@ -38,7 +38,7 @@ resources:
 oidc:
   clientId: ""
   clientSecret: ""
-  discovery: ""
-  renewToken: ""
-  sessionName: ""
+  discovery: "https://moj-cloud-platforms-dev.eu.auth0.com/.well-known/openid-configuration"
+  renewToken: "true"
+  sessionName: "oidc_proxy"
   sessionSecret: ""


### PR DESCRIPTION
**Overview**
---
This PR contains the OIDC-proxy Helm chart as outlined in https://github.com/ministryofjustice/cloud-platform/issues/583. The idead behind this Helm chart is to create a 'plug and play' template for applications wishing to use an auth proxy. Initially the team will use this to create an auth layer in front of Prometheus and Alert Manager. This will be written in Terraform and will be presented in a separate PR. 

**What's in this PR?**
---
- The oidc-proxy helm chart stored in the `/helm-charts` directory.
- A supporting `values.yaml` file containing default values, which are to be populated at run time.
- A README displaying proper use of the Helm chart.

**What does it do?**
---
This PR will enable the team to automate the process of including an OIDC proxy authenticator. 