### PR TITLE
Add cpu threshold receiver 'null'

### DIFF
--- a/terraform/cloud-platform-components/templates/prometheus-operator.yaml.tpl
+++ b/terraform/cloud-platform-components/templates/prometheus-operator.yaml.tpl
@@ -95,6 +95,9 @@ alertmanager:
       receiver: 'null'
       routes:
       - match:
+          alertname: CPUThrottlingHigh
+        receiver: 'null'
+      - match:
           alertname: DeadMansSwitch
         receiver: 'null'
       - match:


### PR DESCRIPTION
Overview
---
This PR connects to https://github.com/ministryofjustice/cloud-platform/issues/653 and resolves the alert blindness and fatigue we currently get in our low priority slack channel. It was decided in a team gathering that the best way to solve this is to null the alert and add a new custom alarm containing the relevant namespaces.

What
---
Add the appropriate alert name to receiver `null` (i.e. ignored)

Why
---
So we can be more precise with relevant namespaces. 