### PR TITLE
create test ES cluster

### DIFF
--- a/terraform/global-resources/elasticsearch.tf
+++ b/terraform/global-resources/elasticsearch.tf
@@ -278,3 +278,47 @@ resource "aws_elasticsearch_domain" "audit_1" {
     Domain = "${local.audit_domain}"
   }
 }
+
+resource "aws_elasticsearch_domain" "test" {
+  domain_name = "cloud-platform-test"
+  provider              = "aws.cloud-platform"
+  elasticsearch_version = "6.5"
+  cluster_config {
+    instance_type  = "r5.xlarge.elasticsearch"
+    instance_count = "1"
+  }
+  ebs_options {
+    ebs_enabled = "true"
+    volume_type = "gp2"
+    volume_size = "128"
+  }
+  access_policies = <<TESTPOLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "es:*",
+      "Resource": "arn:aws:es:eu-west-2:754256621582:domain/cloud-platform-test/*",
+      "Condition": {
+        "IpAddress": {
+          "aws:SourceIp": [
+            "81.134.202.29",
+            "18.130.193.254",
+            "18.130.140.174",
+            "3.9.1.230",
+            "88.98.227.149",
+            "35.177.135.226",
+            "18.130.212.151",
+            "35.178.89.175"
+          ]
+        }
+      }
+    }
+  ]
+}
+TESTPOLICY
+}

--- a/terraform/global-resources/elasticsearch.tf
+++ b/terraform/global-resources/elasticsearch.tf
@@ -280,18 +280,21 @@ resource "aws_elasticsearch_domain" "audit_1" {
 }
 
 resource "aws_elasticsearch_domain" "test" {
-  domain_name = "cloud-platform-test"
+  domain_name           = "cloud-platform-test"
   provider              = "aws.cloud-platform"
   elasticsearch_version = "6.5"
+
   cluster_config {
     instance_type  = "r5.xlarge.elasticsearch"
     instance_count = "1"
   }
+
   ebs_options {
     ebs_enabled = "true"
     volume_type = "gp2"
     volume_size = "128"
   }
+
   access_policies = <<TESTPOLICY
 {
   "Version": "2012-10-17",


### PR DESCRIPTION
**Why**
A smaller cluster where test-* k8s fluentd will send logs; can have its data wiped at any time