### PR TITLE
Allow privileged containers in opa and kiam namespaces

### DIFF
--- a/terraform/cloud-platform-components/resources/psp/pod-security-policy.yaml
+++ b/terraform/cloud-platform-components/resources/psp/pod-security-policy.yaml
@@ -135,3 +135,9 @@ subjects:
 - kind: Group
   name: system:serviceaccounts:monitoring
   apiGroup: rbac.authorization.k8s.io
+- kind: Group
+  name: system:serviceaccounts:kiam
+  apiGroup: rbac.authorization.k8s.io
+- kind: Group
+  name: system:serviceaccounts:opa
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
- `opa` uses a container running as root
- `kiam` needs to be able to mount host volumes and bind on the host network interfaces