### PR TITLE
replace test ES cluster enpoint with placeholder string

### DIFF
--- a/terraform/cloud-platform-components/fluentd.tf
+++ b/terraform/cloud-platform-components/fluentd.tf
@@ -5,7 +5,11 @@ resource "helm_release" "fluentd_es" {
 
   set {
     name  = "fluent_elasticsearch_host"
-    value = "${replace(terraform.workspace, "live", "") != terraform.workspace ? "search-cloud-platform-live-dibidbfud3uww3lpxnhj2jdws4.eu-west-2.es.amazonaws.com" : "search-cloud-platform-test-zradqd7twglkaydvgwhpuypzy4.eu-west-2.es.amazonaws.com"}"
+    value = "${replace(terraform.workspace, "live", "") != terraform.workspace ? "search-cloud-platform-live-dibidbfud3uww3lpxnhj2jdws4.eu-west-2.es.amazonaws.com" : "placeholder-elasticsearch"}"
+
+    # if you need to connect to the test elasticsearch cluster, replace "placeholder-elasticsearch" with "search-cloud-platform-test-zradqd7twglkaydvgwhpuypzy4.eu-west-2.es.amazonaws.com"
+    # -> value = "${replace(terraform.workspace, "live", "") != terraform.workspace ? "search-cloud-platform-live-dibidbfud3uww3lpxnhj2jdws4.eu-west-2.es.amazonaws.com" : "search-cloud-platform-test-zradqd7twglkaydvgwhpuypzy4.eu-west-2.es.amazonaws.com"
+    # Your cluster will need to be whitelisted.
   }
 
   set {


### PR DESCRIPTION
- Replaced the test-elasticsearch endpoint that's applied to all non-live cluster 
- The new endpoint is a placeholder string, which seems to stop Fluentd from crashing
- If the test cluster has to be used, that string would have to be replaced manually.
