### PR TITLE
Convert booleans to strings

### DIFF
--- a/terraform/cloud-platform-components/templates/oauth2-proxy.yaml.tpl
+++ b/terraform/cloud-platform-components/templates/oauth2-proxy.yaml.tpl
@@ -22,8 +22,8 @@ extraArgs:
   skip-auth-regex: "${exclude_paths}"
   cookie-expire: "7h"
   skip-provider-button: true
-  pass-basic-auth: false
-  pass-host-header: false
+  pass-basic-auth: "false"
+  pass-host-header: "false"
 
 ingress:
   enabled: true


### PR DESCRIPTION
It's a known fact that helm chart quality is seemingly random.
Because of https://github.com/helm/charts/blob/master/stable/oauth2-proxy/templates/deployment.yaml#L38-L42