### PR TITLE
Add AlertManager and Prometheus proxies to Terraform components

### DIFF
--- a/terraform/cloud-platform-components/templates/oidc-proxy.yaml.tpl
+++ b/terraform/cloud-platform-components/templates/oidc-proxy.yaml.tpl
@@ -1,0 +1,44 @@
+# This file will be populated by terraform and must not be used manually.
+# This is a YAML-formatted file.
+
+# Application definition to be placed behind the proxy.
+replicaCount: 1
+
+image:
+  repository: evry/oidc-proxy
+  tag: v1.3.0
+  pullPolicy: Always
+
+nameOverride: ""
+fullnameOverride: ""
+
+# OIDC service
+service:
+  type: ClusterIP
+  port: 80
+
+# Application
+application:
+  serviceName: ${ application_service_name }
+  port: ${ application_port }
+  hostName: ${ application_hostname }
+  healthCheck:
+    enabled: ${ application_healthcheck }
+    path: ${ application_healthcheck_port }
+
+resources:
+  limits:
+    cpu: 5m
+    memory: 64Mi
+  requests:
+    cpu: 5m
+    memory: 64Mi
+
+# OIDC prvider
+oidc:
+  clientId: ${ oidc_client_id }
+  clientSecret: ${ oidc_client_secret }
+  discovery: "https://moj-cloud-platforms-dev.eu.auth0.com/.well-known/openid-configuration"
+  renewToken: "true"
+  sessionName: "oidc_proxy"
+  sessionSecret: ${ oidc_session_secret }


### PR DESCRIPTION
**Overview**
---
This PR connects to https://github.com/ministryofjustice/cloud-platform/issues/583, which builds upon and utilises the OIDC-proxy Helm chart created in https://github.com/ministryofjustice/cloud-platform-infrastructure/pull/144. 

**What does this PR contain?**
---
An amendment to the `prometheus.tf` file in `/terraform/cloud-platform-components`.

**Why perform this change?**
---
The `cloud-platform-components` state allows us to bootstrap the Cloud-Platform to a point of instant usage. This addition will enable the automation of the AlertManager and Prometheus proxies, linking up with the OIDC client created at cluster build. This saves engineers time at creation. 
