### PR TITLE
Opa for live-0

### DIFF
--- a/terraform/cloud-platform-components/opa.tf
+++ b/terraform/cloud-platform-components/opa.tf
@@ -1,0 +1,32 @@
+data "template_file" "values" {
+  template = "${file("${path.module}/templates/opa/values.yaml.tpl")}"
+}
+
+resource "helm_release" "open-policy-agent" {
+  name       = "opa"
+  namespace  = "opa"
+  repository = "stable"
+  chart      = "opa"
+  version    = "1.3.2"
+
+  values = [
+    "${data.template_file.values.rendered}",
+  ]
+
+  lifecycle {
+    ignore_changes = ["keyring"]
+  }
+}
+
+resource "null_resource" "open-policy-agent_policies" {
+  depends_on = ["helm_release.open-policy-agent"]
+
+  provisioner "local-exec" {
+    command = "kubectl apply -n opa -f ${path.module}/resources/opa/"
+  }
+
+  provisioner "local-exec" {
+    when    = "destroy"
+    command = "kubectl delete -n opa --ignore-not-found -f ${path.module}/resources/opa/"
+  }
+}

--- a/terraform/cloud-platform-components/resources/opa/opa-default-system-main.yaml
+++ b/terraform/cloud-platform-components/resources/opa/opa-default-system-main.yaml
@@ -1,0 +1,34 @@
+# This YAML applies a ConfigMap that contains the main OPA policy and default response.
+# This policy is used as an entry-point for policy evaluations and returns allowed:true if policies are not matched to inbound data.
+
+kind: ConfigMap
+apiVersion: v1
+
+metadata:
+  name: policy-default
+  namespace: opa
+  labels:
+    openpolicyagent.org/policy: rego
+data:
+  main: |
+    package system
+
+    import data.cloud_platform.admission
+
+    main = {
+      "apiVersion": "admission.k8s.io/v1beta1",
+      "kind": "AdmissionReview",
+      "response": response,
+    }
+
+    default response = {"allowed": true}
+
+    response = {
+        "allowed": false,
+        "status": {
+            "reason": reason,
+        },
+    } {
+        reason := concat(", ", deny)
+        reason != ""
+    }

--- a/terraform/cloud-platform-components/resources/opa/opa-default-system-main.yaml
+++ b/terraform/cloud-platform-components/resources/opa/opa-default-system-main.yaml
@@ -29,6 +29,6 @@ data:
             "reason": reason,
         },
     } {
-        reason := concat(", ", deny)
+        reason := concat(", ", admission.deny)
         reason != ""
     }

--- a/terraform/cloud-platform-components/resources/opa/opa-psp-rbac.yaml
+++ b/terraform/cloud-platform-components/resources/opa/opa-psp-rbac.yaml
@@ -1,0 +1,16 @@
+# Being allowed to use the _privileged_ policy means binding it to the default serviceaccount of a namespace.
+# A simple RoleBinding resource needs to be created, as described below :
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: PrivilegedRoleBinding
+  namespace: opa
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: psp:privileged
+subjects:
+- kind: Group
+  name: system:serviceaccounts:opa
+  apiGroup: rbac.authorization.k8s.io

--- a/terraform/cloud-platform-components/resources/opa/opa-psp-rbac.yaml
+++ b/terraform/cloud-platform-components/resources/opa/opa-psp-rbac.yaml
@@ -4,7 +4,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: PrivilegedRoleBinding
+  name: opa:psp-privileged
   namespace: opa
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/terraform/cloud-platform-components/resources/opa/policy-ingress-conflicts.yaml
+++ b/terraform/cloud-platform-components/resources/opa/policy-ingress-conflicts.yaml
@@ -1,0 +1,22 @@
+# This policy prevents Ingress objects in different namespaces from sharing the same hostname.
+
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: policy-ingress-conflicts
+  namespace: opa
+  labels:
+    openpolicyagent.org/policy: rego
+data:
+  ingress-conflicts.rego: |
+    package cloud_platform.admission
+
+    import data.kubernetes.ingresses
+
+    deny[msg] {
+       input.request.kind.kind == "Ingress"
+       host := input.request.object.spec.rules[_].host
+       other_hosts := data.kubernetes.ingresses[namespace][name].spec.rules[_].host
+       host == other_hosts
+       msg := sprintf("ingress host (%v) conflicts with ingress %v/%v", [host, namespace, name])
+    }

