### PR TITLE
Set version of nginx-ingress to the current one

### DIFF
--- a/terraform/cloud-platform-components/nginx-ingress.tf
+++ b/terraform/cloud-platform-components/nginx-ingress.tf
@@ -2,11 +2,12 @@ resource "helm_release" "nginx_ingress" {
   name      = "nginx-ingress"
   chart     = "stable/nginx-ingress"
   namespace = "ingress-controllers"
-  version   = "v1.1.4"
+  version   = "v0.29.0"
 
   values = [<<EOF
 controller:
   replicaCount: 3
+
   config:
     generate-request-id: "true"
     proxy-buffer-size: "16k"
@@ -15,19 +16,25 @@ controller:
       if ($http_x_forwarded_proto != 'https') {
         return 308 https://$host$request_uri;
       }
+
   stats:
     enabled: true
+
   metrics:
     enabled: true
+
   service:
     annotations:
       external-dns.alpha.kubernetes.io/hostname: "*.apps.${data.terraform_remote_state.cluster.cluster_domain_name}"
       service.beta.kubernetes.io/aws-load-balancer-ssl-cert: "${data.terraform_remote_state.cluster.certificate_arn}"
       service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
       service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "http"
+
     targetPorts:
       https: 80
+
     externalTrafficPolicy: "Local"
+
 rbac:
   create: true
 EOF


### PR DESCRIPTION
This prevents any kind of update to nginx-ingress which is going to be decommissioned in favour of nginx-ingress-acme.