### PR TITLE
Remove apparmor from Grafana

### DIFF
--- a/terraform/cloud-platform-components/templates/prometheus-operator.yaml.tpl
+++ b/terraform/cloud-platform-components/templates/prometheus-operator.yaml.tpl
@@ -480,6 +480,9 @@ alertmanager:
 ##
 grafana:
   enabled: true
+  
+  rbac:
+    pspUseAppArmor: false
 
   ## Deploy default dashboards.
   ##


### PR DESCRIPTION
**Overview**
---
Now PSPs are enabled in the cluster, Grafana immediately tries to use apparmor. It has been decided this will not be enabled and thus breaks the Grafana install. This PR removes the apparmor configuration using the instruction here: https://github.com/helm/charts/tree/master/stable/prometheus-operator#grafana