### PR TITLE
add service.justice to cert-manager

### DIFF
--- a/terraform/cloud-platform-components/cert-manager-external.tf
+++ b/terraform/cloud-platform-components/cert-manager-external.tf
@@ -4,6 +4,7 @@ locals {
   cert_manager_dsd_zones = [
     "find-legal-advice.justice.gov.uk.",
     "checklegalaid.service.gov.uk.",
+    "service.justice.gov.uk.",
   ]
 }
 


### PR DESCRIPTION
**Why**
Allows us to have easy to remember hostnames not including .apps.clustername
