### PR TITLE
Run opa tests in the CircleCI pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,9 +23,20 @@ jobs:
       - persist_to_workspace:
           root: .
           paths: .
+  test_opa:
+    machine:
+      image: ubuntu-1604:201903-01
+    steps:
+      - checkout
+      - run:
+          name: run opa tests
+          command: docker run -v $(pwd)/terraform/cloud-platform-components/resources/opa/policies:/tmp/foobar openpolicyagent/opa test /tmp/foobar
 
 workflows:
   version: 2
   build:
     jobs:
       - validate
+  opatest:
+    jobs:
+      - test_opa


### PR DESCRIPTION
This has been tested by deliberately breaking one of the OPA tests:

https://circleci.com/gh/ministryofjustice/cloud-platform-infrastructure/1245

<img width="735" alt="Screen Shot 2019-07-05 at 16 21 03" src="https://user-images.githubusercontent.com/2338/60732036-eaf29300-9f40-11e9-98fb-34a019b18cac.png">
