### PR TITLE
live-0: define node-exporter resources

### DIFF
--- a/terraform/cloud-platform-components/templates/prometheus-operator.yaml.tpl
+++ b/terraform/cloud-platform-components/templates/prometheus-operator.yaml.tpl
@@ -698,6 +698,13 @@ nodeExporter:
   ## Use the value configured in prometheus-node-exporter.podLabels
   ##
   jobLabel: jobLabel
+  resources:
+    limits:
+      cpu: 10m
+      memory: 50Mi
+    requests:
+      cpu: 5m
+      memory: 25Mi
 
 ## Configuration for prometheus-node-exporter subchart
 ##


### PR DESCRIPTION
These are based on current usage (and are generous values!) but they are still a lot less than the defaults in
LimitRange which cause scheduling problems.