### PR TITLE
Minor fix to the OPA policy for LoadBalancers

### DIFF
--- a/terraform/cloud-platform-components/nginx-ingress-acme.tf
+++ b/terraform/cloud-platform-components/nginx-ingress-acme.tf
@@ -14,7 +14,7 @@ resource "kubernetes_namespace" "ingress_controllers" {
       "cloud-platform.justice.gov.uk/business-unit"                 = "cloud-platform"
       "cloud-platform.justice.gov.uk/owner"                         = "Cloud Platform: platforms@digital.justice.gov.uk"
       "cloud-platform.justice.gov.uk/source-code"                   = "https://github.com/ministryofjustice/cloud-platform-infrastructure"
-      "cloud-platform.justice.gov.uk/can-use-loadbalancer-services" = ""
+      "cloud-platform.justice.gov.uk/can-use-loadbalancer-services" = "true"
     }
   }
 }

--- a/terraform/cloud-platform-components/resources/opa/policies/service_type_test.rego
+++ b/terraform/cloud-platform-components/resources/opa/policies/service_type_test.rego
@@ -13,24 +13,24 @@ new_service(namespace, name, type) = {
   }
 }
 
-new_namespace(name, has_annotation) = {
+new_namespace(name, annotation) = {
   "apiVersion": "v1",
   "kind": "Namespace",
   "metadata": {
     "name": name
   }
-} { not has_annotation }
+} { not annotation }
 
-new_namespace(name, has_annotation) = {
+new_namespace(name, annotation) = {
   "apiVersion": "v1",
   "kind": "Namespace",
   "metadata": {
     "name": name,
     "annotations": {
-      "cloud-platform.justice.gov.uk/can-use-loadbalancer-services": ""
+      "cloud-platform.justice.gov.uk/can-use-loadbalancer-services": annotation
     }
   }
-} { has_annotation }
+} { annotation }
 
 test_service_create_allowed {
   not denied
@@ -52,6 +52,14 @@ test_service_create_allowed_by_annotation {
   not denied
     with input as new_admission_review("CREATE", new_service("ns-0", "svc-0", "LoadBalancer"), null)
     with data.kubernetes.namespaces as {
-      "ns-0": new_namespace("ns-0", true)
+      "ns-0": new_namespace("ns-0", "")
+    }
+}
+
+test_service_create_allowed_by_annotation_with_value {
+  not denied
+    with input as new_admission_review("CREATE", new_service("ns-0", "svc-0", "LoadBalancer"), null)
+    with data.kubernetes.namespaces as {
+      "ns-0": new_namespace("ns-0", "foobar")
     }
 }


### PR DESCRIPTION
The kubernetes terraform provider does not seem to be capable of properly distinguishing between an empty value annotation and a non-existing annotation.

This PR ensures that the annotation for the `ingress-controllers` namespace has a value and that our policy accepts any value.