### PR TITLE
Upgrade prometheus chart and remove recreate_pods

### DIFF
--- a/terraform/cloud-platform-components/prometheus.tf
+++ b/terraform/cloud-platform-components/prometheus.tf
@@ -40,10 +40,10 @@ data "template_file" "prometheus_operator" {
 }
 
 resource "helm_release" "prometheus_operator" {
-  name          = "prometheus-operator"
-  chart         = "stable/prometheus-operator"
-  namespace     = "monitoring"
-  recreate_pods = "true"
+  name      = "prometheus-operator"
+  chart     = "stable/prometheus-operator"
+  namespace = "monitoring"
+  version   = "3.0.0"
 
   values = [
     "${ data.template_file.prometheus_operator.rendered }",
@@ -87,11 +87,10 @@ data "template_file" "prometheus_proxy" {
 }
 
 resource "helm_release" "prometheus_proxy" {
-  name          = "prometheus-proxy"
-  namespace     = "monitoring"
-  chart         = "stable/oauth2-proxy"
-  version       = "0.9.1"
-  recreate_pods = true
+  name      = "prometheus-proxy"
+  namespace = "monitoring"
+  chart     = "stable/oauth2-proxy"
+  version   = "0.9.1"
 
   values = [
     "${data.template_file.prometheus_proxy.rendered}",
@@ -122,11 +121,10 @@ data "template_file" "alertmanager_proxy" {
 }
 
 resource "helm_release" "alertmanager_proxy" {
-  name          = "alertmanager-proxy"
-  namespace     = "monitoring"
-  chart         = "stable/oauth2-proxy"
-  version       = "0.9.1"
-  recreate_pods = true
+  name      = "alertmanager-proxy"
+  namespace = "monitoring"
+  chart     = "stable/oauth2-proxy"
+  version   = "0.9.1"
 
   values = [
     "${data.template_file.alertmanager_proxy.rendered}",


### PR DESCRIPTION
- `recreate_pod` introduces a lot of unnecessary pod bouncing when changes are applied. It's best used for development
   or special cases (the old oidc-proxy for example)

- upgrade the prometheus chart to latest which also pulls latest grafana and fixes a race condition with datasources
  https://github.com/helm/charts/pull/9842