--- a/terraform/cloud-platform-components/templates/opa/values.yaml.tpl
+++ b/terraform/cloud-platform-components/templates/opa/values.yaml.tpl
@@ -1,0 +1,170 @@
+# Default values for opa.
+# -----------------------
+#
+# The 'opa' key embeds an OPA configuration file. See
+# https://www.openpolicyagent.org/docs/configuration.html for more details.
+opa:
+  # services:
+  #   controller:
+  #     url: "https://www.openpolicyagent.org"
+  # bundle:
+  #   service: controller
+  #   name: "helm-kubernetes-quickstart"
+  # default_decision: "/helm_kubernetes_quickstart/main"
+
+# To enforce mutating policies, change to MutatingWebhookConfiguration.
+admissionControllerKind: ValidatingWebhookConfiguration
+
+# To _fail closed_ on failures, change to Fail. During initial testing, we
+# recommend leaving the failure policy as Ignore.
+admissionControllerFailurePolicy: Fail
+
+# To restrict the kinds of operations and resources that are subject to OPA
+# policy checks, see the settings below. By default, all resources and
+# operations are subject to OPA policy checks.
+admissionControllerRules:
+  - operations: ["CREATE", "UPDATE"]
+    apiGroups: ["extensions"]
+    apiVersions: ["*"]
+    resources: ["ingresses"]
+
+# Controls a PodDisruptionBudget for the OPA pod. Suggested use if having opa
+# always running for admission control is important
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+# maxUnavailable: 1
+
+# The helm Chart will automatically generate a CA and server certificate for
+# the OPA. If you want to supply your own certificates, set the field below to
+# false and add the PEM encoded CA certificate and server key pair below.
+#
+# WARNING: The common name name in the server certificate MUST match the
+# hostname of the service that exposes the OPA to the apiserver. For example.
+# if the service name is created in the "default" nanamespace with name "opa"
+# the common name MUST be set to "opa.default.svc".
+#
+# If the common name is not set correctly, the apiserver will refuse to
+# communicate with the OPA.
+generateAdmissionControllerCerts: true
+admissionControllerCA: ""
+admissionControllerCert: ""
+admissionControllerKey: ""
+
+authz:
+  # Disable if you don't want authorization.
+  # Mostly useful for debugging.
+  enabled: true
+
+# Docker image and tag to deploy.
+image: openpolicyagent/opa
+imageTag: 0.10.5
+imagePullPolicy: IfNotPresent
+
+mgmt:
+  enabled: true
+  image: openpolicyagent/kube-mgmt
+  imageTag: 0.8
+  imagePullPolicy: IfNotPresent
+  extraArgs: []
+  resources: {}
+  configmapPolicies:
+    enabled: true
+    namespaces: [opa] # kube-mgmt automatically discovers policies stored in ConfigMaps,created in a namespace listed here.
+    requireLabel: true
+  replicate:
+# NOTE IF you use these, remember to update the RBAC rules above to allow
+#      permissions to replicate these things
+    cluster:
+      - "v1/namespaces"
+    namespace:
+      - "extensions/v1beta1/ingresses"
+    path: kubernetes
+
+# Log level for OPA ('debug', 'info', 'error') (app default=info)
+logLevel: info
+
+# Log format for OPA ('text', 'json') (app default=text)
+logFormat: text
+
+# Number of OPA replicas to deploy. OPA maintains an eventually consistent
+# cache of policies and data. If you want high availability you can deploy two
+# or more replicas.
+replicas: 1
+
+# To control how the OPA is scheduled on the cluster, set the tolerations and
+# nodeSelector values below. For example, to deploy OPA onto the master nodes:
+#
+# tolerations: [{key: "node-role.kubernetes.io/master", effect: NoSchedule, operator: Exists}]
+# nodeSelector: {"kubernetes.io/role": "master"}
+tolerations: []
+nodeSelector: {}
+
+# To control the CPU and memory resource limits and requests for OPA, set the
+# field below.
+resources: {}
+
+rbac:
+  # If true, create & use RBAC resources
+  #
+  create: true
+  rules:
+    cluster:
+    - apiGroups:
+        - ""
+      resources:
+      - configmaps
+      verbs:
+      - update
+      - patch
+      - get
+      - list
+      - watch
+    - apiGroups:
+        - ""
+      resources:
+      - namespaces
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+        - extensions
+      resources:
+      - ingresses
+      verbs:
+      - get
+      - list
+      - watch
+
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+# This proxy allows opa to make Kubernetes SubjectAccessReview checks against the
+# Kubernetes API. You can get a rego function at github.com/open-policy-agent/library
+sar:
+  enabled: false
+  image: lachlanevenson/k8s-kubectl
+  imageTag: latest
+  imagePullPolicy: IfNotPresent
+  resources: {}
+
+# To control the liveness and readiness probes change the fields below.
+readinessProbe:
+  httpGet:
+    path: /
+    scheme: HTTPS
+    port: 443
+    initialDelaySeconds: 3
+    periodSeconds: 5
+livenessProbe:
+  httpGet:
+    path: /
+    scheme: HTTPS
+    port: 443
+    initialDelaySeconds: 3
+    periodSeconds: 5


### PR DESCRIPTION
This PR is to deploy OPA on live-0 and apply default and policy-ingress-conflicts policy.

OPA changes are already merged and applied on Live-1, this PR will get it to live-0.