### PR TITLE
Update fluentd-es helm chart version

### DIFF
--- a/helm-charts/fluentd-es/Chart.yaml
+++ b/helm-charts/fluentd-es/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "v2.2.0"
 description: A Helm chart for fluentd-es
 name: fluentd-es
-version: 0.1.1
+version: 0.1.2

--- a/terraform/cloud-platform-components/templates/prometheus-operator.yaml.tpl
+++ b/terraform/cloud-platform-components/templates/prometheus-operator.yaml.tpl
@@ -483,7 +483,7 @@ alertmanager:
 ##
 grafana:
   enabled: true
-  
+
   rbac:
     pspUseAppArmor: false
 


### PR DESCRIPTION
Version bump was missed during the update and is needed for terraform to pick up the changes.