### PR TITLE
Shorter hostnames for live ingresses

### DIFF
--- a/terraform/cloud-platform-components/cert-manager.tf
+++ b/terraform/cloud-platform-components/cert-manager.tf
@@ -21,7 +21,12 @@ resource "aws_iam_role" "cert_manager" {
 data "aws_iam_policy_document" "cert_manager" {
   statement {
     actions   = ["route53:ChangeResourceRecordSets"]
-    resources = ["arn:aws:route53:::hostedzone/${data.terraform_remote_state.cluster.hosted_zone_id}"]
+
+    resources = ["${compact(list(
+      "arn:aws:route53:::hostedzone/${data.terraform_remote_state.cluster.hosted_zone_id}",
+      "${terraform.workspace == local.live_workspace ? format("%s/%s", "arn:aws:route53:::hostedzone", data.terraform_remote_state.global.cp_zone_id) : ""}",
+    ))}"]
+
   }
 
   statement {

--- a/terraform/cloud-platform-components/cert-manager.tf
+++ b/terraform/cloud-platform-components/cert-manager.tf
@@ -20,13 +20,12 @@ resource "aws_iam_role" "cert_manager" {
 
 data "aws_iam_policy_document" "cert_manager" {
   statement {
-    actions   = ["route53:ChangeResourceRecordSets"]
+    actions = ["route53:ChangeResourceRecordSets"]
 
     resources = ["${compact(list(
       "arn:aws:route53:::hostedzone/${data.terraform_remote_state.cluster.hosted_zone_id}",
       "${terraform.workspace == local.live_workspace ? format("%s/%s", "arn:aws:route53:::hostedzone", data.terraform_remote_state.global.cp_zone_id) : ""}",
     ))}"]
-
   }
 
   statement {

--- a/terraform/cloud-platform-components/external-dns.tf
+++ b/terraform/cloud-platform-components/external-dns.tf
@@ -16,11 +16,12 @@ resource "aws_iam_role" "external_dns" {
 
 data "aws_iam_policy_document" "external_dns" {
   statement {
-    actions   = ["route53:ChangeResourceRecordSets"]
+    actions = ["route53:ChangeResourceRecordSets"]
+
     resources = [
       "arn:aws:route53:::hostedzone/${data.terraform_remote_state.cluster.hosted_zone_id}",
-      "${terraform.workspace == local.live_workspace ? format("%s/%s", "arn:aws:route53:::hostedzone", data.terraform_remote_state.global.cp_zone_id) : "arn:aws:route53:::hostedzone/${data.terraform_remote_state.cluster.hosted_zone_id}"}"
-      ]
+      "${terraform.workspace == local.live_workspace ? format("%s/%s", "arn:aws:route53:::hostedzone", data.terraform_remote_state.global.cp_zone_id) : "arn:aws:route53:::hostedzone/${data.terraform_remote_state.cluster.hosted_zone_id}"}",
+    ]
   }
 
   statement {

--- a/terraform/cloud-platform-components/external-dns.tf
+++ b/terraform/cloud-platform-components/external-dns.tf
@@ -17,7 +17,10 @@ resource "aws_iam_role" "external_dns" {
 data "aws_iam_policy_document" "external_dns" {
   statement {
     actions   = ["route53:ChangeResourceRecordSets"]
-    resources = ["arn:aws:route53:::hostedzone/${data.terraform_remote_state.cluster.hosted_zone_id}"]
+    resources = [
+      "arn:aws:route53:::hostedzone/${data.terraform_remote_state.cluster.hosted_zone_id}", 
+      "arn:aws:route53:::hostedzone/${data.terraform_remote_state.global.justice_gov_uk.zone_id}"
+      ]
   }
 
   statement {

--- a/terraform/cloud-platform-components/external-dns.tf
+++ b/terraform/cloud-platform-components/external-dns.tf
@@ -18,10 +18,10 @@ data "aws_iam_policy_document" "external_dns" {
   statement {
     actions = ["route53:ChangeResourceRecordSets"]
 
-    resources = [
+    resources = ["${compact(list(
       "arn:aws:route53:::hostedzone/${data.terraform_remote_state.cluster.hosted_zone_id}",
-      "${terraform.workspace == local.live_workspace ? format("%s/%s", "arn:aws:route53:::hostedzone", data.terraform_remote_state.global.cp_zone_id) : "arn:aws:route53:::hostedzone/${data.terraform_remote_state.cluster.hosted_zone_id}"}",
-    ]
+      "${terraform.workspace == local.live_workspace ? format("%s/%s", "arn:aws:route53:::hostedzone", data.terraform_remote_state.global.cp_zone_id) : ""}",
+    ))}"]
   }
 
   statement {

--- a/terraform/cloud-platform-components/external-dns.tf
+++ b/terraform/cloud-platform-components/external-dns.tf
@@ -18,8 +18,8 @@ data "aws_iam_policy_document" "external_dns" {
   statement {
     actions   = ["route53:ChangeResourceRecordSets"]
     resources = [
-      "arn:aws:route53:::hostedzone/${data.terraform_remote_state.cluster.hosted_zone_id}", 
-      "arn:aws:route53:::hostedzone/${data.terraform_remote_state.global.justice_gov_uk.zone_id}"
+      "arn:aws:route53:::hostedzone/${data.terraform_remote_state.cluster.hosted_zone_id}",
+      "${terraform.workspace == local.live_workspace ? format("%s/%s", "arn:aws:route53:::hostedzone", data.terraform_remote_state.global.cp_zone_id) : "arn:aws:route53:::hostedzone/${data.terraform_remote_state.cluster.hosted_zone_id}"}"
       ]
   }
 
@@ -57,6 +57,7 @@ aws:
   zoneType: public
 domainFilters:
   - "${data.terraform_remote_state.cluster.cluster_domain_name}"
+  ${terraform.workspace == local.live_workspace ? format("- %s", local.live_domain) : ""}
 rbac:
   create: true
   apiVersion: v1

--- a/terraform/cloud-platform-components/fluentd.tf
+++ b/terraform/cloud-platform-components/fluentd.tf
@@ -5,12 +5,12 @@ resource "helm_release" "fluentd_es" {
 
   set {
     name  = "fluent_elasticsearch_host"
-    value = "search-cloud-platform-live-dibidbfud3uww3lpxnhj2jdws4.eu-west-2.es.amazonaws.com"
+    value = "${terraform.workspace == local.live_workspace ? "search-cloud-platform-live-dibidbfud3uww3lpxnhj2jdws4.eu-west-2.es.amazonaws.com" : "search-test-yuq2c7ziybjvpmr2tllkghh6va.eu-west-2.es.amazonaws.com"}"
   }
 
   set {
     name  = "fluent_elasticsearch_audit_host"
-    value = "search-cloud-platform-audit-dq5bdnjokj4yt7qozshmifug6e.eu-west-2.es.amazonaws.com"
+    value = "${terraform.workspace == local.live_workspace ? "search-cloud-platform-audit-dq5bdnjokj4yt7qozshmifug6e.eu-west-2.es.amazonaws.com" : "search-test-yuq2c7ziybjvpmr2tllkghh6va.eu-west-2.es.amazonaws.com"}"
   }
 
   set {

--- a/terraform/cloud-platform-components/fluentd.tf
+++ b/terraform/cloud-platform-components/fluentd.tf
@@ -5,12 +5,12 @@ resource "helm_release" "fluentd_es" {
 
   set {
     name  = "fluent_elasticsearch_host"
-    value = "${terraform.workspace == local.live_workspace ? "search-cloud-platform-live-dibidbfud3uww3lpxnhj2jdws4.eu-west-2.es.amazonaws.com" : "search-test-yuq2c7ziybjvpmr2tllkghh6va.eu-west-2.es.amazonaws.com"}"
+    value = "${replace(terraform.workspace, "live", "") != terraform.workspace ? "search-cloud-platform-live-dibidbfud3uww3lpxnhj2jdws4.eu-west-2.es.amazonaws.com" : "search-test-yuq2c7ziybjvpmr2tllkghh6va.eu-west-2.es.amazonaws.com"}"
   }
 
   set {
     name  = "fluent_elasticsearch_audit_host"
-    value = "${terraform.workspace == local.live_workspace ? "search-cloud-platform-audit-dq5bdnjokj4yt7qozshmifug6e.eu-west-2.es.amazonaws.com" : "search-test-yuq2c7ziybjvpmr2tllkghh6va.eu-west-2.es.amazonaws.com"}"
+    value = "${replace(terraform.workspace, "live", "") != terraform.workspace ? "search-cloud-platform-audit-dq5bdnjokj4yt7qozshmifug6e.eu-west-2.es.amazonaws.com" : "search-test-yuq2c7ziybjvpmr2tllkghh6va.eu-west-2.es.amazonaws.com"}"
   }
 
   set {

--- a/terraform/cloud-platform-components/kuberos.tf
+++ b/terraform/cloud-platform-components/kuberos.tf
@@ -6,12 +6,12 @@ resource "helm_release" "kuberos" {
 
   set {
     name  = "ingress.host"
-    value = "login.apps.${data.terraform_remote_state.cluster.cluster_domain_name}"
+    value = "${terraform.workspace == local.live_workspace ? format("%s.%s", "login", local.live_domain) : format("%s.%s", "login.apps", data.terraform_remote_state.cluster.cluster_domain_name)}"
   }
 
   set {
     name  = "ingress.tls.secretName.host"
-    value = "login.apps.${data.terraform_remote_state.cluster.cluster_domain_name}"
+    value = "${terraform.workspace == local.live_workspace ? format("%s.%s", "login", local.live_domain) : format("%s.%s", "login.apps", data.terraform_remote_state.cluster.cluster_domain_name)}"
   }
 
   set {

--- a/terraform/cloud-platform-components/main.tf
+++ b/terraform/cloud-platform-components/main.tf
@@ -30,6 +30,17 @@ data "terraform_remote_state" "cluster" {
   }
 }
 
+data "terraform_remote_state" "global" {
+  backend = "s3"
+
+  config {
+    bucket  = "cloud-platform-terraform-state"
+    region  = "eu-west-1"
+    key     = "global-resources/terraform.tfstate"
+    profile = "moj-cp"
+  }
+}
+
 // This is the kubernetes role that node hosts are assigned.
 data "aws_iam_role" "nodes" {
   name = "nodes.${data.terraform_remote_state.cluster.cluster_domain_name}"
@@ -51,6 +62,6 @@ locals {
     "checklegalaid.service.gov.uk.",
   ]
 
-  live_workspace = "test-1"
+  live_workspace = "live-1"
   live_domain    = "cloud-platform.service.justice.gov.uk"
 }

--- a/terraform/cloud-platform-components/main.tf
+++ b/terraform/cloud-platform-components/main.tf
@@ -50,4 +50,7 @@ locals {
     "find-legal-advice.justice.gov.uk.",
     "checklegalaid.service.gov.uk.",
   ]
+
+  live_workspace = "test-1"
+  live_domain    = "cloud-platform.service.justice.gov.uk"
 }

--- a/terraform/cloud-platform-components/main.tf
+++ b/terraform/cloud-platform-components/main.tf
@@ -60,6 +60,7 @@ locals {
   dsd_zones = [
     "find-legal-advice.justice.gov.uk.",
     "checklegalaid.service.gov.uk.",
+    "helpwithchildarrangements.service.justice.gov.uk.",
   ]
 
   live_workspace = "live-1"

--- a/terraform/cloud-platform-components/nginx-ingress-acme.tf
+++ b/terraform/cloud-platform-components/nginx-ingress-acme.tf
@@ -59,7 +59,7 @@ data "template_file" "nginx_ingress_default_certificate" {
 
   vars {
     common_name = "*.apps.${data.terraform_remote_state.cluster.cluster_domain_name}"
-    alt_name    = "${terraform.workspace == local.live_workspace ? format("- *.%s", local.live_domain) : ""}"
+    alt_name    = "${terraform.workspace == local.live_workspace ? format("- '*.%s'", local.live_domain) : ""}"
   }
 }
 

--- a/terraform/cloud-platform-components/nginx-ingress-acme.tf
+++ b/terraform/cloud-platform-components/nginx-ingress-acme.tf
@@ -30,7 +30,7 @@ controller:
 
   service:
     annotations:
-      external-dns.alpha.kubernetes.io/hostname: "*.apps.${data.terraform_remote_state.cluster.cluster_domain_name},apps.${data.terraform_remote_state.cluster.cluster_domain_name}"
+      external-dns.alpha.kubernetes.io/hostname: "${terraform.workspace == local.live_workspace ? format("*.%s, *.apps.%s, apps.%s", local.live_domain, data.terraform_remote_state.cluster.cluster_domain_name, data.terraform_remote_state.cluster.cluster_domain_name) : format("*.apps.%s, apps.%s", data.terraform_remote_state.cluster.cluster_domain_name, data.terraform_remote_state.cluster.cluster_domain_name)}"
       service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
 
     externalTrafficPolicy: "Local"
@@ -59,7 +59,7 @@ data "template_file" "nginx_ingress_default_certificate" {
 
   vars {
     common_name = "*.apps.${data.terraform_remote_state.cluster.cluster_domain_name}"
-    alt_name    = "${terraform.workspace == local.live_workspace ? format("- '*.%s'", local.live_domain) : ""}"
+    alt_name    = "${terraform.workspace == local.live_workspace ? format("- *.%s", local.live_domain) : ""}"
   }
 }
 

--- a/terraform/cloud-platform-components/nginx-ingress-acme.tf
+++ b/terraform/cloud-platform-components/nginx-ingress-acme.tf
@@ -59,6 +59,7 @@ data "template_file" "nginx_ingress_default_certificate" {
 
   vars {
     common_name = "*.apps.${data.terraform_remote_state.cluster.cluster_domain_name}"
+    alt_name    = "${terraform.workspace == local.live_workspace ? format("- '*.%s'", local.live_domain) : ""}"
   }
 }
 

--- a/terraform/cloud-platform-components/nginx-ingress-acme.tf
+++ b/terraform/cloud-platform-components/nginx-ingress-acme.tf
@@ -30,7 +30,7 @@ controller:
 
   service:
     annotations:
-      external-dns.alpha.kubernetes.io/hostname: "${terraform.workspace == local.live_workspace ? format("*.%s, *.apps.%s, apps.%s", local.live_domain, data.terraform_remote_state.cluster.cluster_domain_name, data.terraform_remote_state.cluster.cluster_domain_name) : format("*.apps.%s, apps.%s", data.terraform_remote_state.cluster.cluster_domain_name, data.terraform_remote_state.cluster.cluster_domain_name)}"
+      external-dns.alpha.kubernetes.io/hostname: "*.apps.${data.terraform_remote_state.cluster.cluster_domain_name},apps.${data.terraform_remote_state.cluster.cluster_domain_name}${terraform.workspace == local.live_workspace ? format(",*.%s", local.live_domain) : ""}"
       service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
 
     externalTrafficPolicy: "Local"

--- a/terraform/cloud-platform-components/prometheus.tf
+++ b/terraform/cloud-platform-components/prometheus.tf
@@ -31,7 +31,7 @@ data "template_file" "prometheus_operator" {
 
   vars {
     alertmanager_ingress                     = "https://alertmanager.apps.${ data.terraform_remote_state.cluster.cluster_domain_name }"
-    grafana_ingress                          = "grafana.apps.${ data.terraform_remote_state.cluster.cluster_domain_name }"
+    grafana_ingress                          = "${terraform.workspace == "live-1" ? "grafana.cloud-platform.service.justice.gov.uk" : format("%s.%s","grafana.apps",data.terraform_remote_state.cluster.cluster_domain_name) }"
     grafana_root                             = "https://grafana.apps.${ data.terraform_remote_state.cluster.cluster_domain_name }"
     pagerduty_config                         = "${ var.pagerduty_config }"
     slack_config                             = "${ var.slack_config }"
@@ -88,7 +88,7 @@ data "template_file" "prometheus_proxy" {
 
   vars {
     upstream      = "http://prometheus-operator-prometheus:9090"
-    hostname      = "prometheus.apps.${data.terraform_remote_state.cluster.cluster_domain_name}"
+    hostname      = "${terraform.workspace == "live-1" ? "prometheus.cloud-platform.service.justice.gov.uk" : format("%s.%s","prometheus.apps",data.terraform_remote_state.cluster.cluster_domain_name)}"
     exclude_paths = "^/-/healthy$"
     issuer_url    = "${data.terraform_remote_state.cluster.oidc_issuer_url}"
     client_id     = "${data.terraform_remote_state.cluster.oidc_components_client_id}"
@@ -122,7 +122,7 @@ data "template_file" "alertmanager_proxy" {
 
   vars {
     upstream      = "http://prometheus-operator-alertmanager:9093"
-    hostname      = "alertmanager.apps.${data.terraform_remote_state.cluster.cluster_domain_name}"
+    hostname      = "${terraform.workspace == "live-1" ? "alertmanager.cloud-platform.service.justice.gov.uk" : format("%s.%s","alertmanager.apps",data.terraform_remote_state.cluster.cluster_domain_name)}"
     exclude_paths = "^/-/healthy$"
     issuer_url    = "${data.terraform_remote_state.cluster.oidc_issuer_url}"
     client_id     = "${data.terraform_remote_state.cluster.oidc_components_client_id}"

--- a/terraform/cloud-platform-components/prometheus.tf
+++ b/terraform/cloud-platform-components/prometheus.tf
@@ -31,7 +31,7 @@ data "template_file" "prometheus_operator" {
 
   vars {
     alertmanager_ingress                     = "https://alertmanager.apps.${ data.terraform_remote_state.cluster.cluster_domain_name }"
-    grafana_ingress                          = "${terraform.workspace == "live-1" ? "grafana.cloud-platform.service.justice.gov.uk" : format("%s.%s","grafana.apps",data.terraform_remote_state.cluster.cluster_domain_name) }"
+    grafana_ingress                          = "${terraform.workspace == "live-1" ? list("grafana.cloud-platform.service.justice.gov.uk", format("%s.%s","grafana.apps",data.terraform_remote_state.cluster.cluster_domain_name)) : format("%s.%s","grafana.apps",data.terraform_remote_state.cluster.cluster_domain_name) }"
     grafana_root                             = "https://grafana.apps.${ data.terraform_remote_state.cluster.cluster_domain_name }"
     pagerduty_config                         = "${ var.pagerduty_config }"
     slack_config                             = "${ var.slack_config }"
@@ -88,7 +88,6 @@ data "template_file" "prometheus_proxy" {
 
   vars {
     upstream      = "http://prometheus-operator-prometheus:9090"
-    hostname      = "${terraform.workspace == "live-1" ? "prometheus.cloud-platform.service.justice.gov.uk" : format("%s.%s","prometheus.apps",data.terraform_remote_state.cluster.cluster_domain_name)}"
     exclude_paths = "^/-/healthy$"
     issuer_url    = "${data.terraform_remote_state.cluster.oidc_issuer_url}"
     client_id     = "${data.terraform_remote_state.cluster.oidc_components_client_id}"
@@ -107,6 +106,11 @@ resource "helm_release" "prometheus_proxy" {
     "${data.template_file.prometheus_proxy.rendered}",
   ]
 
+  set {
+    name  = "hostnames"
+    value = "${terraform.workspace == "live-1" ? format("{%s,%s.%s}","prometheus.cloud-platform.service.justice.gov.uk","prometheus.apps", data.terraform_remote_state.cluster.cluster_domain_name) : format("%s.%s", "prometheus.apps", data.terraform_remote_state.cluster.cluster_domain_name)}"
+  }
+
   depends_on = [
     "null_resource.deploy",
     "random_id.session_secret",
@@ -122,7 +126,6 @@ data "template_file" "alertmanager_proxy" {
 
   vars {
     upstream      = "http://prometheus-operator-alertmanager:9093"
-    hostname      = "${terraform.workspace == "live-1" ? "alertmanager.cloud-platform.service.justice.gov.uk" : format("%s.%s","alertmanager.apps",data.terraform_remote_state.cluster.cluster_domain_name)}"
     exclude_paths = "^/-/healthy$"
     issuer_url    = "${data.terraform_remote_state.cluster.oidc_issuer_url}"
     client_id     = "${data.terraform_remote_state.cluster.oidc_components_client_id}"
@@ -140,6 +143,8 @@ resource "helm_release" "alertmanager_proxy" {
   values = [
     "${data.template_file.alertmanager_proxy.rendered}",
   ]
+
+
 
   depends_on = [
     "null_resource.deploy",

--- a/terraform/cloud-platform-components/prometheus.tf
+++ b/terraform/cloud-platform-components/prometheus.tf
@@ -30,9 +30,9 @@ data "template_file" "prometheus_operator" {
   template = "${file("${ path.module }/templates/prometheus-operator.yaml.tpl")}"
 
   vars {
-    alertmanager_ingress                     = "https://alertmanager.apps.${ data.terraform_remote_state.cluster.cluster_domain_name }"
-    grafana_ingress                          = "${terraform.workspace == "live-1" ? list("grafana.cloud-platform.service.justice.gov.uk", format("%s.%s","grafana.apps",data.terraform_remote_state.cluster.cluster_domain_name)) : format("%s.%s","grafana.apps",data.terraform_remote_state.cluster.cluster_domain_name) }"
-    grafana_root                             = "https://grafana.apps.${ data.terraform_remote_state.cluster.cluster_domain_name }"
+    alertmanager_ingress                     = "${terraform.workspace == local.live_workspace ? format("%s.%s", "https://alertmanager", local.live_domain) : format("%s.%s", "https://alertmanager.apps", data.terraform_remote_state.cluster.cluster_domain_name)}"
+    grafana_ingress                          = "${terraform.workspace == local.live_workspace ? format("%s.%s", "grafana", local.live_domain) : format("%s.%s", "grafana.apps", data.terraform_remote_state.cluster.cluster_domain_name)}"
+    grafana_root                             = "${terraform.workspace == local.live_workspace ? format("%s.%s", "https://grafana", local.live_domain) : format("%s.%s", "https://grafana.apps", data.terraform_remote_state.cluster.cluster_domain_name)}"
     pagerduty_config                         = "${ var.pagerduty_config }"
     slack_config                             = "${ var.slack_config }"
     slack_config_apply-for-legal-aid-prod    = "${var.slack_config_apply-for-legal-aid-prod}"
@@ -40,7 +40,7 @@ data "template_file" "prometheus_operator" {
     slack_config_apply-for-legal-aid-uat     = "${var.slack_config_apply-for-legal-aid-uat}"
     slack_config_laa-cla-fala                = "${var.slack_config_laa-cla-fala}"
     slack_config_prisoner-money              = "${var.slack_config_prisoner-money}"
-    prometheus_ingress                       = "https://prometheus.apps.${ data.terraform_remote_state.cluster.cluster_domain_name }"
+    prometheus_ingress                       = "${terraform.workspace == local.live_workspace ? format("%s.%s", "https://prometheus", local.live_domain) : format("%s.%s", "https://prometheus.apps", data.terraform_remote_state.cluster.cluster_domain_name)}"
     random_username                          = "${ random_id.username.hex }"
     random_password                          = "${ random_id.password.hex }"
   }
@@ -88,6 +88,7 @@ data "template_file" "prometheus_proxy" {
 
   vars {
     upstream      = "http://prometheus-operator-prometheus:9090"
+    hostname      = "${terraform.workspace == local.live_workspace ? format("%s.%s", "prometheus", local.live_domain) : format("%s.%s", "prometheus.apps", data.terraform_remote_state.cluster.cluster_domain_name)}"
     exclude_paths = "^/-/healthy$"
     issuer_url    = "${data.terraform_remote_state.cluster.oidc_issuer_url}"
     client_id     = "${data.terraform_remote_state.cluster.oidc_components_client_id}"
@@ -106,11 +107,6 @@ resource "helm_release" "prometheus_proxy" {
     "${data.template_file.prometheus_proxy.rendered}",
   ]
 
-  set {
-    name  = "hostnames"
-    value = "${terraform.workspace == "live-1" ? format("{%s,%s.%s}","prometheus.cloud-platform.service.justice.gov.uk","prometheus.apps", data.terraform_remote_state.cluster.cluster_domain_name) : format("%s.%s", "prometheus.apps", data.terraform_remote_state.cluster.cluster_domain_name)}"
-  }
-
   depends_on = [
     "null_resource.deploy",
     "random_id.session_secret",
@@ -126,6 +122,7 @@ data "template_file" "alertmanager_proxy" {
 
   vars {
     upstream      = "http://prometheus-operator-alertmanager:9093"
+    hostname      = "${terraform.workspace == local.live_workspace ? format("%s.%s", "prometheus", local.live_domain) : format("%s.%s", "prometheus.apps", data.terraform_remote_state.cluster.cluster_domain_name)}"
     exclude_paths = "^/-/healthy$"
     issuer_url    = "${data.terraform_remote_state.cluster.oidc_issuer_url}"
     client_id     = "${data.terraform_remote_state.cluster.oidc_components_client_id}"
@@ -143,8 +140,6 @@ resource "helm_release" "alertmanager_proxy" {
   values = [
     "${data.template_file.alertmanager_proxy.rendered}",
   ]
-
-
 
   depends_on = [
     "null_resource.deploy",

--- a/terraform/cloud-platform-components/prometheus.tf
+++ b/terraform/cloud-platform-components/prometheus.tf
@@ -122,7 +122,7 @@ data "template_file" "alertmanager_proxy" {
 
   vars {
     upstream      = "http://prometheus-operator-alertmanager:9093"
-    hostname      = "${terraform.workspace == local.live_workspace ? format("%s.%s", "prometheus", local.live_domain) : format("%s.%s", "prometheus.apps", data.terraform_remote_state.cluster.cluster_domain_name)}"
+    hostname      = "${terraform.workspace == local.live_workspace ? format("%s.%s", "alertmanager", local.live_domain) : format("%s.%s", "alertmanager.apps", data.terraform_remote_state.cluster.cluster_domain_name)}"
     exclude_paths = "^/-/healthy$"
     issuer_url    = "${data.terraform_remote_state.cluster.oidc_issuer_url}"
     client_id     = "${data.terraform_remote_state.cluster.oidc_components_client_id}"

--- a/terraform/cloud-platform-components/templates/nginx-ingress/default-certificate.yaml
+++ b/terraform/cloud-platform-components/templates/nginx-ingress/default-certificate.yaml
@@ -16,3 +16,6 @@ spec:
       domains:
       - '${common_name}'
       ${alt_name}
+  dnsNames:
+    - '${common_name}'
+    ${alt_name}

--- a/terraform/cloud-platform-components/templates/nginx-ingress/default-certificate.yaml
+++ b/terraform/cloud-platform-components/templates/nginx-ingress/default-certificate.yaml
@@ -15,3 +15,4 @@ spec:
         provider: route53-cloud-platform
       domains:
       - '${common_name}'
+      ${alt_name}

--- a/terraform/cloud-platform-components/templates/oauth2-proxy.yaml.tpl
+++ b/terraform/cloud-platform-components/templates/oauth2-proxy.yaml.tpl
@@ -29,10 +29,10 @@ ingress:
   enabled: true
   path: /
   hosts:
-    {{- range .Values.hostnames }} 
+    - "${hostname}" 
   tls:
     - hosts:
-      {{- range .Values.hostnames }}
+      - "${hostname}"
 
   # annotations:
   #   kubernetes.io/ingress.class: nginx
@@ -42,10 +42,8 @@ ingress:
   #   kubernetes.io/ingress.class: nginx
   #   kubernetes.io/tls-acme: "true"
   tls:
-    # Secrets must be manually created in the namespace.
-    - secretName: oauth2-tls
-      hosts:
-        {{- range .Values.hostnames }}
+    - hosts:
+      - "${hostname}"
 
 resources: {}
   # limits:

--- a/terraform/cloud-platform-components/templates/oauth2-proxy.yaml.tpl
+++ b/terraform/cloud-platform-components/templates/oauth2-proxy.yaml.tpl
@@ -29,10 +29,10 @@ ingress:
   enabled: true
   path: /
   hosts:
-    - "${hostname}"
+    {{- range .Values.hostnames }} 
   tls:
     - hosts:
-      - "${hostname}"
+      {{- range .Values.hostnames }}
 
   # annotations:
   #   kubernetes.io/ingress.class: nginx
@@ -45,7 +45,7 @@ ingress:
     # Secrets must be manually created in the namespace.
     - secretName: oauth2-tls
       hosts:
-        - "${hostname}"
+        {{- range .Values.hostnames }}
 
 resources: {}
   # limits:

--- a/terraform/cloud-platform-components/templates/prometheus-operator.yaml.tpl
+++ b/terraform/cloud-platform-components/templates/prometheus-operator.yaml.tpl
@@ -515,8 +515,8 @@ grafana:
     - "${ grafana_ingress }"
 
     tls:
-      hosts:
-      - "${ grafana_ingress }"
+      - hosts:
+        - "${ grafana_ingress }"
 
   env:
     GF_SERVER_ROOT_URL: "${ grafana_root }"

--- a/terraform/cloud-platform-components/templates/prometheus-operator.yaml.tpl
+++ b/terraform/cloud-platform-components/templates/prometheus-operator.yaml.tpl
@@ -264,7 +264,7 @@ alertmanager:
         {{ range .Alerts }}
             *Alert:* {{ .Annotations.message}}
             *Details:*
-            {{ range .Labels.SortedPairs }} • *{{ .Name }}:* `{{ .Value }}`
+            {{ range .Labels.SortedPairs }} - *{{ .Name }}:* `{{ .Value }}`
             {{ end }}
             *-----*
           {{ end }}
@@ -356,7 +356,7 @@ alertmanager:
   ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#alertmanagerspec
   ##
   alertmanagerSpec:
-    ## Standard object’s metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#metadata
+    ## Standard object's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#metadata
     ## Metadata Labels and Annotations gets propagated to the Alertmanager pods.
     ##
     podMetadata: {}
@@ -1081,7 +1081,7 @@ prometheus:
     ##
     routePrefix: /
 
-    ## Standard object’s metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#metadata
+    ## Standard object's metadata. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#metadata
     ## Metadata Labels and Annotations gets propagated to the prometheus pods.
     ##
     podMetadata: {}

--- a/terraform/cloud-platform-components/templates/prometheus-operator.yaml.tpl
+++ b/terraform/cloud-platform-components/templates/prometheus-operator.yaml.tpl
@@ -514,11 +514,7 @@ grafana:
     hosts:
     - "${ grafana_ingress }"
 
-    ## TLS configuration for prometheus Ingress
-    ## Secret must be manually created in the namespace
-    ##
     tls:
-    - secretName: prometheus-general-tls
       hosts:
       - "${ grafana_ingress }"
 

--- a/terraform/cloud-platform/main.tf
+++ b/terraform/cloud-platform/main.tf
@@ -131,7 +131,9 @@ resource "auth0_client" "components" {
     "https://prometheus.apps.${local.cluster_base_domain_name}/redirect_uri",
     "https://alertmanager.apps.${local.cluster_base_domain_name}/redirect_uri",
     "https://concourse.apps.${local.cluster_base_domain_name}/sky/issuer/callback",
+    "${terraform.workspace == local.live_workspace ? format("https://concourse.%s/sky/issuer/callback", local.live_domain) : ""}",
     "https://kibana.apps.${local.cluster_base_domain_name}/oauth2/callback",
+    "${terraform.workspace == local.live_workspace ? format("https://kibana.%s/oauth2/callback", local.live_domain) : ""}",
     "https://grafana.apps.${local.cluster_base_domain_name}/login/generic_oauth",
     "${terraform.workspace == local.live_workspace ? format("https://grafana.%s/login/generic_oauth", local.live_domain) : ""}",
   ]

--- a/terraform/cloud-platform/main.tf
+++ b/terraform/cloud-platform/main.tf
@@ -105,7 +105,10 @@ resource "auth0_client" "kubernetes" {
   description = "Cloud Platform kubernetes"
   app_type    = "regular_web"
 
-  callbacks = ["https://login.apps.${local.cluster_base_domain_name}/ui"]
+  callbacks = [
+    "https://login.apps.${local.cluster_base_domain_name}/ui",
+    "${terraform.workspace == local.live_workspace ? format("https://login.%s/ui", local.live_domain) : ""}",
+  ]
 
   custom_login_page_on = true
   is_first_party       = true

--- a/terraform/cloud-platform/main.tf
+++ b/terraform/cloud-platform/main.tf
@@ -42,6 +42,9 @@ locals {
   cluster_base_domain_name = "${local.cluster_name}.cloud-platform.service.justice.gov.uk"
   auth0_tenant_domain      = "justice-cloud-platform.eu.auth0.com"
   oidc_issuer_url          = "https://${local.auth0_tenant_domain}/"
+
+  live_workspace = "live-1"
+  live_domain    = "cloud-platform.service.justice.gov.uk"
 }
 
 # Modules
@@ -122,12 +125,15 @@ resource "auth0_client" "components" {
 
   callbacks = [
     "https://prometheus.apps.${local.cluster_base_domain_name}/oauth2/callback",
+    "${terraform.workspace == local.live_workspace ? format("https://prometheus.%s/oauth2/callback", local.live_domain) : ""}",
     "https://alertmanager.apps.${local.cluster_base_domain_name}/oauth2/callback",
+    "${terraform.workspace == local.live_workspace ? format("https://alertmanager.%s/oauth2/callback", local.live_domain) : ""}",
     "https://prometheus.apps.${local.cluster_base_domain_name}/redirect_uri",
     "https://alertmanager.apps.${local.cluster_base_domain_name}/redirect_uri",
     "https://concourse.apps.${local.cluster_base_domain_name}/sky/issuer/callback",
     "https://kibana.apps.${local.cluster_base_domain_name}/oauth2/callback",
     "https://grafana.apps.${local.cluster_base_domain_name}/login/generic_oauth",
+    "${terraform.workspace == local.live_workspace ? format("https://grafana.%s/login/generic_oauth", local.live_domain) : ""}",
   ]
 
   custom_login_page_on = true


### PR DESCRIPTION
**Why**
We don't want the main monitoring/login page address to change when we switch clusters