### PR TITLE
add inactive user check template

### DIFF
--- a/cloudformation/cloud-platform-security/aws-iam-suspend-inactive-users/README.md
+++ b/cloudformation/cloud-platform-security/aws-iam-suspend-inactive-users/README.md
@@ -1,0 +1,61 @@
+# Check Inactive IAM Users in AWS Account
+
+## Description
+To increase the security of the AWS account, we need to remove IAM user credentials (that is, passwords and access keys) that are not needed. For example, when users leave the organization or no longer need AWS access, we need to ensure their credentials are no longer operational. Ideally, the credentials should be deleted, if they are no longer needed. The accounts can be recreated at a later date if the need arises. At the very least, we need to delete the password and deactivate the access keys, so that the former users no longer have access.
+
+The template deactivates unused credentials, if they have not been used for 120days and then moves the user accounts to the SuspendedUsersGroup. The SuspendedUsersGroup will have DenyAll IAM policy and the user will have no access to AWS services. The users in SuspendedUsersGroup will be checked and deleted after 10days of being in the group. Also recently created user profile or access key that has not been used for more than 7 days, are deactivated.
+
+There are three lambda functions which carry out the task. 
+Lambda1 - DisableUnusedCredentials will run everyday Monday-friday 9AM UTC and checks if the user accounts have not been used. It moves inactive user accounts (inactive console login and inactive access keys) to the SuspendedUsersGroup. It sends sns notification of DeletedPasswords, InactiveAccessKeys, users moved to SuspendedUsersGroup
+Lambda2 - DeleteUsersInSuspendedUsersGroup deletes user accounts from the SuspendedUserAccounts. It sends sns notification of user accounts deleted from the SuspendedUsersGroup
+Lambda3 - Slack Integration which outputs the result of Lambda1 and Lambda2 execution to the slack
+
+EXCEPTION - Users with Admin privileges obtained through AWS Managed Policy are not checked for inactive status. Users with Admin privileges obtained through Inline Policy will be checked for inactive status.
+
+## How to Deploy
+
+### Prerequisites
+Install [AWS CLI] (https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) and [configure the AWS CLI] (https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html) access keys using the below commands:
+
+```
+sudo apt-get install -y python-dev python-pip
+sudo pip install awscli
+aws --version
+aws configure
+``` 
+
+### Parameters
+The IAM user or the access key is made Inactive if they have not logged in or used the accee key for DEFAULT_AGE_THRESHOLD_IN_DAYS. Currently set to 120 days
+A New IAM user or a New access key is not checked for inactive status for CREATE_DATE_AGE_THRESHOLD_IN_DAYS. Currently set as 7 days
+
+### Package the template 
+
+The script package_template.sh uses AWS CLI commands to package the lambda and the template
+
+```
+#!/bin/bash
+set +x
+
+# parameters
+AWS_PROFILE={aws_profile_name}
+S3BUCKETNAME={new_bucket_name} 
+export AWS_PROFILE
+export S3BUCKETNAME
+
+# create bucket & package template
+aws s3 mb s3://$S3BUCKETNAME --profile $AWS_PROFILE
+aws cloudformation package --template-file check_inactive_users.yaml --s3-bucket $S3BUCKETNAME --output-template-file check_inactive_users-output.yaml --profile $AWS_PROFILE
+aws s3 ls s3://$S3BUCKETNAME --profile $AWS_PROFILE
+
+# validate the template
+aws cloudformation validate-template --template-body file://check_inactive_users-output.yaml --profile $AWS_PROFILE 
+
+# deploy the template
+aws cloudformation deploy --template-file check_inactive_users-output.yaml --stack-name check-inactive-users \\
+--parameter-overrides ParameterKey=pCreateSnsTopic,ParameterValue=false ParameterKey=pSlackChannelName,ParameterValue= ParameterKey=pSlackHookUrl,ParameterValue= ParameterKey=pExistingSnsTopic,ParameterValue={existing-sns-topic-arn} \\
+--tags Owner={team_email} AgencyName={agency_name} ApplicationID=aws-iam Environment=Production \\
+--capabilities CAPABILITY_NAMED_IAM \\
+--profile $AWS_PROFILE
+
+```
+

