### PR TITLE
Allow critical namespaces access to the Privileged PSP

### DIFF
--- a/terraform/cloud-platform-components/resources/psp/pod-security-policy.yaml
+++ b/terraform/cloud-platform-components/resources/psp/pod-security-policy.yaml
@@ -118,14 +118,20 @@ roleRef:
   name: psp:privileged
 subjects:
 - kind: Group
-  name: system:serviceaccounts:kube-system
+  name: system:serviceaccounts:cert-manager
   apiGroup: rbac.authorization.k8s.io
 - kind: Group
-  name: system:serviceaccounts:monitoring
+  name: system:serviceaccounts:concourse
+  apiGroup: rbac.authorization.k8s.io
+- kind: Group
+  name: system:serviceaccounts:ingress-controllers
+  apiGroup: rbac.authorization.k8s.io
+- kind: Group
+  name: system:serviceaccounts:kuberos
   apiGroup: rbac.authorization.k8s.io
 - kind: Group
   name: system:serviceaccounts:logging
   apiGroup: rbac.authorization.k8s.io
 - kind: Group
-  name: system:serviceaccounts:ingress-controllers
+  name: system:serviceaccounts:monitoring
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
**Overview**
---
This PR connects to https://github.com/ministryofjustice/cloud-platform/issues/749 and ensures that Pod Security Policies work in live-1. 

**What does it include and why**
---
It adds namespaces that require privileged pods to the clusterrole which uses the privileged psp.