### PR TITLE
Remove monitoring namespace annotation

### DIFF
--- a/terraform/cloud-platform-components/prometheus.tf
+++ b/terraform/cloud-platform-components/prometheus.tf
@@ -4,10 +4,10 @@
 resource "kubernetes_namespace" "monitoring" {
   metadata {
     name = "monitoring"
+  }
 
-    annotations {
-      "iam.amazonaws.com/permitted" = ".*"
-    }
+  lifecycle {
+    ignore_changes = ["metadata"]
   }
 }
 


### PR DESCRIPTION
This was causing conflicts when applying terraform, the ignore changes allows changes to be made in the environments repository.

The annotation removed (below) still needs to exist so this will be added here:
https://github.com/ministryofjustice/cloud-platform-environments/blob/master/namespaces/live-1.cloud-platform.service.justice.gov.uk/monitoring/00-namespace.yaml