--- a/cloudformation/cloud-platform-security/aws-iam-suspend-inactive-users/check_inactive_users.yaml
+++ b/cloudformation/cloud-platform-security/aws-iam-suspend-inactive-users/check_inactive_users.yaml
@@ -1,0 +1,286 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: 'Determine and deactivate unused IAM user credentials and access keys'
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+    - Label:
+        default: SNS Topic
+      Parameters:
+        - pCreateSnsTopic
+        - pExistingSnsTopic
+        - pSlackChannelName
+        - pSlackHookUrl
+    ParameterLabels:
+      pCreateSnsTopic:
+        default: Create new SNS Topic for slack notifications
+      pSlackChannelName:
+        default: Slack Channel Name
+      pSlackHookUrl:
+        default: Slack Channel Hook Url
+      pExistingSnsTopic:
+        default: Existing SNS Topic integrated with slack
+
+Parameters:
+  pCreateSnsTopic:
+    Type: String
+    Default: 'true'
+    Description: If set to true, it will create a new SNS topic and lambda
+    AllowedValues:
+    - 'true'
+    - 'false'
+  pSlackChannelName:
+    Type: String
+    Description: Slack Channel Name
+    Default: ''
+  pSlackHookUrl:
+    Type: String
+    Description: Slack Hook Url
+    Default: ''
+  pExistingSnsTopic:
+    Type: String
+    Description: Arn of existing SNS Topic with lambda to slack integration
+    Default: ''
+
+Conditions:
+  cCreateSnsTopic: !Equals [ !Ref pCreateSnsTopic, 'true' ]
+
+Resources:
+  #==================================================
+  # Deny All IAM Policy for the SuspendedUsersGroup
+  #==================================================
+  DenyAllPolicy:
+    Type: "AWS::IAM::Policy"
+    Properties: 
+      PolicyName: DenyAllPolicy
+      PolicyDocument: 
+        Version: "2012-10-17"
+        Statement: 
+          Effect: "Deny"
+          Action: "*"
+          Resource: "*"
+      Groups:
+      - !Ref SuspendedUsersGroup
+  SuspendedUsersGroup:
+    Type: AWS::IAM::Group
+    Properties:
+      GroupName: SuspendedUsersGroup
+  #==================================================
+  # CIS 1.3	Ensure unused credentials are disabled
+  # CIS 1.4	Ensure access keys are rotated
+  # updated the rule set to check for 120 days 
+  #==================================================
+  RoleForDisableUnusedCredentialsFunction:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          -
+            Effect: Allow
+            Principal:
+              Service: [lambda.amazonaws.com]
+            Action:
+              - sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Path: /servicerole/
+      Policies:
+        -
+          PolicyName: DisableCredentials
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              -
+                Effect: Allow
+                Action:
+                  - iam:AddUserToGroup
+                  - iam:DeactivateMFADevice
+                  - iam:DeleteLoginProfile
+                  - iam:DetachUserPolicy
+                  - iam:GetAccessKeyLastUsed
+                  - iam:GetLoginProfile
+                  - iam:GetUser
+                  - iam:DeleteLoginProfile
+                  - iam:DeleteUserPolicy
+                  - iam:ListAccessKeys
+                  - iam:ListGroupsForUser
+                  - iam:ListMFADevices
+                  - iam:ListUsers
+                  - iam:ListAttachedGroupPolicies
+                  - iam:ListAttachedUserPolicies
+                  - iam:ListUserPolicies
+                  - iam:RemoveUserFromGroup
+                  - iam:UpdateAccessKey
+                  - sns:Publish
+                Resource: "*"
+
+  FunctionToDisableUnusedCredentials:
+    Type: AWS::Lambda::Function
+    DependsOn: RoleForDisableUnusedCredentialsFunction
+    Properties:
+      FunctionName: DisableUnusedCredentials
+      Code: ./lambda/disable_unused_credentials.py
+      Description: Deletes unused passwords, disables unused access keys and moves inactive users to SuspendedUsersGroup
+      Environment:
+        Variables:
+          SUSPENDED_USERS_GROUP: !Ref SuspendedUsersGroup
+          TOPIC_ARN: !If [cCreateSnsTopic, !Ref CreateSnsTopic, !Ref pExistingSnsTopic]
+      Handler: disable_unused_credentials.lambda_handler
+      MemorySize: 256
+      Role: !GetAtt RoleForDisableUnusedCredentialsFunction.Arn
+      Runtime: python3.6
+      Timeout: 180
+  LambdaPermissionForDisableUnusedCredentials:
+    Type: AWS::Lambda::Permission
+    DependsOn:
+      - FunctionToDisableUnusedCredentials
+    Properties:
+      FunctionName: !GetAtt FunctionToDisableUnusedCredentials.Arn
+      Action: lambda:InvokeFunction
+      Principal: events.amazonaws.com
+  # Lambda Runs everyday at 9am UTC 
+  ScheduledRuleForDisableUnusedCredentials:
+    Type: AWS::Events::Rule
+    Properties:
+      Name: DisableUnusedCredentials
+      Description: Deletes unused passwords and disables unused access keys
+      ScheduleExpression: cron(0 9 ? * MON-FRI *)
+      State: ENABLED
+      Targets:
+        -
+          Arn: !GetAtt FunctionToDisableUnusedCredentials.Arn
+          Id: TargetFunctionV1
+  #==================================================
+  # Delete Users from SuspendedUsersGroup
+  #==================================================
+  RoleForDeleteUsersInSuspendedUsersGroupFunction:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          -
+            Effect: Allow
+            Principal:
+              Service: [lambda.amazonaws.com]
+            Action:
+              - sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Path: /servicerole/
+      Policies:
+        -
+          PolicyName: DeleteUsersInSuspendedUsersGroup
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              -
+                Effect: Allow
+                Action:
+                  - iam:GetGroup
+                  - iam:DeleteUser
+                  - sns:Publish
+                Resource: "*"
+
+  FunctionToDeleteUsersInSuspendedUsersGroup:
+    Type: AWS::Lambda::Function
+    DependsOn: RoleForDeleteUsersInSuspendedUsersGroupFunction
+    Properties:
+      FunctionName: DeleteUsersInSuspendedUsersGroup
+      Code: ./lambda/delete_users_in_suspendedusersgroup.py
+      Description: Delete Users In the SuspendedUsersGroup
+      Environment:
+        Variables:
+          SUSPENDED_USERS_GROUP: !Ref SuspendedUsersGroup
+          TOPIC_ARN: !If [cCreateSnsTopic, !Ref CreateSnsTopic, !Ref pExistingSnsTopic]
+      Handler: delete_users_in_suspendedusersgroup.lambda_handler
+      MemorySize: 128
+      Role: !GetAtt RoleForDeleteUsersInSuspendedUsersGroupFunction.Arn
+      Runtime: python3.6
+      Timeout: 20
+  LambdaPermissionForDeleteUsersInSuspendedUsersGroup:
+    Type: AWS::Lambda::Permission
+    DependsOn:
+      - FunctionToDeleteUsersInSuspendedUsersGroup
+    Properties:
+      FunctionName: !GetAtt FunctionToDeleteUsersInSuspendedUsersGroup.Arn
+      Action: lambda:InvokeFunction
+      Principal: events.amazonaws.com
+  # Lambda Runs every Tuesday at 10am UTC 
+  ScheduledRuleForDeleteUsersInSuspendedUsersGroup:
+    Type: AWS::Events::Rule
+    Properties:
+      Name: DeleteUsersInSuspendedUsersGroup
+      Description: Delete Users In the SuspendedUsersGroup
+      ScheduleExpression: cron(0 10 ? * TUE *)
+      State: ENABLED
+      Targets:
+        -
+          Arn: !GetAtt FunctionToDeleteUsersInSuspendedUsersGroup.Arn
+          Id: TargetFunctionV1
+  #==================================================
+  # Lambda to Slack Integration
+  #==================================================
+  RoleForSlackIntegrationFunction:
+    Type: AWS::IAM::Role
+    Condition: cCreateSnsTopic
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          -
+            Effect: Allow
+            Principal:
+              Service: [lambda.amazonaws.com]
+            Action:
+              - sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Path: /servicerole/
+
+  FunctionForSlackIntegration:
+    Type: AWS::Lambda::Function
+    DependsOn: RoleForSlackIntegrationFunction
+    Condition: cCreateSnsTopic
+    Properties:
+      FunctionName: SlackIntegration
+      Code: ./lambda/slack_integration.py
+      Description: Lambda to Slack Integration
+      Environment:
+        Variables:
+          SLACK_CHANNEL: !Ref pSlackChannelName
+          HOOK_URL: !Ref pSlackHookUrl
+      Handler: slack_integration.lambda_handler
+      MemorySize: 128
+      Role: !GetAtt RoleForSlackIntegrationFunction.Arn
+      Runtime: python3.6
+      Timeout: 20
+  LambdaPermissionForSlackIntegration:
+    Type: AWS::Lambda::Permission
+    DependsOn:
+      - FunctionForSlackIntegration
+    Condition: cCreateSnsTopic
+    Properties:
+      FunctionName: !GetAtt FunctionForSlackIntegration.Arn
+      Action: lambda:InvokeFunction
+      Principal: sns.amazonaws.com
+      SourceArn: !Ref CreateSnsTopic
+  #==================================================
+  # Optional SNS configuration
+  #==================================================
+  CreateSnsTopic:
+    Type: AWS::SNS::Topic
+    Condition: cCreateSnsTopic
+    DependsOn: FunctionForSlackIntegration
+    Properties:
+      DisplayName: "CheckInactiveUsersSNSTopic"
+      Subscription:
+        - Endpoint: !GetAtt FunctionForSlackIntegration.Arn
+          Protocol: lambda
+  SnsAlarmSubscription:
+    Type: AWS::SNS::Subscription
+    Condition: cCreateSnsTopic
+    Properties:
+      Endpoint: !GetAtt FunctionForSlackIntegration.Arn
+      Protocol: lambda
+      TopicArn: !Ref CreateSnsTopic

