### PR TITLE
Add AWS Limit monitor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 
 terraform: &terraform
   docker:
-    - image: hashicorp/terraform:light
+    - image: hashicorp/terraform:0.11.11
   working_directory: /tmp/workspace/terraform
 
 jobs:

--- a/cloudformation/aws-limit-monitor/README.md
+++ b/cloudformation/aws-limit-monitor/README.md
@@ -1,0 +1,31 @@
+# AWS Limit Monitor
+
+The AWS Limit monitor leverages AWS Trusted Advisor service limit checks that display your usage and limits for specific AWS services.
+An AWS Lambda function runs once every 24 hours and checks to retrieve the most current utilisation and limit data through API calls.  
+
+Limit Status:
+
+| Status | Utilisation | 
+| - | - |
+| OK | Less than 80% |
+| WARN | 80%-99% |
+| ERROR | 100% |
+
+
+
+
+## Configuration
+
+The following table lists the configurable parameters and their default values.
+
+| Parameter | Description | Default |
+| - | - | - |
+| SNSEmail | (Required) The email address to subscribe for alert messages | platforms@digital.justice.gov.uk |
+| SNSEvents | List of alert levels to send email alerts in response to | "ERROR" |
+| SlackEvents | List of alert levels to send Slack alerts in response to | "WARN","ERROR" |
+| SlackHookURL | SSM parameter key for incoming Slack web hook URL |  |
+| SlackChannel | SSM parameter key for the Slack channel | lower-priority-alarms |
+
+Click [here](https://docs.aws.amazon.com/solutions/latest/limit-monitor/welcome.html) for official AWS documentation 
+
+Click [here](https://github.com/awslabs/aws-limit-monitor) for Github repository 

--- a/cloudformation/aws-limit-monitor/limit-monitor.template
+++ b/cloudformation/aws-limit-monitor/limit-monitor.template
@@ -1,0 +1,635 @@
+# Serverless Limit Monitor Solution
+#
+# template for serverless-limit-monitor-solution
+# **DO NOT DELETE**
+#
+# author: aws-solutions-builder@
+AWSTemplateFormatVersion: 2010-09-09
+
+Description: AWS Serverless Limit Monitor Solution
+
+Parameters:
+  # Email address to receive alerts
+  SNSEmail:
+    Description: (Required) The email address to subscribe for alert messages.
+    Default: platforms@digital.justice.gov.uk
+    Type: String
+
+  # Accounts where limits need to be audited
+  AccountList:
+    Description: List of comma-separated and double-quoted account numbers to monitor. If you leave this parameter blank, the solution will only monitor limits in the primary account. If you enter multiple secondary account IDs, you must also provide the primary account ID in this parameter.
+    Type: String
+    AllowedPattern: '^"\d{12}"(,"\d{12}")*$|(^\s*)$'
+
+  # Events for SNS notification
+  SNSEvents:
+    Type: String
+    Default: '"ERROR"'
+    Description : 'List of alert levels to send email alerts in response to. Leave blank if you do not wish to receive email notifications. Must be double-quoted and comma separated.'
+
+  # Events for Slack notification
+  SlackEvents:
+    Type: String
+    Default: '"WARN","ERROR"'
+    Description : 'List of alert levels to send Slack alerts in response to. Leave blank if you do not wish to receive Slack notifications. Must be double-quoted and comma separated.'
+
+  # Slack web hook URL
+  SlackHookURL:
+    Type: String
+    Description: 'SSM parameter key for incoming Slack web hook URL. Leave blank if you do not wish to receive Slack notifications.'
+
+  # Slack channel name
+  SlackChannel:
+    Type: String
+    Default: 'lower-priority-alarms'
+    Description: 'SSM parameter key for the Slack channel. Leave blank if you do not wish to receive Slack notifications.'
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+    - Label:
+        default: Account Configuration
+      Parameters:
+      - AccountList
+    - Label:
+        default: Notification Configuration
+      Parameters:
+      - SNSEvents
+      - SNSEmail
+      - SlackEvents
+      - SlackHookURL
+      - SlackChannel
+    ParameterLabels:
+      AccountList:
+        default: Account List
+      SNSEmail:
+        default: Email Address
+      SNSEvents:
+        default: Email Notification Level
+      SlackEvents:
+        default: Slack Notification Level
+      SlackHookURL:
+        default: Slack Hook Url Key Name
+      SlackChannel:
+        default: Slack Channel Key Name
+
+
+
+Mappings:
+  MetricsMap:
+    Send-Data:
+      SendAnonymousData: "Yes" # change to 'No' if needed
+
+  RefreshRate:
+    CronSchedule:
+      Default: rate(1 day) # change as needed
+
+  SourceCode:
+    General:
+      S3Bucket: solutions
+      KeyPrefix: "limit-monitor/v5.1.1"
+
+  EventsMap:
+    Checks:
+      Services: '"AutoScaling","CloudFormation","EBS","EC2","ELB","IAM","Kinesis","RDS","SES","VPC"' # change as needed
+
+Conditions:
+  SingleAccnt: !Equals [!Ref AccountList , '']
+  SNSTrue: !Not [!Equals [ !Ref SNSEvents, '' ]]
+  SlackTrue: !Not [!Equals [ !Ref SlackEvents, '' ]]
+  AnonymousMetric: !Equals [!FindInMap [MetricsMap, Send-Data, SendAnonymousData], "Yes"]
+
+Resources:
+  #
+  # Limit Monitor Cloudwatch Rules
+  # [TASQSRule, TASNSRule, TASlackRule]
+  #
+  TASQSRule:
+    Type: AWS::Events::Rule
+    Properties:
+      Description: Limit Monitor Solution - Rule for TA SQS events
+      EventPattern: !Join
+        - ''
+        - - '{"account":['
+          - !If
+            - SingleAccnt
+            - !Join
+              - ''
+              - - '"'
+                - !Ref AWS::AccountId
+                - '"'
+            - !Ref AccountList
+          - '],'
+          - '"source":["aws.trustedadvisor"],'
+          - '"detail-type":["Trusted Advisor Check Item Refresh Notification"],'
+          - '"detail":{'
+          - '"status":['
+          - '"OK","WARN","ERROR"'
+          - '],'
+          - '"check-item-detail":{'
+          - '"Service":['
+          - !FindInMap [EventsMap, Checks, Services]
+          - ']'
+          - '}'
+          - '}'
+          - '}'
+      State: ENABLED
+      Targets:
+        - Arn: !Sub ${EventQueue.Arn}
+          Id: LimitMonitorSQSTarget
+
+  TASNSRule:
+    Type: AWS::Events::Rule
+    Condition: SNSTrue
+    Properties:
+      Description: Limit Monitor Solution - Rule for TA SNS events
+      EventPattern: !Join
+        - ''
+        - - '{"account":['
+          - !If
+            - SingleAccnt
+            - !Join
+              - ''
+              - - '"'
+                - !Ref AWS::AccountId
+                - '"'
+            - !Ref AccountList
+          - '],'
+          - '"source":["aws.trustedadvisor"],'
+          - '"detail-type":["Trusted Advisor Check Item Refresh Notification"],'
+          - '"detail":{'
+          - '"status":['
+          - !Ref SNSEvents
+          - '],'
+          - '"check-item-detail":{'
+          - '"Service":['
+          - !FindInMap [EventsMap, Checks, Services]
+          - ']'
+          - '}'
+          - '}'
+          - '}'
+      State: ENABLED
+      # SO-Limit-M-41 - 07/30/2018 - Input transformer
+      # Using transformer to make SNS notification readable
+      Targets:
+        - Arn: !Sub ${SNSTopic}
+          Id: LimitMonitorSNSTarget
+          InputTransformer:
+            InputPathsMap:
+              limitdetails: "$.detail.check-item-detail"
+              time: "$.time"
+              account: "$.account"
+            InputTemplate: '"AWS-Account : <account> || Timestamp : <time> || Limit-Details : <limitdetails>"'
+
+  TASlackRule:
+    Type: AWS::Events::Rule
+    Condition: SlackTrue
+    Properties:
+      Description: Limit Monitor Solution - Rule for TA Slack events
+      EventPattern: !Join
+        - ''
+        - - '{"account":['
+          - !If
+            - SingleAccnt
+            - !Join
+              - ''
+              - - '"'
+                - !Ref AWS::AccountId
+                - '"'
+            - !Ref AccountList
+          - '],'
+          - '"source":["aws.trustedadvisor"],'
+          - '"detail-type":["Trusted Advisor Check Item Refresh Notification"],'
+          - '"detail":{'
+          - '"status":['
+          - !Ref SlackEvents
+          - '],'
+          - '"check-item-detail":{'
+          - '"Service":['
+          - !FindInMap [EventsMap, Checks, Services]
+          - ']'
+          - '}'
+          - '}'
+          - '}'
+      State: ENABLED
+      Targets:
+        - Arn: !Sub ${SlackNotifier.Arn}
+          Id: LimitMonitorSlackTarget
+
+  #
+  # Limit summarizer resources
+  # [EventQueue, DeadLetterQueue, EventQueuePolicy, QueuePollSchedule,
+  # SummarizerInvokePermission, LimitSummarizer, LimitSummarizerRole, SummaryDDB]
+  #
+  EventQueue:
+     Type: AWS::SQS::Queue
+     Properties:
+       RedrivePolicy:
+         deadLetterTargetArn: !Sub ${DeadLetterQueue.Arn}
+         maxReceiveCount: 3
+       VisibilityTimeout: 60
+       MessageRetentionPeriod: 86400 #1 day retention
+
+  DeadLetterQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      MessageRetentionPeriod: 604800 #7 day retention
+
+  EventQueuePolicy:
+    Type: AWS::SQS::QueuePolicy
+    Properties:
+      PolicyDocument:
+        Id: LimitMonitorSQSPolicy
+        Version: '2012-10-17'
+        Statement:
+        - Sid: LimitMonitorCWEventsAccess
+          Effect: Allow
+          Principal:
+            Service: events.amazonaws.com
+          Action: sqs:SendMessage
+          Resource: !Sub ${EventQueue.Arn}
+      Queues:
+      - !Ref EventQueue
+
+  QueuePollSchedule:
+    Type: AWS::Events::Rule
+    Properties:
+      Description: Limit Monitor Solution - Schedule to poll SQS queue
+      ScheduleExpression: rate(5 minutes)
+      State: ENABLED
+      Targets:
+        - Arn: !Sub ${LimitSummarizer.Arn}
+          Id: SqsPollRate
+
+  SummarizerInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Sub ${LimitSummarizer}
+      Action: lambda:InvokeFunction
+      Principal: !Sub events.amazonaws.com
+      SourceArn: !Sub ${QueuePollSchedule.Arn}
+
+  LimitSummarizer:
+    Type: AWS::Lambda::Function
+    Properties:
+      Description: Serverless Limit Monitor - Lambda function to summarize service limit usage
+      Environment:
+        Variables:
+          LIMIT_REPORT_TBL: !Sub ${SummaryDDB}
+          SQS_URL: !Sub ${EventQueue}
+          MAX_MESSAGES: 10 #100 messages can be read with each invocation, change as needed
+          MAX_LOOPS: 10
+          ANONYMOUS_DATA: !FindInMap [MetricsMap, Send-Data, SendAnonymousData]
+          SOLUTION: 'SO0005'
+          UUID: !Sub ${CreateUUID.UUID}
+          LOG_LEVEL: 'INFO' #change to WARN, ERROR or DEBUG as needed
+      Handler: index.handler
+      Role: !Sub ${LimitSummarizerRole.Arn}
+      Code:
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
+        S3Key: !Join ["/", [!FindInMap ["SourceCode", "General", "KeyPrefix"],  "limtr-report-service.zip"]]
+      Runtime: nodejs8.10
+      Timeout: 300
+
+  LimitSummarizerRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: lambda.amazonaws.com
+          Action: sts:AssumeRole
+      Path: /
+      Policies:
+      - PolicyName: !Sub Limit-Monitor-Policy-${AWS::StackName}-${AWS::Region}
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - logs:CreateLogGroup
+            - logs:CreateLogStream
+            - logs:PutLogEvents
+            Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*
+          - Effect: Allow
+            Action:
+            - sqs:DeleteMessage
+            - sqs:ReceiveMessage
+            Resource:
+            - !Sub ${EventQueue.Arn}
+          - Effect: Allow
+            Action:
+            - dynamodb:GetItem
+            - dynamodb:PutItem
+            Resource:
+            - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${SummaryDDB}
+
+  SummaryDDB:
+    Type: AWS::DynamoDB::Table
+    DeletionPolicy: Retain # retaining DDB after stack deletion
+    Properties:
+      TableName: !Sub LimitMonitor-${AWS::StackName}
+      SSESpecification:
+        SSEEnabled: true
+      AttributeDefinitions:
+        - AttributeName: TimeStamp
+          AttributeType: S
+        - AttributeName: MessageId
+          AttributeType: S
+      KeySchema:
+        - AttributeName: MessageId
+          KeyType: HASH
+        - AttributeName: TimeStamp
+          KeyType: RANGE
+      ProvisionedThroughput:
+        ReadCapacityUnits: 2
+        WriteCapacityUnits: 2
+      Tags:
+        - Key: Solution
+          Value: Serverless-Limit-Monitor
+      TimeToLiveSpecification:
+          AttributeName: ExpiryTime
+          Enabled: true
+
+  #
+  # Slack notification resources
+  # [SlackNotifier, SlackNotifierRole, SlackNotifierInvokePermission, SlackHook, SlackChannel]
+  #
+  SlackNotifier:
+    Type: AWS::Lambda::Function
+    Condition: SlackTrue
+    Properties:
+      Description: Serverless Limit Monitor - Lambda function to send notifications on slack
+      Environment:
+        Variables:
+          SLACK_HOOK: !Sub ${SlackHookURL}
+          SLACK_CHANNEL: !Sub ${SlackChannel}
+          LOG_LEVEL: 'INFO' # change to WARN, ERROR or DEBUG as needed
+      Handler: index.handler
+      Role: !Sub ${SlackNotifierRole.Arn}
+      Code:
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
+        S3Key: !Join ["/", [!FindInMap ["SourceCode", "General", "KeyPrefix"],  "limtr-slack-service.zip"]]
+      Runtime: nodejs8.10
+      Timeout: 300
+
+  SlackNotifierRole:
+    Type: AWS::IAM::Role
+    Condition: SlackTrue
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: lambda.amazonaws.com
+          Action: sts:AssumeRole
+      Path: /
+      Policies:
+      - PolicyName: !Sub Limit-Monitor-Policy-${AWS::StackName}-${AWS::Region}
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - logs:CreateLogGroup
+            - logs:CreateLogStream
+            - logs:PutLogEvents
+            Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*
+          - Effect: Allow
+            Action:
+            - ssm:GetParameter
+            Resource:
+            - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:*
+            - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:*
+
+  SlackNotifierInvokePermission:
+    Type: AWS::Lambda::Permission
+    Condition: SlackTrue
+    Properties:
+      FunctionName: !Sub ${SlackNotifier}
+      Action: lambda:InvokeFunction
+      Principal: events.amazonaws.com
+      SourceArn: !Sub ${TASlackRule.Arn}
+
+  #
+  # Email notification resources
+  # [SNSTopic, SNSTopicPolicy]
+  #
+  SNSTopic:
+    Type: AWS::SNS::Topic
+    Condition: SNSTrue
+    Properties:
+      # SO-Limit-M-41 - 07/30/2018 - SNS email
+      # Converted to email to make more readable
+      Subscription:
+      - Protocol: email
+        Endpoint: !Sub ${SNSEmail}
+
+  SNSTopicPolicy:
+    Type: AWS::SNS::TopicPolicy
+    Properties:
+      PolicyDocument:
+        Id: LimitMonitorSNSPolicy
+        Version: '2012-10-17'
+        Statement:
+        - Sid: LimitMonitorCWEventsAccess
+          Effect: Allow
+          Principal:
+            Service: !Sub events.amazonaws.com
+          Action: sns:Publish
+          Resource: '*'
+      Topics:
+      - !Ref SNSTopic
+
+  #
+  # TA refresh resources
+  # [TARefreshSchedule, TARefresher, TARefresherRole, TARefresherInvokePermission]
+  #
+  TARefreshSchedule:
+    Type: AWS::Events::Rule
+    Properties:
+      Description: Limit Monitor Solution - Schedule to refresh TA checks
+      ScheduleExpression: !FindInMap [RefreshRate, CronSchedule, Default]
+      State: ENABLED
+      Targets:
+        - Arn: !Sub ${TARefresher.Arn}
+          Id: TARefreshRate
+
+  TARefresher:
+    Type: AWS::Lambda::Function
+    Properties:
+      Description: Serverless Limit Monitor - Lambda function to summarize service limits
+      Environment:
+        Variables:
+          AWS_SERVICES: !FindInMap [EventsMap, Checks, Services]
+          LOG_LEVEL: 'INFO' #change to WARN, ERROR or DEBUG as needed
+      Handler: index.handler
+      Role: !Sub ${TARefresherRole.Arn}
+      Code:
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
+        S3Key: !Join ["/", [!FindInMap ["SourceCode", "General", "KeyPrefix"],  "limtr-refresh-service.zip"]]
+      Runtime: nodejs8.10
+      Timeout: 300
+
+  TARefresherRole:
+    Type: AWS::IAM::Role
+    # SO-Limit-M-41 - 07/30/2018 - cfn nag
+    # Fixed cfn nag error, allow support:*
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+        - id: F3
+          reason: Override the IAM role to allow support:* resource on its permissions policy
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: lambda.amazonaws.com
+          Action: sts:AssumeRole
+      Path: /
+      Policies:
+      - PolicyName: !Sub Limit-Monitor-Refresher-Policy-${AWS::StackName}
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - logs:CreateLogGroup
+            - logs:CreateLogStream
+            - logs:PutLogEvents
+            Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*
+          - Effect: Allow
+            Action:
+            - support:*
+            Resource:
+            - '*'
+
+  TARefresherInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Sub ${TARefresher}
+      Action: lambda:InvokeFunction
+      Principal: !Sub events.amazonaws.com
+      SourceArn: !Sub ${TARefreshSchedule.Arn}
+
+  #
+  # Helper resources
+  # LimtrHelperFunction, GetUUID, EstablishTrust,
+  # AccountAnonymousData, SSMParameter, LimtrHelperRole
+  #
+  LimtrHelperFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      Handler: index.handler
+      Environment:
+        Variables:
+          LOG_LEVEL: 'INFO' #change to WARN, ERROR or DEBUG as needed
+      Code:
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
+        S3Key: !Join ["/", [!FindInMap ["SourceCode", "General", "KeyPrefix"],  "limtr-helper-service.zip"]]
+      Runtime: nodejs8.10
+      Timeout: 300
+      Description: This function generates UUID, establishes cross account trust on CloudWatch Event Bus and sends anonymous metric
+      Role: !Sub ${LimtrHelperRole.Arn}
+
+  CreateUUID:
+    Type: Custom::UUID
+    Properties:
+      ServiceToken: !GetAtt LimtrHelperFunction.Arn
+
+  EstablishTrust:
+    Type: Custom::CrossAccntTrust
+    Properties:
+      ServiceToken: !GetAtt LimtrHelperFunction.Arn
+      SUB_ACCOUNTS: !Ref AccountList
+
+  SSMParameter:
+    Type: Custom::SSMParameter
+    Condition: SlackTrue
+    Properties:
+      ServiceToken: !GetAtt LimtrHelperFunction.Arn
+      SLACK_HOOK_KEY: !Sub ${SlackHookURL}
+      SLACK_CHANNEL_KEY: !Sub ${SlackChannel}
+
+  AccountAnonymousData:
+    Type: Custom::AnonymousData
+    Condition: AnonymousMetric
+    Properties:
+      ServiceToken: !GetAtt LimtrHelperFunction.Arn
+      SOLUTION: 'SO0005'
+      UUID: !Sub ${CreateUUID.UUID}
+      SNS_EVENTS: !If [SNSTrue, 'true', 'false']
+      SLACK_EVENTS: !If [SlackTrue, 'true', 'false']
+      SUB_ACCOUNTS: !Ref AccountList
+      VERSION: v5.1.1
+      TA_REFRESH_RATE: !FindInMap [RefreshRate, CronSchedule, Default]
+
+  DeploymentData:
+    Type: Custom::DeploymentData
+    Properties:
+      ServiceToken: !GetAtt LimtrHelperFunction.Arn
+      SOLUTION: 'SO0005'
+      UUID: !Sub ${CreateUUID.UUID}
+      VERSION: v5.1.1
+      ANONYMOUS_DATA: !FindInMap [MetricsMap, Send-Data, SendAnonymousData]
+
+  LimtrHelperRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: lambda.amazonaws.com
+          Action: sts:AssumeRole
+      Path: /
+      Policies:
+      - PolicyName: Custom_Limtr_Helper_Permissions
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+          - Effect: Allow
+            Action:
+            - logs:CreateLogGroup
+            - logs:CreateLogStream
+            - logs:PutLogEvents
+            Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*
+          - Effect: Allow
+            Action:
+            - events:PutPermission
+            - events:RemovePermission
+            Resource: !Sub arn:aws:events:${AWS::Region}:${AWS::AccountId}:event-bus/default
+          - Effect: Allow
+            Action:
+            - ssm:GetParameters
+            - ssm:PutParameter
+            Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/* # restrict as needed
+
+Outputs:
+  ServiceChecks:
+    Description: Service limits monitored in the account
+    Value: !FindInMap [EventsMap, Checks, Services]
+
+  AccountList:
+    Description: Accounts to be monitored for service limits
+    Value: !Ref AccountList
+
+  SlackChannelKey:
+    Condition: SlackTrue
+    Description: SSM parameter for Slack Channel, change the value for your slack workspace
+    Value: !Sub ${SlackChannel}
+
+  SlackHookKey:
+    Condition: SlackTrue
+    Description: SSM parameter for Slack Web Hook, change the value for your slack workspace
+    Value: !Sub ${SlackHookURL}
+
+  UUID:
+    Description: UUID for the deployment
+    Value: !Sub ${CreateUUID.UUID}


### PR DESCRIPTION
WHAT
Set up AWS Limit Monitor on CP account

WHY
Get prior warning when we are reaching the limit for AWS resources so we can increase before hitting the max number available 