### PR TITLE
Added resource in prometheus.tf to apply alerts

### DIFF
--- a/terraform/cloud-platform-components/prometheus.tf
+++ b/terraform/cloud-platform-components/prometheus.tf
@@ -146,3 +146,16 @@ resource "helm_release" "alertmanager_proxy" {
     ignore_changes = ["keyring"]
   }
 }
+
+resource "null_resource" "prometheus-customalerts" {
+  depends_on = ["helm_release.prometheus_operator"]
+
+  provisioner "local-exec" {
+    command = "kubectl apply -n monitoring -f ${path.module}/resources/prometheusrule-alerts/"
+  }
+
+  provisioner "local-exec" {
+    when    = "destroy"
+    command = "kubectl delete -n monitoring -f ${path.module}/resources/prometheusrule-alerts/"
+  }
+}


### PR DESCRIPTION
This PR is to add a resource to apply custom-alerts to current Prometheus installation in Terraform (https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/cloud-platform-components/prometheus.tf).