### PR TITLE
Extract index template in separate file in fluentd-es chart

### DIFF
--- a/helm-charts/fluentd-es/Chart.yaml
+++ b/helm-charts/fluentd-es/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "v2.2.0"
 description: A Helm chart for fluentd-es
 name: fluentd-es
-version: 0.1.2
+version: 0.1.3

--- a/helm-charts/fluentd-es/config/audit-index-template.json
+++ b/helm-charts/fluentd-es/config/audit-index-template.json
@@ -1,0 +1,20 @@
+{
+  "template": "logstash-*",
+  "mappings": {
+    "fluentd": {
+      "dynamic_templates": [
+        {
+          "default_no_index": {
+            "path_match": "^.*$",
+            "path_unmatch": "^(@timestamp|kubernetes_cluster|auditID|level|stage|requestURI|sourceIPs|metadata|objectRef|user|verb)(\\..+)?$",
+            "match_pattern": "regex",
+            "mapping": {
+              "index": false,
+              "enabled": false
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/helm-charts/fluentd-es/config/output.conf
+++ b/helm-charts/fluentd-es/config/output.conf
@@ -18,8 +18,8 @@
     port "#{ENV['FLUENT_ELASTICSEARCH_AUDIT_PORT'] || '443'}"
     scheme "#{ENV['FLUENT_ELASTICSEARCH_AUDIT_SCHEME'] || 'https'}"
     logstash_format true
-    template_name index-template
-    template_file /etc/fluent/config.d/index-template.json
+    template_name audit-index-template
+    template_file /etc/fluent/config.d/audit-index-template.json
     # Prevent reloading connections to AWS ES
     # Link to issue solution: https://github.com/atomita/fluent-plugin-aws-elasticsearch-service/issues/15#issuecomment-254793259
     reload_on_failure false

--- a/helm-charts/fluentd-es/templates/fluentd-es-config.yaml
+++ b/helm-charts/fluentd-es/templates/fluentd-es-config.yaml
@@ -12,24 +12,3 @@ metadata:
     addonmanager.kubernetes.io/mode: Reconcile
 data:
 {{ tpl (.Files.Glob "config/**").AsConfig . | indent 2 }}
-  index-template.json: |-
-    {
-      "template": "logstash-*",
-      "mappings": {
-        "fluentd": {
-          "dynamic_templates": [
-            {
-              "default_no_index": {
-                "path_match": "^.*$",
-                "path_unmatch": "^(@timestamp|kubernetes_cluster|auditID|level|stage|requestURI|sourceIPs|metadata|objectRef|user|verb)(\\..+)?$",
-                "match_pattern": "regex",
-                "mapping": {
-                  "index": false,
-                  "enabled": false
-                }
-              }
-            }
-          ]
-        }
-      }
-    }


### PR DESCRIPTION
The index-template is no different from any other configuration file so we can manage in a separate file for consistency.