### PR TITLE
Increase ES node count in live

### DIFF
--- a/terraform/global-resources/elasticsearch.tf
+++ b/terraform/global-resources/elasticsearch.tf
@@ -47,7 +47,7 @@ resource "aws_elasticsearch_domain" "live" {
 
   cluster_config {
     instance_type            = "m4.large.elasticsearch"
-    instance_count           = "3"
+    instance_count           = "4"
     dedicated_master_enabled = true
     dedicated_master_type    = "m4.large.elasticsearch"
     dedicated_master_count   = "3"


### PR DESCRIPTION
Connects to https://github.com/ministryofjustice/cloud-platform/issues/658. Due to a legitimate lack of disk space it has been decided that we'll bump the disk space. As we've hit max EBS capacity we've had to increase the node count.