### PR TITLE
 PSP RoleBinding resource created for OPA

### DIFF
--- a/terraform/cloud-platform-components/resources/opa/opa-default-system-main.yaml
+++ b/terraform/cloud-platform-components/resources/opa/opa-default-system-main.yaml
@@ -29,6 +29,6 @@ data:
             "reason": reason,
         },
     } {
-        reason := concat(", ", deny)
+        reason := concat(", ", admission.deny)
         reason != ""
     }

--- a/terraform/cloud-platform-components/resources/opa/opa-psp-rbac.yaml
+++ b/terraform/cloud-platform-components/resources/opa/opa-psp-rbac.yaml
@@ -1,0 +1,16 @@
+# Being allowed to use the _privileged_ policy means binding it to the default serviceaccount of a namespace.
+# A simple RoleBinding resource needs to be created, as described below :
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: PrivilegedRoleBinding
+  namespace: opa
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: psp:privileged
+subjects:
+- kind: Group
+  name: system:serviceaccounts:opa
+  apiGroup: rbac.authorization.k8s.io

--- a/terraform/cloud-platform-components/resources/opa/opa-psp-rbac.yaml
+++ b/terraform/cloud-platform-components/resources/opa/opa-psp-rbac.yaml
@@ -4,7 +4,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: PrivilegedRoleBinding
+  name: opa:psp-privileged
   namespace: opa
 roleRef:
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Being allowed to use the _privileged_ policy means binding it to the default service account of a namespace. A simple RoleBinding resource needs to be created.