### PR TITLE
Simplify package model for opa policies

### DIFF
--- a/terraform/cloud-platform-components/resources/opa/policies/ingress_clash.rego
+++ b/terraform/cloud-platform-components/resources/opa/policies/ingress_clash.rego
@@ -1,4 +1,4 @@
-package cloud_platform.admission.ingress
+package cloud_platform.admission
 
 import data.kubernetes.ingresses
 

--- a/terraform/cloud-platform-components/resources/opa/policies/ingress_clash_test.rego
+++ b/terraform/cloud-platform-components/resources/opa/policies/ingress_clash_test.rego
@@ -1,4 +1,4 @@
-package cloud_platform.admission.ingress
+package cloud_platform.admission
 
 # generates a redacted Ingress spec
 new_ingress(namespace, name, host) = {

--- a/terraform/cloud-platform-components/resources/opa/policies/main.rego
+++ b/terraform/cloud-platform-components/resources/opa/policies/main.rego
@@ -13,6 +13,6 @@ default response = {"allowed": true}
 response = {
     "allowed": false,
     "status": {
-        "reason": admission.ingress.denied_msg,
+        "reason": admission.denied_msg,
     },
-} { admission.ingress.denied }
+} { admission.denied }


### PR DESCRIPTION
It is simpler to keep all policy rules in the same package for simplicity, until we have a reason for using multiple
packages.

This is already applied on `live-1` and working as intended.