### PR TITLE
Update external-dns and cert-manager configuration

### DIFF
--- a/terraform/cloud-platform-components/cert-manager.tf
+++ b/terraform/cloud-platform-components/cert-manager.tf
@@ -84,7 +84,7 @@ ingressShim:
   defaultIssuerName: letsencrypt-production
   defaultIssuerKind: ClusterIssuer
   defaultACMEChallengeType: dns01
-  defaultACMEDNS01ChallengeProvider: route53
+  defaultACMEDNS01ChallengeProvider: route53-cloud-platform
 
 securityContext:
   enabled: false

--- a/terraform/cloud-platform-components/cert-manager.tf
+++ b/terraform/cloud-platform-components/cert-manager.tf
@@ -23,9 +23,8 @@ data "aws_iam_policy_document" "cert_manager" {
     actions = ["route53:ChangeResourceRecordSets"]
 
     resources = ["${compact(list(
-      "arn:aws:route53:::hostedzone/${data.terraform_remote_state.cluster.hosted_zone_id}",
-      "${terraform.workspace == local.live_workspace ? format("%s/%s", "arn:aws:route53:::hostedzone", data.terraform_remote_state.global.cp_zone_id) : ""}",
-    ))}"]
+      "${terraform.workspace == local.live_workspace ? "arn:aws:route53:::hostedzone/*" : format("%s/%s", "arn:aws:route53:::hostedzone", data.terraform_remote_state.cluster.hosted_zone_id)}",
+          ))}"]
   }
 
   statement {

--- a/terraform/cloud-platform-components/cert-manager.tf
+++ b/terraform/cloud-platform-components/cert-manager.tf
@@ -22,9 +22,7 @@ data "aws_iam_policy_document" "cert_manager" {
   statement {
     actions = ["route53:ChangeResourceRecordSets"]
 
-    resources = ["${compact(list(
-      "${terraform.workspace == local.live_workspace ? "arn:aws:route53:::hostedzone/*" : format("%s/%s", "arn:aws:route53:::hostedzone", data.terraform_remote_state.cluster.hosted_zone_id)}",
-          ))}"]
+    resources = ["${format("arn:aws:route53:::hostedzone/%s", terraform.workspace == local.live_workspace ? "*" : data.terraform_remote_state.cluster.hosted_zone_id)}"]
   }
 
   statement {

--- a/terraform/cloud-platform-components/external-dns.tf
+++ b/terraform/cloud-platform-components/external-dns.tf
@@ -19,9 +19,8 @@ data "aws_iam_policy_document" "external_dns" {
     actions = ["route53:ChangeResourceRecordSets"]
 
     resources = ["${compact(list(
-      "arn:aws:route53:::hostedzone/${data.terraform_remote_state.cluster.hosted_zone_id}",
-      "${terraform.workspace == local.live_workspace ? format("%s/%s", "arn:aws:route53:::hostedzone", data.terraform_remote_state.global.cp_zone_id) : ""}",
-    ))}"]
+      "${terraform.workspace == local.live_workspace ? "arn:aws:route53:::hostedzone/*" : format("%s/%s", "arn:aws:route53:::hostedzone", data.terraform_remote_state.cluster.hosted_zone_id)}",
+          ))}"]
   }
 
   statement {
@@ -57,8 +56,7 @@ aws:
   region: eu-west-2
   zoneType: public
 domainFilters:
-  - "${data.terraform_remote_state.cluster.cluster_domain_name}"
-  ${terraform.workspace == local.live_workspace ? format("- %s", local.live_domain) : ""}
+  ${terraform.workspace == local.live_workspace ? "" : format("- %s", data.terraform_remote_state.cluster.cluster_domain_name)}
 rbac:
   create: true
   apiVersion: v1

--- a/terraform/cloud-platform-components/external-dns.tf
+++ b/terraform/cloud-platform-components/external-dns.tf
@@ -18,9 +18,7 @@ data "aws_iam_policy_document" "external_dns" {
   statement {
     actions = ["route53:ChangeResourceRecordSets"]
 
-    resources = ["${compact(list(
-      "${terraform.workspace == local.live_workspace ? "arn:aws:route53:::hostedzone/*" : format("%s/%s", "arn:aws:route53:::hostedzone", data.terraform_remote_state.cluster.hosted_zone_id)}",
-          ))}"]
+    resources = ["${format("arn:aws:route53:::hostedzone/%s", terraform.workspace == local.live_workspace ? "*" : data.terraform_remote_state.cluster.hosted_zone_id)}"]
   }
 
   statement {


### PR DESCRIPTION
This PR is to update external-dns and cert-manager configuration, so that:

-components in live-1 can access all the Route53 zones in the cloud-platform account 
-components in other clusters are only able to access their own dedicated zone

#802 