### PR TITLE
increase node and ingress limits

### DIFF
--- a/terraform/cloud-platform-components/nginx-ingress-acme.tf
+++ b/terraform/cloud-platform-components/nginx-ingress-acme.tf
@@ -6,7 +6,7 @@ resource "helm_release" "nginx_ingress_acme" {
 
   values = [<<EOF
 controller:
-  replicaCount: 3
+  replicaCount: 6
 
   config:
     generate-request-id: "true"

--- a/terraform/cloud-platform-components/nginx-ingress.tf
+++ b/terraform/cloud-platform-components/nginx-ingress.tf
@@ -6,7 +6,7 @@ resource "helm_release" "nginx_ingress" {
 
   values = [<<EOF
 controller:
-  replicaCount: 3
+  replicaCount: 6
 
   config:
     generate-request-id: "true"

--- a/terraform/cloud-platform/templates/kops.yaml.tpl
+++ b/terraform/cloud-platform/templates/kops.yaml.tpl
@@ -372,8 +372,8 @@ metadata:
 spec:
   image: kope.io/k8s-1.10-debian-stretch-amd64-hvm-ebs-2018-08-17
   machineType: r5.xlarge
-  maxSize: 6
-  minSize: 6
+  maxSize: 12
+  minSize: 12
   nodeLabels:
     kops.k8s.io/instancegroup: nodes
   cloudLabels:


### PR DESCRIPTION
**Why**
https://grafana.apps.cloud-platform-live-0.k8s.integration.dsd.io/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-compute-resources-pod?refresh=10s&orgId=1&var-datasource=Prometheus&var-namespace=ingress-controllers was showing high res usage and users were reporting 504 errors