### PR TITLE
Remove unwanted grafana references

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,17 +274,6 @@ Server: &version.Version{SemVer:"v2.11.0", GitCommit:"2e55dbe1fdb5fdb96b75ff144a
 ```
 fix / destroy / apply again if the values don't match.
 
-*Warning* the kuberos app itself is not fully parametrized yet, after logging on login.apps.${CLUSTER_NAME}.k8s.integration.dsd.io the output has references to `live-0` but the other values are correct; just sed/live-0/${CLUSTER_NAME}/ before using.
-
-7. We haven't yet fully automated some extra resources for Grafana so you'll need to apply the following in the `monitoring` namespace:
-- Apply the [grafana-dashboard-aggregator](https://github.com/ministryofjustice/cloud-platform-environments/blob/master/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/monitoring/grafana-dashboard-aggregator.yaml)
-
-  `kubectl apply -f grafana-dashboard-aggregator.yaml -n monitoring`
-
-- Apply the [grafana-auth-secret](https://github.com/ministryofjustice/cloud-platform-environments/blob/master/namespaces/cloud-platform-live-0.k8s.integration.dsd.io/monitoring/grafana-auth-secret.yaml).
-
-  `kubectl apply -f grafana-auth-secret.yaml -n monitoring`
-
 ### How to delete a cluster
 
 1. To delete a cluster you must first export the following:


### PR DESCRIPTION
The Grafana Terraform in cloud-platform-components now creates a secret and the aggregator is no longer required.