### PR TITLE
Make audit logging optional in the fluentd-es chart

### DIFF
--- a/helm-charts/fluentd-es/config/audit.input.conf
+++ b/helm-charts/fluentd-es/config/audit.input.conf
@@ -1,3 +1,4 @@
+{{ if .Values.fluent_elasticsearch_audit_host }}
 # This configuration file for Fluentd / td-agent is used to watch changes
 # to the kubernetes audit log file. The path to the log file is part of the
 # kops configuration for a cluster (`auditLogPath`).
@@ -60,3 +61,4 @@
     keep_time_key true
     </parse>
 </source>
+{{ end }}

--- a/helm-charts/fluentd-es/config/output.conf
+++ b/helm-charts/fluentd-es/config/output.conf
@@ -8,6 +8,7 @@
     kubernetes_cluster "#{ENV['FLUENT_KUBERNETES_CLUSTER_NAME']}"
     </record>
 </filter>
+{{ if .Values.fluent_elasticsearch_audit_host }}
 <match kubernetes-audit>
     @id elasticsearch-audit
     @type elasticsearch
@@ -37,6 +38,7 @@
     overflow_action block
     </buffer>
 </match>
+{{ end }}
 <match **>
     @id elasticsearch
     @type elasticsearch

--- a/helm-charts/fluentd-es/config/system.input.conf
+++ b/helm-charts/fluentd-es/config/system.input.conf
@@ -174,7 +174,7 @@
 <source>
     @id journald-container-runtime
     @type systemd
-    filters [{ "_SYSTEMD_UNIT": "{{ container_runtime }}.service" }]
+    filters [{ "_SYSTEMD_UNIT": "{{ "{{" }} container_runtime {{ "}}" }}.service" }]
     <storage>
     @type local
     persistent true

--- a/helm-charts/fluentd-es/templates/fluentd-es-config.yaml
+++ b/helm-charts/fluentd-es/templates/fluentd-es-config.yaml
@@ -3,7 +3,7 @@
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: {{  template "fluentd-es.fullname" . }}-config
+  name: {{ template "fluentd-es.fullname" . }}-config
   labels:
     app: {{ .Release.Name }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
@@ -11,7 +11,7 @@ metadata:
     release: {{ .Release.Name }}
     addonmanager.kubernetes.io/mode: Reconcile
 data:
-{{ (.Files.Glob "config/**").AsConfig | indent 2 }}
+{{ tpl (.Files.Glob "config/**").AsConfig . | indent 2 }}
   index-template.json: |-
     {
       "template": "logstash-*",

--- a/terraform/cloud-platform-components/fluentd.tf
+++ b/terraform/cloud-platform-components/fluentd.tf
@@ -10,7 +10,7 @@ resource "helm_release" "fluentd_es" {
 
   set {
     name  = "fluent_elasticsearch_audit_host"
-    value = "${replace(terraform.workspace, "live", "") != terraform.workspace ? "search-cloud-platform-audit-dq5bdnjokj4yt7qozshmifug6e.eu-west-2.es.amazonaws.com" : "search-cloud-platform-test-zradqd7twglkaydvgwhpuypzy4.eu-west-2.es.amazonaws.com"}"
+    value = "${replace(terraform.workspace, "live", "") != terraform.workspace ? "search-cloud-platform-audit-dq5bdnjokj4yt7qozshmifug6e.eu-west-2.es.amazonaws.com" : ""}"
   }
 
   set {


### PR DESCRIPTION
This allows us to disable audit log scraping by fluentd, which is very useful for test clusters. The current solution
does not work properly since it's set to log both into the same ElasticSearch cluster, something that's causing issues
due to the difference in mappings and structure of logs.