### PR TITLE
Add/fluentd buffer alarm

### DIFF
--- a/helm-charts/fluentd-es/Chart.yaml
+++ b/helm-charts/fluentd-es/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "v2.2.0"
 description: A Helm chart for fluentd-es
 name: fluentd-es
-version: 0.1.0
+version: 0.1.1

--- a/helm-charts/fluentd-es/config/output.conf
+++ b/helm-charts/fluentd-es/config/output.conf
@@ -32,7 +32,7 @@
     flush_interval 5s
     retry_forever
     retry_max_interval 30
-    chunk_limit_size 50M
+    chunk_limit_size 256M
     queue_limit_length 8
     overflow_action block
     </buffer>
@@ -59,7 +59,7 @@
     flush_interval 5s
     retry_forever
     retry_max_interval 30
-    chunk_limit_size 50M
+    chunk_limit_size 256M
     queue_limit_length 8
     overflow_action block
     </buffer>

--- a/helm-charts/fluentd-es/templates/prometheus-custom-rules-fluentd.yaml
+++ b/helm-charts/fluentd-es/templates/prometheus-custom-rules-fluentd.yaml
@@ -1,19 +1,19 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  namespace: <namespace>
+  namespace: logging
   labels:
     role: alert-rules
-  name: prometheus-custom-rules-<application_name>
+  name: prometheus-custom-rules-fluentd
 spec:
   groups:
   - name: application-rules
     rules:
-    - alert: <alert_name>
-      expr: <alert_query>
-      for: <check_time_length>
+    - alert: fluentd_buffer_full
+      expr: fluentd_output_status_buffer_total_bytes > 1800000000
+      for: 2m
       labels:
-        severity: <team_name>
+        severity: cp-team
       annotations:
-        message: <alert_message> 
-        runbook_url: <http://my-support-docs>
+        message: The Fluentd buffer limit of 8 x 256Mb chunks is full. This indicates that Fluentd is having issues writing to the ElasticSearch cluster or it is collecting logs quicker than it can write. 
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-infrastructure/tree/master/helm-charts/fluentd-es

--- a/helm-charts/fluentd-es/templates/prometheus-custom-rules-fluentd.yaml
+++ b/helm-charts/fluentd-es/templates/prometheus-custom-rules-fluentd.yaml
@@ -13,7 +13,7 @@ spec:
       expr: fluentd_output_status_buffer_total_bytes > 1800000000
       for: 2m
       labels:
-        severity: cp-team
+        severity: high-priority
       annotations:
         message: The Fluentd buffer limit (defined by the chunk_limit_size and queue_limit_length values in helm-charts/fluentd-es/config/output.conf) is full. This indicates that Fluentd is having issues writing to the ElasticSearch cluster or it is collecting logs quicker than it can write. 
-        runbook_url: https://github.com/ministryofjustice/cloud-platform-infrastructure/tree/master/helm-charts/fluentd-es
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/cloud-platform-components/README.md

--- a/helm-charts/fluentd-es/templates/prometheus-custom-rules-fluentd.yaml
+++ b/helm-charts/fluentd-es/templates/prometheus-custom-rules-fluentd.yaml
@@ -1,0 +1,19 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  namespace: <namespace>
+  labels:
+    role: alert-rules
+  name: prometheus-custom-rules-<application_name>
+spec:
+  groups:
+  - name: application-rules
+    rules:
+    - alert: <alert_name>
+      expr: <alert_query>
+      for: <check_time_length>
+      labels:
+        severity: <team_name>
+      annotations:
+        message: <alert_message> 
+        runbook_url: <http://my-support-docs>

--- a/helm-charts/fluentd-es/templates/prometheus-custom-rules-fluentd.yaml
+++ b/helm-charts/fluentd-es/templates/prometheus-custom-rules-fluentd.yaml
@@ -9,7 +9,7 @@ spec:
   groups:
   - name: application-rules
     rules:
-    - alert: fluentd_buffer_full
+    - alert: FluentdBufferFull
       expr: fluentd_output_status_buffer_total_bytes > 1800000000
       for: 2m
       labels:

--- a/helm-charts/fluentd-es/templates/prometheus-custom-rules-fluentd.yaml
+++ b/helm-charts/fluentd-es/templates/prometheus-custom-rules-fluentd.yaml
@@ -15,5 +15,5 @@ spec:
       labels:
         severity: cp-team
       annotations:
-        message: The Fluentd buffer limit of 8 x 256Mb chunks is full. This indicates that Fluentd is having issues writing to the ElasticSearch cluster or it is collecting logs quicker than it can write. 
+        message: The Fluentd buffer limit (defined by the chunk_limit_size and queue_limit_length values in helm-charts/fluentd-es/config/output.conf) is full. This indicates that Fluentd is having issues writing to the ElasticSearch cluster or it is collecting logs quicker than it can write. 
         runbook_url: https://github.com/ministryofjustice/cloud-platform-infrastructure/tree/master/helm-charts/fluentd-es

--- a/terraform/cloud-platform-components/README.md
+++ b/terraform/cloud-platform-components/README.md
@@ -21,6 +21,11 @@ ExternalDNS synchronizes exposed Kubernetes Services and Ingresses with DNS prov
 ## Fluentd
 The Terraform in this directory has all the required resources to deploy `fluentd` as a `DaemonSet` on the cluster. As long as applications are writing out to stdout logs are scrapped and pushed to Elasticsearch. 
 
+### Full buffer
+Fluentd has a buffer limit (defined by the chunk_limit_size and queue_limit_length values in helm-charts/fluentd-es/config/output.conf)
+
+When full this normally indicates that Fluentd is unable to write to the ElasticSearch cluster. In this case, view various sources of metrics and logs to determine the cause. 
+
 ## Helm
 To enable three quarters of deployments on the cluster we must first install and configure Helm. This is done via a series of `local_exec`'s in the `helm.tf` file. 
 


### PR DESCRIPTION
This PR connect to ministryofjustice/cloud-platform#673

If merged this PR will add a Prometheus alarm to the Helm chart of Fluentd.

The alarm is triggered when the Fluentd buffer size is nearly full for over 2 minutes.

The metric is measured in total byte size. The actual buffer limit is 256M, but this alarm is trigger at anything over 180M.  