--- a/cloudformation/cloud-platform-security/aws-iam-suspend-inactive-users/lambda/delete_users_in_suspendedusersgroup.py
+++ b/cloudformation/cloud-platform-security/aws-iam-suspend-inactive-users/lambda/delete_users_in_suspendedusersgroup.py
@@ -1,0 +1,44 @@
+#==================================================================================================
+# Function: DeleteUsersInSuspendedUsersGroup
+# Purpose:  Delete Users In the SuspendedUsersGroup
+#==================================================================================================
+
+import boto3, json, datetime, os
+from time import gmtime, strftime
+from datetime import date
+
+DEFAULT_AGE_THRESHOLD_IN_DAYS = 130
+
+#==================================================================================================
+# Function handler
+#==================================================================================================
+def lambda_handler(event, context):
+
+return_value = {}
+return_value['DeletedUsers'] = []
+now = date(datetime.date.today().year, datetime.date.today().month, datetime.date.today().day)
+suspended_users_group = os.environ['SUSPENDED_USERS_GROUP']
+sns_topic_arn = os.environ['TOPIC_ARN']
+account_id = context.invoked_function_arn.split(":")[4]
+date_fmt = strftime("%d_%m_%Y_%H:%M:%S", gmtime())              #get to the current date
+
+client = boto3.client('iam')
+
+print ('Deleting the Users In SuspendedUserGroup')
+for user in client.get_group(GroupName = suspended_users_group)['Users']:
+    if 'CreateDate' in user :
+    user_created_date = user['CreateDate']
+    user_created_date = date(user_created_date.year, user_created_date.month, user_created_date.day)
+    age = (now - user_created_date).days
+    if age > DEFAULT_AGE_THRESHOLD_IN_DAYS:
+        print ('Deleting User {0}'.format(user['UserName']) )
+        response = client.delete_user(UserName = user['UserName'])
+        return_value['DeletedUsers'].append({'UserName': user['UserName'], 'CreateDate': str(user_created_date)})
+
+# SNS topic Email Section
+sns_client       = boto3.client('sns',region_name='eu-west-1')
+subject          = 'AWS Account - ' + account_id + ' Users Deleted from SuspendedUserGroup ' + date_fmt
+message_body     = '\n' + "Deleted Users are " + str(return_value['DeletedUsers']) + ' \n '
+sns_client.publish(TopicArn=sns_topic_arn, Message=message_body, Subject=subject)
+
+return return_value

