### PR TITLE
live-0: Remove aws-assume-role from external-dns config

### DIFF
--- a/terraform/cloud-platform-components/external-dns.tf
+++ b/terraform/cloud-platform-components/external-dns.tf
@@ -49,15 +49,13 @@ provider: aws
 aws:
   region: eu-west-1
   zoneType: public
-extraArgs:
-  aws-assume-role: "${aws_iam_role.external_dns.arn}"
 domainFilters:
   - "${data.terraform_remote_state.cluster.cluster_domain_name}"
 rbac:
   create: true
   apiVersion: v1
   serviceAccountName: default
-logLevel: debug
+logLevel: info
 podAnnotations:
   iam.amazonaws.com/role: "${aws_iam_role.external_dns.name}"
 EOF


### PR DESCRIPTION
This breaks external dns:
1. kiam gives the Pod credentials for the correct role (controlled by the Pod annotation)
2. external-dns tries to assume the role which fails

We don't need step (2) since (1) gives us the correct set of credentials.