### PR TITLE
Add default entries for webhook and channel for AWS Limit Monitor

### DIFF
--- a/cloudformation/aws-limit-monitor/README.md
+++ b/cloudformation/aws-limit-monitor/README.md
@@ -23,8 +23,10 @@ The following table lists the configurable parameters and their default values.
 | SNSEmail | (Required) The email address to subscribe for alert messages | platforms@digital.justice.gov.uk |
 | SNSEvents | List of alert levels to send email alerts in response to | "ERROR" |
 | SlackEvents | List of alert levels to send Slack alerts in response to | "WARN","ERROR" |
-| SlackHookURL | SSM parameter key for incoming Slack web hook URL |  |
-| SlackChannel | SSM parameter key for the Slack channel | lower-priority-alarms |
+| SlackHookURL | SSM parameter key for incoming Slack web hook URL | limit_monitor_slack_webhook |
+| SlackChannel | SSM parameter key for the Slack channel | limit_monitor_slack_channel |
+
+Once cloudformation has completed creating the stack, you will need to enter the real slack webhook and channel names in the AWS Parameter Store and replace the dummy entries. 
 
 Click [here](https://docs.aws.amazon.com/solutions/latest/limit-monitor/welcome.html) for official AWS documentation 
 

--- a/cloudformation/aws-limit-monitor/limit-monitor.template
+++ b/cloudformation/aws-limit-monitor/limit-monitor.template
@@ -36,12 +36,13 @@ Parameters:
   # Slack web hook URL
   SlackHookURL:
     Type: String
+    Default: 'limit_monitor_slack_webhook'
     Description: 'SSM parameter key for incoming Slack web hook URL. Leave blank if you do not wish to receive Slack notifications.'
 
   # Slack channel name
   SlackChannel:
     Type: String
-    Default: 'lower-priority-alarms'
+    Default: 'limit_monitor_slack_channel'
     Description: 'SSM parameter key for the Slack channel. Leave blank if you do not wish to receive Slack notifications.'
 
 Metadata:


### PR DESCRIPTION
Add default entires for slack webhook and channel. Also add instructions on readme for replacing dummy entries in AWS Parameter Store for real webhook and channel name. 