--- a/cloudformation/cloud-platform-security/aws-iam-suspend-inactive-users/lambda/disable_unused_credentials.py
+++ b/cloudformation/cloud-platform-security/aws-iam-suspend-inactive-users/lambda/disable_unused_credentials.py
@@ -1,0 +1,158 @@
+#==================================================================================================
+# Function: DisableUnusedCredentials
+# Purpose:  Disables unused access keys older than the given period.
+#==================================================================================================
+
+import boto3, json, datetime, os
+from time import gmtime, strftime
+from datetime import date
+
+DEFAULT_AGE_THRESHOLD_IN_DAYS = 120
+CREATE_DATE_AGE_THRESHOLD_IN_DAYS = 7
+
+#==================================================================================================
+# Function handler
+#==================================================================================================
+def lambda_handler(event, context):
+
+    return_value = {} 
+    return_value['DeletedPasswords'] = []
+    return_value['DisabledAccessKeys'] = []
+    return_value['SuspendedUsers'] = []
+    date_fmt = strftime("%d_%m_%Y_%H:%M:%S", gmtime())              #get to the current date
+    suspended_users_group = os.environ['SUSPENDED_USERS_GROUP']
+    sns_topic_arn = os.environ['TOPIC_ARN']
+    account_id = context.invoked_function_arn.split(":")[4]
+
+    client = boto3.client('iam')
+
+    now = date(datetime.date.today().year, datetime.date.today().month, datetime.date.today().day)
+
+    # For each user, determine:
+    # (1) the create date for the user or access key is less than 7 days or check if user has Admin privileges
+    # (2) the status of all the access keys
+    # (3) the console login status
+    # (4) if console login and access key are inactive, move to suspended users group
+    for user in client.list_users(MaxItems=500)['Users']:
+        active_login_profile = "true"
+        active_access_key = "true"
+        check_user = "true"
+        access_key_count = 0
+        inactive_access_key_count = 0
+        login_create_date = client.get_user(UserName = user['UserName'])['User']['CreateDate']
+        login_create_date = date(login_create_date.year, login_create_date.month, login_create_date.day)
+        login_age = (now - login_create_date).days
+        if (login_age <= CREATE_DATE_AGE_THRESHOLD_IN_DAYS):
+            print('User {0} was created less than 7days ago. Skip'.format(user['UserName']))
+            check_user = "false"
+        else:
+            for access_key in client.list_access_keys(UserName = user['UserName'])['AccessKeyMetadata']:
+                access_key_create_date = date(access_key['CreateDate'].year, access_key['CreateDate'].month, access_key['CreateDate'].day)
+                access_key_age = (now - access_key_create_date).days
+                if (access_key_age <= CREATE_DATE_AGE_THRESHOLD_IN_DAYS):
+                    print('User {0} has access key {1} that was created less than 7days ago. Skip'.format(user['UserName'],access_key['AccessKeyId']))
+                    check_user = "false"
+                    break
+            for group in client.list_groups_for_user(UserName = user['UserName'])['Groups']:
+                if group['GroupName'] == suspended_users_group :
+                    print ('User {0} is in SuspendedUsersGroup. Skip'.format(user['UserName']))
+                    check_user = "false"
+                    break
+                for group_policy in client.list_attached_group_policies(GroupName = group['GroupName'])['AttachedPolicies']:
+                    if group_policy['PolicyName'] == "AdministratorAccess" :
+                        check_user = "false"
+                        print ('User {0} has Admin Access through group policy in {1}. Skip'.format(user['UserName'],group['GroupName']))
+                        break
+                for attached_policy in client.list_attached_user_policies(UserName = user['UserName'])['AttachedPolicies']:
+                    if attached_policy['PolicyName'] == "AdministratorAccess" : 
+                        check_user = "false"
+                        print ('User {0} has Admin Access with AWS managed policy. Skip'.format(user['UserName']))
+        if (check_user == "true") :
+            # Check if there is no access key
+            if (client.list_access_keys(UserName = user['UserName'])['AccessKeyMetadata'] == []):
+                active_access_key = "false"
+                print ('User {0} never had access key'.format(user['UserName']))
+            # Check for all the access keys of User
+            for access_key in client.list_access_keys(UserName = user['UserName'])['AccessKeyMetadata']:
+                access_key_count += 1
+                if access_key['Status'] == 'Active':
+                    response = client.get_access_key_last_used(AccessKeyId = access_key['AccessKeyId'])
+                    if 'LastUsedDate' in response['AccessKeyLastUsed'] :
+                        access_key_last_used_date = response['AccessKeyLastUsed']['LastUsedDate']
+                        access_key_last_used_date = date(access_key_last_used_date.year, access_key_last_used_date.month, access_key_last_used_date.day)
+                        age = (now - access_key_last_used_date).days
+                        if age > DEFAULT_AGE_THRESHOLD_IN_DAYS:
+                            print('The access key {0} for the user {1} has not been used in {2} days, DISABLING access key'.format(access_key['AccessKeyId'], user['UserName'], age))
+                            response = client.update_access_key(
+                                UserName = user['UserName'],
+                                AccessKeyId = access_key['AccessKeyId'],
+                                Status = 'Inactive')
+                            return_value['DisabledAccessKeys'].append({'UserName': user['UserName'], 'LastUsedDate': str(access_key_last_used_date)})
+                    else:
+                        print('User {0} has not used access key {1}. DISABLING access key'.format(user['UserName'], access_key['AccessKeyId']))
+                        response = client.update_access_key(
+                            UserName = user['UserName'],
+                            AccessKeyId = access_key['AccessKeyId'],
+                            Status = 'Inactive')
+                        return_value['DisabledAccessKeys'].append({'UserName': user['UserName'], 'LastUsedDate': ''})
+                else:
+                    inactive_access_key_count += 1
+                    print ('User {0} has Inactive access key {1}'.format(user['UserName'], access_key['AccessKeyId']))
+            # If all the user access keys are inactive
+            if (access_key_count == inactive_access_key_count):
+                active_access_key = "false"
+                print ('User {0} has {1} Active and {2} Inactive access keys'.format(user['UserName'],(access_key_count - inactive_access_key_count),inactive_access_key_count))
+            # Check status of console login
+            if 'PasswordLastUsed' in user:
+                password_last_used = date(user['PasswordLastUsed'].year, user['PasswordLastUsed'].month, user['PasswordLastUsed'].day)
+                age = (now - password_last_used).days
+                if age > DEFAULT_AGE_THRESHOLD_IN_DAYS:
+                    # Disable the user's password (delete login profile).
+                    try:
+                        if client.get_login_profile(UserName = user['UserName']):
+                            print('The user {0} has not logged in to the console in {1} days, DELETING password'.format(user['UserName'], age))
+                            response = client.delete_login_profile(UserName = user['UserName'])
+                            return_value['DeletedPasswords'].append({'UserName': user['UserName'], 'PasswordLastUsed': str(user['PasswordLastUsed'])})
+                    except:
+                        print('No login profile exists for {0} '.format(user['UserName']))
+                        active_login_profile = "false" 
+                    if client.list_mfa_devices(UserName = user['UserName']):
+                        for mfa_device in client.list_mfa_devices(UserName = user['UserName'])['MFADevices']:
+                            print('Deactivating MFA device for user')
+                            response = client.deactivate_mfa_device(UserName = user['UserName'], SerialNumber = mfa_device['SerialNumber'])
+                    else:
+                        print('No MFA device exists for {0}'.format(user['UserName']))
+            else:
+                try:
+                    if client.get_login_profile(UserName = user['UserName']):
+                        print('The user {0} has never logged in to the console, DELETING password'.format(user['UserName']))
+                        response = client.delete_login_profile(UserName = user['UserName'])
+                        return_value['DeletedPasswords'].append({'UserName': user['UserName'], 'PasswordLastUsed': str(user['PasswordLastUsed'])})
+                except:
+                    print('No login profile exists for {0}. It may been already been deleted.'.format(user['UserName']))
+                    active_login_profile = "false"
+            # Move Inactive Users to Suspended Users Group with DenyAll access
+            if ( (active_login_profile == "false") and (active_access_key == "false") ):
+                print ('moving User {0} to {1}'.format(user['UserName'], suspended_users_group))
+                for inline_policy in client.list_user_policies(UserName = user['UserName'])['PolicyNames']:
+                    print ('Removing Inline Policy {0}'.format(inline_policy))
+                    response = client.delete_user_policy(UserName = user['UserName'], PolicyName = inline_policy)
+                for attached_policy in client.list_attached_user_policies(UserName = user['UserName'])['AttachedPolicies']:
+                    print ('Removing Attached Policy {0}'.format(attached_policy['PolicyArn']))
+                    response = client.detach_user_policy(UserName = user['UserName'], PolicyArn = attached_policy['PolicyArn'])
+                for group in client.list_groups_for_user(UserName = user['UserName'])['Groups']:
+                    print ('User {0} is removed from group {1}'.format(user['UserName'], group['GroupName']))
+                    response = client.remove_user_from_group(UserName = user['UserName'], GroupName = group['GroupName'])
+                print ('User {0} has been added to {1}'.format(user['UserName'], suspended_users_group))
+                response = client.add_user_to_group(UserName = user['UserName'], GroupName = suspended_users_group)
+                return_value['SuspendedUsers'].append({'UserName': user['UserName']})
+
+    # SNS topic Section
+    sns_client       = boto3.client('sns',region_name='eu-west-1')
+    subject          = 'AWS Account - ' + account_id + ' Inactive User List ' + date_fmt
+    message_body     = '\n' + "DeletedPasswords are " + str(return_value['DeletedPasswords'])
+    message_body     += '\n' + "DisabledAccessKeys are " + str(return_value['DisabledAccessKeys'])
+    message_body     += '\n' + "SuspendedUsers are " + str(return_value['SuspendedUsers'])
+    sns_client.publish(TopicArn=sns_topic_arn, Message=message_body, Subject=subject)
+
+    return return_value

