### PR TITLE
Specify role for external-dns

### DIFF
--- a/terraform/cloud-platform-components/external-dns.tf
+++ b/terraform/cloud-platform-components/external-dns.tf
@@ -54,7 +54,7 @@ provider: aws
 aws:
   region: eu-west-1
   zoneType: public
-  roleArn: "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/external-dns.${data.terraform_remote_state.cluster.cluster_domain_name}"
+  roleArn: "${aws_iam_role.external_dns.arn}"
 domainFilters:
   - "${data.terraform_remote_state.cluster.cluster_domain_name}"
 rbac:

--- a/terraform/cloud-platform-components/external-dns.tf
+++ b/terraform/cloud-platform-components/external-dns.tf
@@ -54,6 +54,7 @@ provider: aws
 aws:
   region: eu-west-1
   zoneType: public
+  roleArn: "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/external-dns.${data.terraform_remote_state.cluster.cluster_domain_name}"
 domainFilters:
   - "${data.terraform_remote_state.cluster.cluster_domain_name}"
 rbac:

--- a/terraform/cloud-platform-components/main.tf
+++ b/terraform/cloud-platform-components/main.tf
@@ -29,3 +29,5 @@ data "terraform_remote_state" "cluster" {
     profile = "moj-cp"
   }
 }
+
+data "aws_caller_identity" "current" {}


### PR DESCRIPTION
Fixes an issue where external-dns assumes the node's role which has no access to edit the route53 zone.