### PR TITLE
Add pinned VPC module version

### DIFF
--- a/terraform/cloud-platform/main.tf
+++ b/terraform/cloud-platform/main.tf
@@ -62,6 +62,7 @@ module "cluster_ssl" {
 }
 
 module "cluster_vpc" {
+  version              = "1.66.0"
   source               = "terraform-aws-modules/vpc/aws"
   name                 = "${local.cluster_name}"
   cidr                 = "${var.vpc_cidr}"


### PR DESCRIPTION
Until we move to 0.12, this version will need to be pinned