--- a/cloudformation/cloud-platform-security/aws-iam-suspend-inactive-users/lambda/slack_integration.py
+++ b/cloudformation/cloud-platform-security/aws-iam-suspend-inactive-users/lambda/slack_integration.py
@@ -1,0 +1,42 @@
+#==================================================================================================
+# Function: SlackIntegration
+# Purpose:  Lambda to Slack Integration
+#==================================================================================================
+import boto3
+import json
+import logging
+import os
+
+from base64 import b64decode
+from urllib.request import Request, urlopen
+from urllib.error import URLError, HTTPError
+
+slack_channel = os.environ['SLACK_CHANNEL']
+slack_hook_url = os.environ['HOOK_URL']
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+def lambda_handler(event, context):
+    logger.info("Event: " + str(event))
+    message = event['Records'][0]['Sns']['Subject'] + '\n' + event['Records'][0]['Sns']['Message']
+    try:
+    message = json.loads(message)
+    except Exception as e:
+    print(e)
+    logger.info("Message: " + str(message))
+    slack_message = {
+        'channel': slack_channel,
+        'username': "AWSSlack",
+        'text': message,
+        'icon_emoji' : ":ghost:"
+    }
+    req = Request(slack_hook_url, json.dumps(slack_message).encode('utf-8'))
+    try:
+        response = urlopen(req)
+        response.read()
+        logger.info("Message posted to %s", slack_message['channel'])
+    except HTTPError as e:
+        logger.error("Request failed: %d %s", e.code, e.reason)
+    except URLError as e:
+        logger.error("Server connection failed: %s", e.reason)

