### PR TITLE
Hotfixes that came up during the FALA migration.

### DIFF
--- a/terraform/cloud-platform-components/external-dns-dsd.tf
+++ b/terraform/cloud-platform-components/external-dns-dsd.tf
@@ -54,6 +54,7 @@ rbac:
   create: true
   apiVersion: v1
   serviceAccountName: default
+txtPrefix: "_external_dns."
 logLevel: info
 EOF
   ]

--- a/terraform/cloud-platform-components/external-dns-dsd.tf
+++ b/terraform/cloud-platform-components/external-dns-dsd.tf
@@ -38,8 +38,11 @@ resource "helm_release" "external_dns_dsd" {
   name      = "external-dns-dsd"
   chart     = "stable/external-dns"
   namespace = "kube-system"
+  version   = "1.7.0"
 
   values = [<<EOF
+image:
+  tag: v0.5.11
 sources:
   - ingress
 provider: aws

--- a/terraform/cloud-platform-components/external-dns.tf
+++ b/terraform/cloud-platform-components/external-dns.tf
@@ -40,8 +40,11 @@ resource "helm_release" "external_dns" {
   name      = "external-dns"
   chart     = "stable/external-dns"
   namespace = "kube-system"
+  version   = "1.7.0"
 
   values = [<<EOF
+image:
+  tag: v0.5.11
 sources:
   - service
 provider: aws

--- a/terraform/cloud-platform-components/external-dns.tf
+++ b/terraform/cloud-platform-components/external-dns.tf
@@ -54,6 +54,7 @@ rbac:
   create: true
   apiVersion: v1
   serviceAccountName: default
+txtPrefix: "_external_dns."
 logLevel: info
 podAnnotations:
   iam.amazonaws.com/role: "${aws_iam_role.external_dns.name}"

--- a/terraform/cloud-platform-components/nginx-ingress-acme.tf
+++ b/terraform/cloud-platform-components/nginx-ingress-acme.tf
@@ -8,6 +8,8 @@ resource "helm_release" "nginx_ingress_acme" {
 controller:
   replicaCount: 6
 
+  electionID: ingress-controller-leader-acme
+
   config:
     generate-request-id: "true"
     proxy-buffer-size: "16k"


### PR DESCRIPTION
Some more detail beyond the commit messages.

Upgrading the version of external dns seems to address an issue I saw with external-dns going in a loop because the
owner of the record was `""`! Unfortunately, I don't see anything that directly references this in the changelog.