### PR TITLE
increase Kuberos token to 30 days

### DIFF
--- a/terraform/cloud-platform/main.tf
+++ b/terraform/cloud-platform/main.tf
@@ -117,7 +117,7 @@ resource "auth0_client" "kubernetes" {
 
   jwt_configuration = {
     alg                 = "RS256"
-    lifetime_in_seconds = "36000"
+    lifetime_in_seconds = "2592000"
   }
 }
 


### PR DESCRIPTION
**Why** 
Seems the new Kuberos actually follows the JWT expiration as set in auth0 and users must regenerate it every 10 hours