### PR TITLE
Change PrometheusRules default rules

### DIFF
--- a/terraform/cloud-platform-components/templates/prometheus-operator.yaml.tpl
+++ b/terraform/cloud-platform-components/templates/prometheus-operator.yaml.tpl
@@ -23,14 +23,14 @@ defaultRules:
   rules:
     alertmanager: true
     etcd: true
-    general: true
+    general: false
     k8s: true
     kubeApiserver: true
     kubePrometheusNodeAlerting: true
     kubePrometheusNodeRecording: true
     kubeScheduler: true
     kubernetesAbsent: true
-    kubernetesApps: true
+    kubernetesApps: false
     kubernetesResources: true
     kubernetesStorage: true
     kubernetesSystem: true


### PR DESCRIPTION
WHAT
Deactivate 2 default prometheusrules set by prometheus-opertaor 

WHY
The general and application default rules set by prometheus-operator have been deactivated and we will create our own custom alerts for application monitoring in specific namespaces 