### PR TITLE
Increased rootVolumeSize from default size of 128  to 256

### DIFF
--- a/terraform/cloud-platform/templates/kops.yaml.tpl
+++ b/terraform/cloud-platform/templates/kops.yaml.tpl
@@ -390,6 +390,7 @@ spec:
   machineType: r5.xlarge
   maxSize: 15
   minSize: ${cluster_node_min_size}
+  rootVolumeSize: 256
   nodeLabels:
     kops.k8s.io/instancegroup: nodes
   cloudLabels:


### PR DESCRIPTION
This is related to https://app.zenhub.com/workspaces/cloud-platform-team-5ccb0b8a81f66118c983c189/issues/ministryofjustice/cloud-platform/982