### PR TITLE
live-1: allow cert-manager to issue domains for checklegalaid.service.gov.uk.

### DIFF
--- a/terraform/cloud-platform-components/cert-manager-external.tf
+++ b/terraform/cloud-platform-components/cert-manager-external.tf
@@ -3,6 +3,7 @@ locals {
   # cert-manager will be given access to.
   cert_manager_dsd_zones = [
     "find-legal-advice.justice.gov.uk.",
+    "checklegalaid.service.gov.uk.",
   ]
 }
 

--- a/terraform/cloud-platform-components/nginx-ingress-acme.tf
+++ b/terraform/cloud-platform-components/nginx-ingress-acme.tf
@@ -25,7 +25,7 @@ controller:
 
   service:
     annotations:
-      external-dns.alpha.kubernetes.io/hostname: "*.apps.${data.terraform_remote_state.cluster.cluster_domain_name}"
+      external-dns.alpha.kubernetes.io/hostname: "*.apps.${data.terraform_remote_state.cluster.cluster_domain_name},apps.${data.terraform_remote_state.cluster.cluster_domain_name}"
       service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
 
     externalTrafficPolicy: "Local"


### PR DESCRIPTION
Counterpart of #194