### PR TITLE
nginx-ingress structured logs

### DIFF
--- a/helm-charts/fluentd-es/config/containers.input.conf
+++ b/helm-charts/fluentd-es/config/containers.input.conf
@@ -134,3 +134,24 @@
 <match kubernetes.var.log.containers.fluentd**>
     @type null
 </match>
+# Filter all records originating in nginx-ingress containers and try to parse
+# them as JSON; if that fails, apply no formatting and treat them as strings.
+<filter kubernetes.var.log.containers.nginx-ingress**>
+    @type parser
+    @id kubernetes.nginx-ingress.log
+    key_name log
+    reserve_data true
+    reserve_time true
+    remove_key_name_field true
+    hash_value_field nginx-ingress
+    <parse>
+    @type multi_format
+    <pattern>
+      format json
+    </pattern>
+    <pattern>
+      format none
+      message_key log
+    </pattern>
+    </parse>
+</filter>

--- a/helm-charts/fluentd-es/config/output.conf
+++ b/helm-charts/fluentd-es/config/output.conf
@@ -39,6 +39,34 @@
     </buffer>
 </match>
 {{ end }}
+<match kubernetes.var.log.containers.nginx-ingress**>
+  @id elasticsearch-nginx-ingress
+  @type elasticsearch
+  @log_level info
+  include_tag_key true
+  host "#{ENV['FLUENT_ELASTICSEARCH_HOST']}"
+  port "#{ENV['FLUENT_ELASTICSEARCH_PORT'] || '443'}"
+  scheme "#{ENV['FLUENT_ELASTICSEARCH_SCHEME'] || 'https'}"
+  logstash_format true
+  logstash_prefix logstash-nginx-ingress
+  # Prevent reloading connections to AWS ES
+  # Link to issue solution: https://github.com/atomita/fluent-plugin-aws-elasticsearch-service/issues/15#issuecomment-254793259
+  reload_on_failure false
+  reload_connections false
+  <buffer>
+  @type file
+  path /var/log/fluentd-buffers/kubernetes.nginx-ingress.buffer
+  flush_mode interval
+  retry_type exponential_backoff
+  flush_thread_count 2
+  flush_interval 5s
+  retry_forever
+  retry_max_interval 30
+  chunk_limit_size 256M
+  queue_limit_length 8
+  overflow_action block
+  </buffer>
+</match>
 <match **>
     @id elasticsearch
     @type elasticsearch

--- a/terraform/cloud-platform-components/nginx-ingress-acme.tf
+++ b/terraform/cloud-platform-components/nginx-ingress-acme.tf
@@ -47,7 +47,6 @@ controller:
       "real_ip": "$the_real_ip",
       "remote_addr": "$remote_addr",
       "remote_user": "$remote_user",
-      "request": "$request",
       "request_id": "$req_id",
       "request_length": "$request_length",
       "request_method": "$request_method",

--- a/terraform/cloud-platform-components/nginx-ingress-acme.tf
+++ b/terraform/cloud-platform-components/nginx-ingress-acme.tf
@@ -19,6 +19,57 @@ controller:
         return 308 https://$host$request_uri;
       }
 
+    #
+    # For a list of available variables please check the documentation on
+    # `log-format-upstream` and also the relevant nginx document:
+    # - https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/log-format/
+    # - https://nginx.org/en/docs/varindex.html
+    #
+    log-format-escape-json: "true"
+    log-format-upstream: >-
+      {
+      "time": "$time_iso8601",
+      "body_bytes_sent": "$body_bytes_sent",
+      "bytes_sent": $bytes_sent,
+      "gzip_ratio": "$gzip_ratio",
+      "http_host": "$host",
+      "http_referer": "$http_referer",
+      "http_user_agent": "$http_user_agent",
+      "http_x_real_ip": "$http_x_real_ip",
+      "http_x_forwarded_for": "$http_x_forwarded_for",
+      "http_x_forwarded_proto": "$http_x_forwarded_proto",
+      "kubernetes_namespace": "$namespace",
+      "kubernetes_ingress_name": "$ingress_name",
+      "kubernetes_service_name": "$service_name",
+      "kubernetes_service_port": "$service_port",
+      "proxy_upstream_name": "$proxy_upstream_name",
+      "proxy_protocol_addr": "$proxy_protocol_addr",
+      "real_ip": "$the_real_ip",
+      "remote_addr": "$remote_addr",
+      "remote_user": "$remote_user",
+      "request": "$request",
+      "request_id": "$req_id",
+      "request_length": "$request_length",
+      "request_method": "$request_method",
+      "request_path": "$uri",
+      "request_proto": "$server_protocol",
+      "request_query": "$args",
+      "request_time": "$request_time",
+      "request_uri": "$request_uri",
+      "response_http_location": "$sent_http_location",
+      "server_name": "$server_name",
+      "server_port": "$server_port",
+      "ssl_cipher": "$ssl_cipher",
+      "ssl_client_s_dn": "$ssl_client_s_dn",
+      "ssl_protocol": "$ssl_protocol",
+      "ssl_session_id": "$ssl_session_id",
+      "status": "$status",
+      "upstream_addr": "$upstream_addr",
+      "upstream_response_length": "$upstream_response_length",
+      "upstream_response_time": "$upstream_response_time",
+      "upstream_status": "$upstream_status"
+      }
+
   publishService:
     enabled: true
 


### PR DESCRIPTION
Connects to https://github.com/ministryofjustice/cloud-platform/issues/846

This brings the following two changes:
- change `nginx-ingress` logformat to produce json documents
- update `fluentd` config to parse these records properly and direct them to separate elasticsearch indices

Overall, this should bring the cloud-platform elasticsearch implementation closer to the template-deploy setup.

Access logs are now structured and fields are extracted under `nginx-ingress.` and are properly mapped, allowing for
more complex but also performant queries.