### PR TITLE
Increase audit ES cluster EBS volume size

### DIFF
--- a/terraform/global-resources/elasticsearch.tf
+++ b/terraform/global-resources/elasticsearch.tf
@@ -230,7 +230,7 @@ resource "aws_elasticsearch_domain" "audit" {
   ebs_options {
     ebs_enabled = "true"
     volume_type = "gp2"
-    volume_size = "320"
+    volume_size = "512"
   }
 
   advanced_options {


### PR DESCRIPTION
**Overview**
The audit cluster doesn't have a curator cronjob to clear disk space so inevitably the disk will fill. This is by design to keep as many logs as possible and to give the security team the option to decided to keep logs over x number of years. 