### PR TITLE
live-1/cert-manager: add labels to the metrics service

### DIFF
--- a/terraform/cloud-platform-components/resources/cert-manager/servicemonitor.yaml
+++ b/terraform/cloud-platform-components/resources/cert-manager/servicemonitor.yaml
@@ -3,6 +3,9 @@ kind: Service
 metadata:
   name: cert-manager-metrics
   namespace: cert-manager
+  labels:
+    app: cert-manager
+    release: cert-manager
 spec:
   ports:
   - name: metrics


### PR DESCRIPTION
This will allow the `ServiceMonitor` to detect scrapable endpoints.

See #214 also