### PR TITLE
Feature/number of nodes variable

### DIFF
--- a/terraform/cloud-platform/kops.tf
+++ b/terraform/cloud-platform/kops.tf
@@ -12,6 +12,7 @@ data "template_file" "kops" {
 
   vars {
     cluster_domain_name                  = "${local.cluster_base_domain_name}"
+    cluster_node_min_size                = "${var.cluster_node_min_size}"
     kops_state_store                     = "${data.terraform_remote_state.global.cloud_platform_kops_state}"
     oidc_issuer_url                      = "${local.oidc_issuer_url}"
     oidc_client_id                       = "${auth0_client.kubernetes.client_id}"

--- a/terraform/cloud-platform/templates/kops.yaml.tpl
+++ b/terraform/cloud-platform/templates/kops.yaml.tpl
@@ -389,7 +389,7 @@ spec:
   image: kope.io/k8s-1.11-debian-stretch-amd64-hvm-ebs-2018-08-17
   machineType: r5.xlarge
   maxSize: 15
-  minSize: 15
+  minSize: ${cluster_node_min_size}
   nodeLabels:
     kops.k8s.io/instancegroup: nodes
   cloudLabels:

--- a/terraform/cloud-platform/variables.tf
+++ b/terraform/cloud-platform/variables.tf
@@ -20,3 +20,7 @@ variable "availability_zones" {
   description = "a list of EC2 availability zones"
   default     = ["eu-west-2a", "eu-west-2b", "eu-west-2c"]
 }
+variable "cluster_node_min_size" {
+  description = "min number of worker node in kops manifest"
+  default     = 15
+}

--- a/terraform/cloud-platform/variables.tf
+++ b/terraform/cloud-platform/variables.tf
@@ -20,6 +20,7 @@ variable "availability_zones" {
   description = "a list of EC2 availability zones"
   default     = ["eu-west-2a", "eu-west-2b", "eu-west-2c"]
 }
+
 variable "cluster_node_min_size" {
   description = "min number of worker node in kops manifest"
   default     = 15


### PR DESCRIPTION
- Added a `cluster_node_min_size` variable, to define the number of worker node Kops will create

-  It defaults to 15 

- for example, to use it,  add `-var 'cluster_node_min_size=3' ` to the terraform plan/apply command