### PR TITLE
Update fluentd docker image, gcr -> quay

### DIFF
--- a/helm-charts/fluentd-es/values.yaml
+++ b/helm-charts/fluentd-es/values.yaml
@@ -1,5 +1,5 @@
 image:
-  repository: "gcr.io/fluentd-elasticsearch/fluentd"
+  repository: "quay.io/fluentd_elasticsearch/fluentd"
   tag: v2.5.2
 
 service:


### PR DESCRIPTION
- This involves the fluentd-es helm chart 
- The original repository seems to be unusable
- Going from a gcr repo to a quay
Following the change from here : [kiwigrid/helm-charts/](https://github.com/kiwigrid/helm-charts/commit/c77bb5e6eb04e1edfdc484a6365d91a4cce44582#diff-ce2053c6a9600163b2470fff5f935948)