### PR TITLE
Custom Alert Rules added to operator install - live0

### DIFF
--- a/terraform/cloud-platform-components/prometheus.tf
+++ b/terraform/cloud-platform-components/prometheus.tf
@@ -61,6 +61,10 @@ resource "helm_release" "prometheus_operator" {
     "null_resource.deploy",
   ]
 
+  provisioner "local-exec" {
+    command = "kubectl apply -n monitoring -f ${path.module}/resources/prometheusrule-alerts/"
+  }
+
   # Delete Prometheus leftovers
   # Ref: https://github.com/coreos/prometheus-operator#removal
   provisioner "local-exec" {

--- a/terraform/cloud-platform-components/resources/prometheusrule-alerts/Custom-Alerts.md
+++ b/terraform/cloud-platform-components/resources/prometheusrule-alerts/Custom-Alerts.md
@@ -228,17 +228,17 @@ Check to see if the external-dns pod is running in the `kube-system` namespace:
 NginxIngressPodDown
 Severity: warning
 ```
-This alert is triggered when less than 3 nginx-ingress pods are running for 5 minutes.
+This alert is triggered when less than 6 nginx-ingress pods are running for 5 minutes.
 
 Expression:
 ```
-kube_deployment_status_replicas_available{deployment="nginx-ingress-controller"} <3
+kube_deployment_status_replicas_available{deployment="nginx-ingress-controller"} < 6
 for: 5m
 ```
 
 ### Action
 
-Check how many nginx-ingress pods are running. There should be at least 3 with the status `Running`.
+Check how many nginx-ingress pods are running. There should be at least 6 with the status `Running`.
 
 `$ kubectl get pods -n nginx-controllers`
 

--- a/terraform/cloud-platform-components/resources/prometheusrule-alerts/application-alerts.yaml
+++ b/terraform/cloud-platform-components/resources/prometheusrule-alerts/application-alerts.yaml
@@ -1,0 +1,239 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: prometheus-operator
+    role: alert-rules
+  name: prometheus-operator-custom-kubernetes-apps.rules
+spec:
+  groups:
+  - name: kubernetes-apps
+    rules:
+    - alert: KubeQuotaExceeded
+      annotations:
+        message: Namespace {{ $labels.namespace }} is using {{ printf "%0.0f" $value
+          }}% of its {{ $labels.resource }} quota.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaexceeded
+      expr: |-
+        100 * kube_resourcequota{job="kube-state-metrics", type="used"} 
+        * on (namespace)
+        group_left() 
+        kube_namespace_annotations{annotation_cloud_platform_justice_gov_uk_business_unit="cloud-platform"}
+        / ignoring(instance, job, type)
+        (kube_resourcequota{job="kube-state-metrics", type="hard"} > 0)
+        > 90
+      for: 15m
+      labels:
+        severity: warning
+    - alert: KubePodCrashLooping
+      annotations:
+        message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container
+          }}) is restarting {{ printf "%.2f" $value }} times / 5 minutes.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodcrashlooping
+      expr: |-
+        rate(kube_pod_container_status_restarts_total{job="kube-state-metrics"}[15m]) 
+        * on (namespace)
+        group_left() 
+        kube_namespace_annotations{annotation_cloud_platform_justice_gov_uk_business_unit="cloud-platform"}
+        * 60 * 5 > 0
+      for: 1h
+      labels:
+        severity: warning
+    - alert: KubePodNotReady
+      annotations:
+        message: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready
+          state for longer than an hour.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodnotready
+      expr: |-
+        sum by (namespace, pod) (kube_pod_status_phase{job="kube-state-metrics", phase=~"Pending|Unknown"}) 
+        * on (namespace) 
+        group_left() 
+        kube_namespace_annotations{annotation_cloud_platform_justice_gov_uk_business_unit="cloud-platform"} 
+        > 0
+      for: 1h
+      labels:
+        severity: warning
+    - alert: KubeDeploymentGenerationMismatch
+      annotations:
+        message: Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment
+          }} does not match, this indicates that the Deployment has failed but has
+          not been rolled back.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedeploymentgenerationmismatch
+      expr: |-
+        kube_deployment_status_observed_generation{job="kube-state-metrics"}
+        * on (namespace)
+        group_left() 
+        kube_namespace_annotations{annotation_cloud_platform_justice_gov_uk_business_unit="cloud-platform"} 
+        !=
+        kube_deployment_metadata_generation{job="kube-state-metrics"}
+      for: 15m
+      labels:
+        severity: warning
+    - alert: KubeDeploymentReplicasMismatch
+      annotations:
+        message: Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has not
+          matched the expected number of replicas for longer than an hour.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedeploymentreplicasmismatch
+      expr: |-
+        kube_deployment_spec_replicas{job="kube-state-metrics"} 
+        * on (namespace)
+        group_left() 
+        kube_namespace_annotations{annotation_cloud_platform_justice_gov_uk_business_unit="cloud-platform"} 
+        != kube_deployment_status_replicas_available{job="kube-state-metrics"}
+      for: 1h
+      labels:
+        severity: warning
+    - alert: KubeStatefulSetReplicasMismatch
+      annotations:
+        message: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} has
+          not matched the expected number of replicas for longer than 15 minutes.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetreplicasmismatch
+      expr: |-
+        kube_statefulset_status_replicas_ready{job="kube-state-metrics"}
+        * on (namespace)
+        group_left() 
+        kube_namespace_annotations{annotation_cloud_platform_justice_gov_uk_business_unit="cloud-platform"}
+        !=
+        kube_statefulset_status_replicas{job="kube-state-metrics"}
+      for: 15m
+      labels:
+        severity: warning
+    - alert: KubeStatefulSetGenerationMismatch
+      annotations:
+        message: StatefulSet generation for {{ $labels.namespace }}/{{ $labels.statefulset
+          }} does not match, this indicates that the StatefulSet has failed but has
+          not been rolled back.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetgenerationmismatch
+      expr: |-
+        kube_statefulset_status_observed_generation{job="kube-state-metrics"}        
+        * on (namespace)
+        group_left() 
+        kube_namespace_annotations{annotation_cloud_platform_justice_gov_uk_business_unit="cloud-platform"}
+        !=
+        kube_statefulset_metadata_generation{job="kube-state-metrics"}
+      for: 15m
+      labels:
+        severity: critical
+    - alert: KubeStatefulSetUpdateNotRolledOut
+      annotations:
+        message: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} update
+          has not been rolled out.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetupdatenotrolledout
+      expr: |-
+        max without (revision) (
+          kube_statefulset_status_current_revision{job="kube-state-metrics"}
+          * on (namespace)
+          group_left() 
+          kube_namespace_annotations{annotation_cloud_platform_justice_gov_uk_business_unit="cloud-platform"}
+            unless
+          kube_statefulset_status_update_revision{job="kube-state-metrics"}
+        )
+          *
+        (
+          kube_statefulset_replicas{job="kube-state-metrics"}
+          * on (namespace)
+          group_left() 
+          kube_namespace_annotations{annotation_cloud_platform_justice_gov_uk_business_unit="cloud-platform"}
+          !=
+          kube_statefulset_status_replicas_updated{job="kube-state-metrics"}
+        )  
+      for: 15m
+      labels:
+        severity: warning
+    - alert: KubeDaemonSetRolloutStuck
+      annotations:
+        message: Only {{ $value }}% of the desired Pods of DaemonSet {{ $labels.namespace
+          }}/{{ $labels.daemonset }} are scheduled and ready.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetrolloutstuck
+      expr: |-
+        kube_daemonset_status_number_ready{job="kube-state-metrics"}
+        * on (namespace)
+        group_left() 
+        kube_namespace_annotations{annotation_cloud_platform_justice_gov_uk_business_unit="cloud-platform"}
+        /
+        kube_daemonset_status_desired_number_scheduled{job="kube-state-metrics"} * 100 < 100
+      for: 15m
+      labels:
+        severity: warning
+    - alert: KubeDaemonSetNotScheduled
+      annotations:
+        message: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset
+          }} are not scheduled.'
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetnotscheduled
+      expr: |-
+        kube_daemonset_status_desired_number_scheduled{job="kube-state-metrics"}     
+        * on (namespace)
+        group_left() 
+        kube_namespace_annotations{annotation_cloud_platform_justice_gov_uk_business_unit="cloud-platform"}
+        -
+        kube_daemonset_status_current_number_scheduled{job="kube-state-metrics"} > 0 
+      for: 10m
+      labels:
+        severity: warning
+    - alert: KubeDaemonSetMisScheduled
+      annotations:
+        message: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset
+          }} are running where they are not supposed to run.'
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetmisscheduled
+      expr: |-
+        kube_daemonset_status_number_misscheduled{job="kube-state-metrics"} 
+        * on (namespace)
+        group_left() 
+        kube_namespace_annotations{annotation_cloud_platform_justice_gov_uk_business_unit="cloud-platform"} 
+        > 0
+      for: 10m
+      labels:
+        severity: warning
+    - alert: KubeCronJobRunning
+      annotations:
+        message: CronJob {{ $labels.namespace }}/{{ $labels.cronjob }} is taking more
+          than 1h to complete.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecronjobrunning
+      expr: |-
+        time() - kube_cronjob_next_schedule_time{job="kube-state-metrics"} 
+        * on (namespace)
+        group_left() 
+        kube_namespace_annotations{annotation_cloud_platform_justice_gov_uk_business_unit="cloud-platform"} 
+        > 3600
+      for: 1h
+      labels:
+        severity: warning
+    - alert: KubeJobCompletion
+      annotations:
+        message: Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking more
+          than one hour to complete.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobcompletion
+      expr: |-
+        kube_job_spec_completions{job="kube-state-metrics"} - kube_job_status_succeeded{job="kube-state-metrics"} 
+        * on (namespace)
+        group_left() 
+        kube_namespace_annotations{annotation_cloud_platform_justice_gov_uk_business_unit="cloud-platform"} 
+        > 0
+      for: 1h
+      labels:
+        severity: warning
+    - alert: KubeJobFailed
+      annotations:
+        message: Job {{ $labels.namespace }}/{{ $labels.job_name }} failed to complete.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobfailed
+      expr: |-
+        kube_job_status_failed{job="kube-state-metrics"}  
+        * on (namespace)
+        group_left() 
+        kube_namespace_annotations{annotation_cloud_platform_justice_gov_uk_business_unit="cloud-platform"} 
+        > 0
+      for: 1h
+      labels:
+        severity: warning
+    - alert: TargetDown
+      annotations:
+        message: '{{ $value }}% of the {{ $labels.job }} targets are down.'
+      expr: |-
+        100 * (count(up == 0) BY (job) / count(up) BY (job)) 
+        * on (namespace)
+        group_left() 
+        kube_namespace_annotations{annotation_cloud_platform_justice_gov_uk_business_unit="cloud-platform"} 
+        > 10
+      for: 10m
+      labels:
+        severity: warning

--- a/terraform/cloud-platform-components/resources/prometheusrule-alerts/node-alerts.yaml
+++ b/terraform/cloud-platform-components/resources/prometheusrule-alerts/node-alerts.yaml
@@ -1,0 +1,116 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: prometheus-operator
+    role: alert-rules
+  name: prometheus-operator-custom-alerts-node.rules
+spec:
+  groups:
+  - name: node.rules
+    rules:
+    - alert: Node-Disk-Space-Low
+      expr: ((node_filesystem_avail_bytes * 100) / node_filesystem_size_bytes) < 10
+      for: 30m
+      labels:
+        severity: warning
+      annotations:
+        message: 'A node is reporting low disk space below 10%. Action is required on a node.'
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/cloud-platform-components/resources/prometheusrule-alerts/Custom-Alerts.md#node-disk-space-low
+    - alert: CPU-High
+      expr: 100 - (avg by (instance) (irate(node_cpu_seconds_total{mode="idle"}[5m])) * 100) > 85
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        message: This device's CPU usage has exceeded the threshold with a value of {{ $value }}. Instance {{ $labels.instance }} CPU usage is dangerously high
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/cloud-platform-components/resources/prometheusrule-alerts/Custom-Alerts.md#cpu-high
+    - alert: CPU-Critical
+      expr: 100 - (avg by (instance) (irate(node_cpu_seconds_total{mode="idle"}[5m])) * 100) > 95
+      for: 5m
+      labels:
+        severity: critical
+      annotations:
+        message: This device's CPU usage has exceeded the threshold with a value of {{ $value }}.Instance {{ $labels.instance }} CPU usage is critically high
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/cloud-platform-components/resources/prometheusrule-alerts/Custom-Alerts.md#cpu-critical
+    - alert: Memory-High
+      expr: (node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) / (node_memory_MemTotal_bytes) * 100 > 80
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        message: '{{ $labels.instance }} has high memory usage for than 5 minutes. Instance {{ $labels.instance }} memory has high usage.'
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/cloud-platform-components/resources/prometheusrule-alerts/Custom-Alerts.md#memory-high
+    - alert: Memory-Critical
+      expr: (node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) / (node_memory_MemTotal_bytes) * 100 > 95
+      for: 5m
+      labels:
+        severity: critical
+      annotations:
+        message: '{{ $labels.instance }} has high memory usage for than 5 minutes. Instance {{ $labels.instance }} memory has critically high usage.'
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/cloud-platform-components/resources/prometheusrule-alerts/Custom-Alerts.md#memory-critical 
+    - alert: External-DNSDown
+      expr: kube_deployment_status_replicas_available{deployment="external-dns"} == 0
+      for: 5m
+      labels:
+        severity: warning
+      annotations: 
+        message: external-dns container has not been running in the namespace 'kube-system' for 5 minutes.
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/cloud-platform-components/resources/prometheusrule-alerts/Custom-Alerts.md#kubednsdown
+    - alert: NginxIngressPodDown
+      expr: kube_deployment_status_replicas_available{deployment="nginx-ingress-controller"} <6
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        message: '{{ $labels.pod}} pod unavailable in the {{ $labels.namespace}} namespace. 1 or more nginx-ingress pods have been unavailable for 5 minutes'
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/cloud-platform-components/resources/prometheusrule-alerts/Custom-Alerts.md#nginxingresspoddown
+    - alert: NginxIngressDown
+      expr: kube_deployment_status_replicas_available{deployment="nginx-ingress-controller"} == 0
+      for: 5m
+      labels:
+        severity: critical
+      annotations:
+        descrition: '{{ $labels.pod}} pod unavailable in the {{ $labels.namespace}} namespace. nginx-ingress has been down for 5 minutes'
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/cloud-platform-components/resources/prometheusrule-alerts/Custom-Alerts.md#nginxingressdown
+    - alert: NginxAcmeIngressPodDown
+      expr: kube_deployment_status_replicas_available{deployment="nginx-ingress-acme-controller"} <6
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        message: '{{ $labels.pod}} pod unavailable in the {{ $labels.namespace}} namespace. 1 or more nginx-acme-ingress pods have been unavailable for 5 minutes'
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/cloud-platform-components/resources/prometheusrule-alerts/Custom-Alerts.md#nginxingresspoddown
+    - alert: NginxAcmeIngressDown
+      expr: kube_deployment_status_replicas_available{deployment="nginx-ingress-acme-controller"} == 0
+      for: 5m
+      labels:
+        severity: critical
+      annotations:
+        descrition: '{{ $labels.pod}} pod unavailable in the {{ $labels.namespace}} namespace. nginx-acme-ingress has been down for 5 minutes'
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/cloud-platform-components/resources/prometheusrule-alerts/Custom-Alerts.md#nginxingressdown
+    - alert: RootVolUtilisation-High
+      expr: (node_filesystem_size_bytes {mountpoint="/"} - node_filesystem_avail_bytes {mountpoint="/"} ) / (node_filesystem_size_bytes {mountpoint="/"} ) * 100 >85
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        message: '{{ $labels.instance }} has exceeded the threshold of root volume utilisation with a value of {{ $value }}. Instance {{ $labels.instance }} root volume utilisation usage is high'
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/cloud-platform-components/resources/prometheusrule-alerts/Custom-Alerts.md#root-volume-utilisation---high
+    - alert: RootVolUtilisation-Critical
+      expr: (node_filesystem_size_bytes {mountpoint="/"} - node_filesystem_avail_bytes {mountpoint="/"} ) / (node_filesystem_size_bytes {mountpoint="/"} ) * 100 >95
+      for: 1m
+      labels:
+        severity: critical
+      annotations:
+        message: '{{ $labels.instance }} has exceeded the threshold of root volume utilisation with a value of {{ $value }}. Instance {{ $labels.instance }} root volume utilisation usage is critically high'
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/cloud-platform-components/resources/prometheusrule-alerts/Custom-Alerts.md#root-volume-utilisation---critical
+    - alert: LoadBalancer5XXCountHigh
+      expr: |-
+        count by (service) (increase(http_requests_total{code=~"5.*"}[15m]))  >=  10
+      for: 15m
+      labels:
+        severity: warning
+      annotations:
+        message: HTTPCode_Target_5XX_Count high for `{{$labels.service}}. HTTPCode_Target_5XX_Count high'
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/cloud-platform-components/resources/prometheusrule-alerts/Custom-Alerts.md

--- a/terraform/cloud-platform-components/templates/prometheus-operator.yaml.tpl
+++ b/terraform/cloud-platform-components/templates/prometheus-operator.yaml.tpl
@@ -23,14 +23,14 @@ defaultRules:
   rules:
     alertmanager: true
     etcd: true
-    general: true
+    general: false
     k8s: true
     kubeApiserver: true
     kubePrometheusNodeAlerting: true
     kubePrometheusNodeRecording: true
     kubeScheduler: true
     kubernetesAbsent: true
-    kubernetesApps: true
+    kubernetesApps: false
     kubernetesResources: true
     kubernetesStorage: true
     kubernetesSystem: true


### PR DESCRIPTION
WHAT
Add custom alerts to Prometheus and apply rules as part of the prometheus-operator install

WHY
The custom rules monitor CP team namespaces as well as system namespaces and are based on the business unit-cloud-platform annotation. The auto apply of these rules also mean they will not be missed if there is a need to reinstall prometheus-operator. Associated runbbook does have also been updated with runbook_url added to all alerts. 