### PR TITLE
Feature/cait external dns

### DIFF
--- a/terraform/cloud-platform-components/main.tf
+++ b/terraform/cloud-platform-components/main.tf
@@ -49,6 +49,6 @@ locals {
   dsd_zones = [
     "find-legal-advice.justice.gov.uk.",
     "checklegalaid.service.gov.uk.",
-    "helpwithchildarrangements.service.justice.gov.uk",
+    "helpwithchildarrangements.service.justice.gov.uk.",
   ]
 }

--- a/terraform/cloud-platform-components/main.tf
+++ b/terraform/cloud-platform-components/main.tf
@@ -9,8 +9,8 @@ terraform {
 }
 
 provider "aws" {
-  profile = "moj-pi"
-  region  = "eu-west-1"
+  profile = "moj-cp"
+  region  = "eu-west-2"
 }
 
 provider "kubernetes" {}

--- a/terraform/cloud-platform-components/main.tf
+++ b/terraform/cloud-platform-components/main.tf
@@ -9,8 +9,8 @@ terraform {
 }
 
 provider "aws" {
-  profile = "moj-cp"
-  region  = "eu-west-2"
+  profile = "moj-pi"
+  region  = "eu-west-1"
 }
 
 provider "kubernetes" {}
@@ -49,5 +49,6 @@ locals {
   dsd_zones = [
     "find-legal-advice.justice.gov.uk.",
     "checklegalaid.service.gov.uk.",
+    "helpwithchildarrangements.service.justice.gov.uk",
   ]
 }


### PR DESCRIPTION
- Added helpwithchildarrangements.service.justice.gov.uk to main.tf

- Outside of the ticket, the new R53 zone has been created in moj-dsd 
(helpwithchildarrangements.service.justice.gov.uk)