### PR TITLE
Use external-dns cli flag to set role

### DIFF
--- a/terraform/cloud-platform-components/external-dns.tf
+++ b/terraform/cloud-platform-components/external-dns.tf
@@ -49,7 +49,8 @@ provider: aws
 aws:
   region: eu-west-1
   zoneType: public
-  roleArn: "${aws_iam_role.external_dns.arn}"
+extraArgs:
+  aws-assume-role: "${aws_iam_role.external_dns.arn}"
 domainFilters:
   - "${data.terraform_remote_state.cluster.cluster_domain_name}"
 rbac:


### PR DESCRIPTION
The `roleArn` chart attribute is only used when the chart is supplied with a set of IAM keys.
This ensures external-dns will assume the correct role.