### PR TITLE
Upgraded ES version from 6.2 to 6.4

### DIFF
--- a/terraform/global-resources/elasticsearch.tf
+++ b/terraform/global-resources/elasticsearch.tf
@@ -43,7 +43,7 @@ data "aws_iam_policy_document" "live" {
 
 resource "aws_elasticsearch_domain" "live" {
   domain_name           = "${local.live_domain}"
-  elasticsearch_version = "6.2"
+  elasticsearch_version = "6.4"
 
   cluster_config {
     instance_type            = "m4.large.elasticsearch"
@@ -114,7 +114,7 @@ data "aws_iam_policy_document" "audit" {
 
 resource "aws_elasticsearch_domain" "audit" {
   domain_name           = "${local.audit_domain}"
-  elasticsearch_version = "6.2"
+  elasticsearch_version = "6.4"
 
   cluster_config {
     instance_type  = "m4.large.elasticsearch"


### PR DESCRIPTION
This PR connects to ministryofjustice/cloud-platform#639

This PR contains an update to the AWS hosted ElasticSearch cluster terraform configuration. 

The ES cluster version has been changed from 6.2 to 6.4 for the `Live` and `Audit` clusters.