--- a/cloudformation/cloud-platform-security/aws-iam-suspend-inactive-users/package_template.sh
+++ b/cloudformation/cloud-platform-security/aws-iam-suspend-inactive-users/package_template.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set +x
+#########################
+# Replace Values in {} 
+#########################
+
+# parameters
+AWS_PROFILE={aws_profile_name}
+S3BUCKETNAME={new_bucket_name}
+export AWS_PROFILE
+export S3BUCKETNAME
+
+# create bucket & package template
+aws s3 mb s3://$S3BUCKETNAME --profile $AWS_PROFILE
+aws cloudformation package --template-file check_inactive_users.yaml --s3-bucket $S3BUCKETNAME --output-template-file check_inactive_users-output.yaml --profile $AWS_PROFILE
+aws s3 ls s3://$S3BUCKETNAME --profile $AWS_PROFILE
+
+# validate the template
+aws cloudformation validate-template --template-body file://check_inactive_users-output.yaml --profile $AWS_PROFILE 
+
+# deploy the template
+aws cloudformation deploy --template-file check_inactive_users-output.yaml --stack-name check-inactive-users --parameter-overrides ParameterKey=pCreateSnsTopic,ParameterValue=false ParameterKey=pSlackChannelName,ParameterValue= ParameterKey=pSlackHookUrl,ParameterValue= ParameterKey=pExistingSnsTopic,ParameterValue={existing_sns_topic_arn} --tags Owner={account_email} AgencyName={agency_name} ApplicationID=aws-iam Environment=Production --capabilities CAPABILITY_NAMED_IAM --profile $AWS_PROFILE
+


### PR DESCRIPTION
To increase the security of the AWS account, we need to remove IAM user credentials (that is, passwords and access keys) that are not needed.
The template deactivates unused credentials and then moves the user accounts to the suspended user group with deny all policy