### PR TITLE
Add prometheus-ecr-exporter as a component

### DIFF
--- a/helm-charts/prometheus-ecr-exporter/.helmignore
+++ b/helm-charts/prometheus-ecr-exporter/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/helm-charts/prometheus-ecr-exporter/Chart.yaml
+++ b/helm-charts/prometheus-ecr-exporter/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+appVersion: "0.1.0"
+description: A Helm chart for prometheus ecr-exporter
+name: prometheus-ecr-exporter
+version: 0.1.0
+home: https://github.com/ministryofjustice/prometheus_ecr_exporter
+sources:
+- https://github.com/ministryofjustice/prometheus_ecr_exporter
+keywords:
+- aws
+- ecr
+- prometheus
+- exporter

--- a/helm-charts/prometheus-ecr-exporter/templates/_helpers.tpl
+++ b/helm-charts/prometheus-ecr-exporter/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "prometheus-ecr-exporter.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "prometheus-ecr-exporter.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "prometheus-ecr-exporter.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/helm-charts/prometheus-ecr-exporter/templates/deployment.yaml
+++ b/helm-charts/prometheus-ecr-exporter/templates/deployment.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ include "prometheus-ecr-exporter.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "prometheus-ecr-exporter.name" . }}
+    helm.sh/chart: {{ include "prometheus-ecr-exporter.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "prometheus-ecr-exporter.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "prometheus-ecr-exporter.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+      annotations:
+        {{ if .Values.aws.role}}iam.amazonaws.com/role: {{ .Values.aws.role }}{{ end }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: AWS_REGION
+              value: {{ .Values.aws.region }}
+          ports:
+            - name: http
+              containerPort: 9606
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/helm-charts/prometheus-ecr-exporter/templates/service.yaml
+++ b/helm-charts/prometheus-ecr-exporter/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "prometheus-ecr-exporter.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "prometheus-ecr-exporter.name" . }}
+    helm.sh/chart: {{ include "prometheus-ecr-exporter.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "prometheus-ecr-exporter.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/helm-charts/prometheus-ecr-exporter/templates/servicemonitor.yaml
+++ b/helm-charts/prometheus-ecr-exporter/templates/servicemonitor.yaml
@@ -1,0 +1,34 @@
+{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) ( .Values.serviceMonitor.enabled ) }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "prometheus-ecr-exporter.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "prometheus-ecr-exporter.name" . }}
+    helm.sh/chart: {{ include "prometheus-ecr-exporter.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.serviceMonitor.labels }}
+{{ toYaml .Values.serviceMonitor.labels | indent 4}}
+{{- end }}
+spec:
+  endpoints:
+  - targetPort: {{ .Values.service.port }}
+{{- if .Values.serviceMonitor.interval }}
+    interval: {{ .Values.serviceMonitor.interval }}
+{{- end }}
+{{- if .Values.serviceMonitor.telemetryPath }}
+    path: {{ .Values.serviceMonitor.path }}
+{{- end }}
+{{- if .Values.serviceMonitor.timeout }}
+    scrapeTimeout: {{ .Values.serviceMonitor.scapeTimeout }}
+{{- end }}
+  jobLabel: {{ template "prometheus-ecr-exporter.fullname" . }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "prometheus-ecr-exporter.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/helm-charts/prometheus-ecr-exporter/values.yaml
+++ b/helm-charts/prometheus-ecr-exporter/values.yaml
@@ -1,0 +1,51 @@
+# Default values for prometheus-ecr-exporter.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: ministryofjustice/prometheus-ecr-exporter
+  tag: 0.1.0
+  pullPolicy: IfNotPresent
+
+nameOverride: ""
+fullnameOverride: ""
+
+service:
+  type: ClusterIP
+  port: 9606
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+serviceMonitor:
+  # When set true then use a ServiceMonitor to configure scraping
+  enabled: false
+  # Set how frequently Prometheus should scrape
+  # interval: 30s
+  # Set path to cloudwatch-exporter telemtery-path
+  # path: /metrics
+  # Set labels for the ServiceMonitor, use this to define your scrape label for Prometheus Operator
+  # labels:
+  # Set timeout for scrape
+  # timeout: 10s
+
+aws:
+  region: eu-west-2
+#  role:

--- a/terraform/cloud-platform-components/ecr-exporter.tf
+++ b/terraform/cloud-platform-components/ecr-exporter.tf
@@ -1,0 +1,63 @@
+data "aws_iam_policy_document" "ecr_exporter_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["${data.aws_iam_role.nodes.arn}"]
+    }
+  }
+}
+
+resource "aws_iam_role" "ecr_exporter" {
+  name               = "ecr-exporter.${data.terraform_remote_state.cluster.cluster_domain_name}"
+  assume_role_policy = "${data.aws_iam_policy_document.ecr_exporter_assume.json}"
+}
+
+data "aws_iam_policy_document" "ecr_exporter" {
+  statement {
+    actions = [
+      "ecr:DescribeRepositories",
+      "ecr:ListImages",
+    ]
+
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "ecr_exporter" {
+  name   = "ecr-exporter"
+  role   = "${aws_iam_role.ecr_exporter.id}"
+  policy = "${data.aws_iam_policy_document.ecr_exporter.json}"
+}
+
+resource "helm_release" "ecr_exporter" {
+  name      = "ecr-exporter"
+  count     = "${terraform.workspace == local.live_workspace ? 1 : 0}"
+  namespace = "monitoring"
+  chart     = "../../helm-charts/prometheus-ecr-exporter"
+
+  set {
+    name  = "serviceMonitor.enabled"
+    value = true
+  }
+
+  set {
+    name  = "aws.role"
+    value = "${aws_iam_role.ecr_exporter.name}"
+  }
+
+  set {
+    name  = "aws.region"
+    value = "eu-west-2"
+  }
+
+  depends_on = [
+    "null_resource.deploy",
+    "helm_release.prometheus_operator",
+  ]
+
+  lifecycle {
+    ignore_changes = ["keyring"]
+  }
+}


### PR DESCRIPTION
Connects to https://github.com/ministryofjustice/cloud-platform/issues/985

Adds a custom helm chart for the ecr-exporter and adds the `helm_release` resource in components.