### PR TITLE
Upgrade audit ES nodes

### DIFF
--- a/terraform/global-resources/elasticsearch.tf
+++ b/terraform/global-resources/elasticsearch.tf
@@ -223,7 +223,7 @@ resource "aws_elasticsearch_domain" "audit" {
   elasticsearch_version = "6.4"
 
   cluster_config {
-    instance_type  = "m4.large.elasticsearch"
+    instance_type  = "m4.xlarge.elasticsearch"
     instance_count = "3"
   }
 
@@ -254,7 +254,7 @@ resource "aws_elasticsearch_domain" "audit_1" {
   elasticsearch_version = "6.4"
 
   cluster_config {
-    instance_type  = "m4.large.elasticsearch"
+    instance_type  = "m4.xlarge.elasticsearch"
     instance_count = "3"
   }
 


### PR DESCRIPTION
**Why**
fluentd send chunks > 10MB which is the maximum for m4.large so logging stopped around Mar 22
`2019-04-15 17:37:34 +0000 [warn]: [elasticsearch-audit] failed to flush the buffer. retry_time=90959 next_retry_seconds=2019-04-15 17:38:02 +0000 chunk="584af69db95dfdaed0843d387485351a" error_class=Elasticsearch::Transport::Transport::Errors::RequestEntityTooLarge error="[413] {\"Message\":\"Request size exceeded 10485760 bytes\"}"`
Will catch up now that it's unblocked