### PR TITLE
Set Duplicate alert to Null Receiver

### DIFF
--- a/terraform/cloud-platform-components/resources/prometheusrule-alerts/application-alerts.yaml
+++ b/terraform/cloud-platform-components/resources/prometheusrule-alerts/application-alerts.yaml
@@ -9,7 +9,7 @@ spec:
   groups:
   - name: kubernetes-apps
     rules:
-    - alert: KubeQuotaExceeded
+    - alert: KubeQuota-Exceeded
       annotations:
         message: Namespace {{ $labels.namespace }} is using {{ printf "%0.0f" $value
           }}% of its {{ $labels.resource }} quota.

--- a/terraform/cloud-platform-components/templates/prometheus-operator.yaml.tpl
+++ b/terraform/cloud-platform-components/templates/prometheus-operator.yaml.tpl
@@ -95,6 +95,9 @@ alertmanager:
       receiver: 'null'
       routes:
       - match:
+          alertname: KubeQuotaExceeded
+        receiver: 'null'
+      - match:
           alertname: CPUThrottlingHigh
         receiver: 'null'
       - match:


### PR DESCRIPTION
There is a duplicate alert in one of the default rules set which has been set to null receiver as there is a requirement for all the other rules in that set. The alert in custom alerts has had its name changes so we still get the alert