### PR TITLE
Setup cert-manager with access to a list of dsd zones

### DIFF
--- a/terraform/cloud-platform-components/cert-manager-external.tf
+++ b/terraform/cloud-platform-components/cert-manager-external.tf
@@ -1,7 +1,9 @@
 locals {
   # This is the list of Route53 Hosted Zones in the DSD account that
   # cert-manager will be given access to.
-  cert_manager_dsd_zones = []
+  cert_manager_dsd_zones = [
+    "find-legal-advice.justice.gov.uk.",
+  ]
 }
 
 data "aws_route53_zone" "cert_manager_dsd" {

--- a/terraform/cloud-platform-components/cert-manager-external.tf
+++ b/terraform/cloud-platform-components/cert-manager-external.tf
@@ -1,0 +1,60 @@
+locals {
+  # This is the list of Route53 Hosted Zones in the DSD account that
+  # cert-manager will be given access to.
+  cert_manager_dsd_zones = []
+}
+
+data "aws_route53_zone" "cert_manager_dsd" {
+  provider = "aws.dsd"
+  count    = "${length(local.cert_manager_dsd_zones)}"
+  name     = "${local.cert_manager_dsd_zones[count.index]}"
+}
+
+resource "aws_iam_user" "cert_manager_dsd" {
+  provider = "aws.dsd"
+  name     = "cert-manager.${data.terraform_remote_state.cluster.cluster_domain_name}"
+  path     = "/cloud-platform/"
+}
+
+resource "aws_iam_access_key" "cert_manager_dsd" {
+  provider = "aws.dsd"
+  user     = "${aws_iam_user.cert_manager_dsd.name}"
+}
+
+resource "aws_iam_user_policy" "cert_manager_dsd" {
+  provider = "aws.dsd"
+  name     = "route53-hostedzones"
+  policy   = "${data.aws_iam_policy_document.cert_manager_dsd.json}"
+  user     = "${aws_iam_user.cert_manager_dsd.name}"
+}
+
+data "aws_iam_policy_document" "cert_manager_dsd" {
+  statement {
+    actions   = ["route53:ChangeResourceRecordSets"]
+    resources = ["${formatlist("arn:aws:route53:::hostedzone/%s", data.aws_route53_zone.cert_manager_dsd.*.zone_id)}"]
+  }
+
+  statement {
+    actions   = ["route53:GetChange"]
+    resources = ["arn:aws:route53:::change/*"]
+  }
+
+  statement {
+    actions   = ["route53:ListHostedZonesByName"]
+    resources = ["*"]
+  }
+}
+
+resource "kubernetes_secret" "cert_manager_dsd" {
+  type = "Opaque"
+
+  metadata {
+    name      = "iam-dsd-route53"
+    namespace = "cert-manager"
+  }
+
+  data {
+    access_key_id     = "${aws_iam_access_key.cert_manager_dsd.id}"
+    secret_access_key = "${aws_iam_access_key.cert_manager_dsd.secret}"
+  }
+}

--- a/terraform/cloud-platform-components/main.tf
+++ b/terraform/cloud-platform-components/main.tf
@@ -36,3 +36,9 @@ data "aws_iam_role" "nodes" {
 }
 
 data "aws_caller_identity" "current" {}
+
+provider "aws" {
+  alias   = "dsd"
+  profile = "moj-dsd"
+  region  = "eu-west-1"
+}

--- a/terraform/cloud-platform-components/nginx-ingress-acme.tf
+++ b/terraform/cloud-platform-components/nginx-ingress-acme.tf
@@ -25,7 +25,7 @@ controller:
 
   service:
     annotations:
-      # external-dns.alpha.kubernetes.io/hostname: "*.apps.${data.terraform_remote_state.cluster.cluster_domain_name}"
+      # external-dns.alpha.kubernetes.io/hostname: "*.apps.${data.terraform_remote_state.cluster.cluster_domain_name},apps.${data.terraform_remote_state.cluster.cluster_domain_name}"
       service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
 
     externalTrafficPolicy: "Local"

--- a/terraform/cloud-platform-components/nginx-ingress.tf
+++ b/terraform/cloud-platform-components/nginx-ingress.tf
@@ -25,7 +25,7 @@ controller:
 
   service:
     annotations:
-      external-dns.alpha.kubernetes.io/hostname: "*.apps.${data.terraform_remote_state.cluster.cluster_domain_name}"
+      external-dns.alpha.kubernetes.io/hostname: "*.apps.${data.terraform_remote_state.cluster.cluster_domain_name},apps.${data.terraform_remote_state.cluster.cluster_domain_name}"
       service.beta.kubernetes.io/aws-load-balancer-ssl-cert: "${data.terraform_remote_state.cluster.certificate_arn}"
       service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
       service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "http"

--- a/terraform/cloud-platform-components/templates/cert-manager/letsencrypt-production.yaml
+++ b/terraform/cloud-platform-components/templates/cert-manager/letsencrypt-production.yaml
@@ -16,7 +16,7 @@ spec:
       cnameStrategy: "Follow"
       # Here we define a list of DNS-01 providers that can solve DNS challenges
       providers:
-      - name: route53-local
+      - name: route53-cloud-platform
         route53:
           region: eu-west-1
       - name: route53-dsd

--- a/terraform/cloud-platform-components/templates/cert-manager/letsencrypt-production.yaml
+++ b/terraform/cloud-platform-components/templates/cert-manager/letsencrypt-production.yaml
@@ -1,21 +1,28 @@
 apiVersion: certmanager.k8s.io/v1alpha1
 kind: ClusterIssuer
 metadata:
-  name: letsencrypt-staging
+  name: letsencrypt-production
 spec:
   acme:
     # The ACME server URL
-    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    server: https://acme-v02.api.letsencrypt.org/directory
     # Email address used for ACME registration
     email: platforms@digital.justice.gov.uk
     # Name of a secret used to store the ACME account private key
     privateKeySecretRef:
-      name: letsencrypt-staging
+      name: letsencrypt-production
     # Enable the DNS-01 challenge provider
     dns01:
       cnameStrategy: "Follow"
       # Here we define a list of DNS-01 providers that can solve DNS challenges
       providers:
-      - name: route53
+      - name: route53-local
         route53:
           region: eu-west-1
+      - name: route53-dsd
+        route53:
+          region: eu-west-1
+          accessKeyID: ${dsd_key_id}
+          secretAccessKeySecretRef:
+            name: ${dsd_secret_name}
+            key: secret_access_key

--- a/terraform/cloud-platform-components/templates/cert-manager/letsencrypt-staging.yaml
+++ b/terraform/cloud-platform-components/templates/cert-manager/letsencrypt-staging.yaml
@@ -16,7 +16,7 @@ spec:
       cnameStrategy: "Follow"
       # Here we define a list of DNS-01 providers that can solve DNS challenges
       providers:
-      - name: route53-local
+      - name: route53-cloud-platform
         route53:
           region: eu-west-1
       - name: route53-dsd

--- a/terraform/cloud-platform-components/templates/cert-manager/letsencrypt-staging.yaml
+++ b/terraform/cloud-platform-components/templates/cert-manager/letsencrypt-staging.yaml
@@ -1,21 +1,28 @@
 apiVersion: certmanager.k8s.io/v1alpha1
 kind: ClusterIssuer
 metadata:
-  name: letsencrypt-production
+  name: letsencrypt-staging
 spec:
   acme:
     # The ACME server URL
-    server: https://acme-v02.api.letsencrypt.org/directory
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
     # Email address used for ACME registration
     email: platforms@digital.justice.gov.uk
     # Name of a secret used to store the ACME account private key
     privateKeySecretRef:
-      name: letsencrypt-production
+      name: letsencrypt-staging
     # Enable the DNS-01 challenge provider
     dns01:
       cnameStrategy: "Follow"
       # Here we define a list of DNS-01 providers that can solve DNS challenges
       providers:
-      - name: route53
+      - name: route53-local
         route53:
           region: eu-west-1
+      - name: route53-dsd
+        route53:
+          region: eu-west-1
+          accessKeyID: ${dsd_key_id}
+          secretAccessKeySecretRef:
+            name: ${dsd_secret_name}
+            key: secret_access_key

--- a/terraform/cloud-platform-components/templates/nginx-ingress/default-certificate.yaml
+++ b/terraform/cloud-platform-components/templates/nginx-ingress/default-certificate.yaml
@@ -12,6 +12,6 @@ spec:
   acme:
     config:
     - dns01:
-        provider: route53
+        provider: route53-local
       domains:
       - '${common_name}'

--- a/terraform/cloud-platform-components/templates/nginx-ingress/default-certificate.yaml
+++ b/terraform/cloud-platform-components/templates/nginx-ingress/default-certificate.yaml
@@ -12,6 +12,6 @@ spec:
   acme:
     config:
     - dns01:
-        provider: route53-local
+        provider: route53-cloud-platform
       domains:
       - '${common_name}'


### PR DESCRIPTION
This is to enable certificate validation for externally-managed route53 zones.