### PR TITLE
Fix component dependencies

### DIFF
--- a/terraform/cloud-platform-components/cert-manager-dsd.tf
+++ b/terraform/cloud-platform-components/cert-manager-dsd.tf
@@ -40,6 +40,10 @@ data "aws_iam_policy_document" "cert_manager_dsd" {
 }
 
 resource "kubernetes_secret" "cert_manager_dsd" {
+  depends_on = [
+    "helm_release.cert-manager",
+  ]
+
   type = "Opaque"
 
   metadata {

--- a/terraform/cloud-platform-components/cert-manager.tf
+++ b/terraform/cloud-platform-components/cert-manager.tf
@@ -92,7 +92,11 @@ podAnnotations:
 EOF
   ]
 
-  depends_on = ["null_resource.deploy", "null_resource.cert-manager-crds"]
+  depends_on = [
+    "null_resource.deploy",
+    "null_resource.cert-manager-crds",
+    "helm_release.open-policy-agent",
+  ]
 
   lifecycle {
     ignore_changes = ["keyring"]

--- a/terraform/cloud-platform-components/external-dns.tf
+++ b/terraform/cloud-platform-components/external-dns.tf
@@ -66,7 +66,11 @@ podAnnotations:
 EOF
   ]
 
-  depends_on = ["null_resource.deploy", "helm_release.kiam"]
+  depends_on = [
+    "null_resource.deploy",
+    "helm_release.kiam",
+    "helm_release.open-policy-agent",
+  ]
 
   lifecycle {
     ignore_changes = ["keyring"]

--- a/terraform/cloud-platform-components/kiam.tf
+++ b/terraform/cloud-platform-components/kiam.tf
@@ -121,7 +121,10 @@ resource "helm_release" "kiam" {
     "${data.template_file.kiam.rendered}",
   ]
 
-  depends_on = ["null_resource.deploy"]
+  depends_on = [
+    "null_resource.deploy",
+    "helm_release.open-policy-agent",
+  ]
 
   lifecycle {
     ignore_changes = ["keyring"]

--- a/terraform/cloud-platform-components/kiam.tf
+++ b/terraform/cloud-platform-components/kiam.tf
@@ -129,7 +129,10 @@ resource "helm_release" "kiam" {
 }
 
 resource "kubernetes_service" "server-metrics" {
-  depends_on = ["helm_release.kiam"]
+  depends_on = [
+    "helm_release.kiam",
+    "helm_release.open-policy-agent",
+  ]
 
   metadata {
     name      = "kiam-server-metrics"
@@ -156,7 +159,10 @@ resource "kubernetes_service" "server-metrics" {
 }
 
 resource "kubernetes_service" "agent-metrics" {
-  depends_on = ["helm_release.kiam"]
+  depends_on = [
+    "helm_release.kiam",
+    "helm_release.open-policy-agent",
+  ]
 
   metadata {
     name      = "kiam-agent-metrics"

--- a/terraform/cloud-platform-components/nginx-ingress-acme.tf
+++ b/terraform/cloud-platform-components/nginx-ingress-acme.tf
@@ -118,7 +118,11 @@ EOF
   // certificate issued, it's not a hard dependency and will resort to using a
   // self-signed certificate until the proper one becomes available. This
   // dependency is not captured here.
-  depends_on = ["null_resource.deploy", "kubernetes_namespace.ingress_controllers"]
+  depends_on = [
+    "null_resource.deploy",
+    "kubernetes_namespace.ingress_controllers",
+    "helm_release.open-policy-agent",
+  ]
 
   lifecycle {
     ignore_changes = ["keyring"]

--- a/terraform/cloud-platform-components/opa.tf
+++ b/terraform/cloud-platform-components/opa.tf
@@ -9,6 +9,10 @@ resource "helm_release" "open-policy-agent" {
   chart      = "opa"
   version    = "1.3.2"
 
+  depends_on = [
+    "null_resource.deploy",
+  ]
+
   values = [
     "${data.template_file.values.rendered}",
   ]

--- a/terraform/cloud-platform-components/prometheus.tf
+++ b/terraform/cloud-platform-components/prometheus.tf
@@ -201,6 +201,7 @@ resource "helm_release" "alertmanager_proxy" {
   depends_on = [
     "null_resource.deploy",
     "random_id.session_secret",
+    "helm_release.open-policy-agent",
   ]
 
   lifecycle {

--- a/terraform/cloud-platform-components/prometheus.tf
+++ b/terraform/cloud-platform-components/prometheus.tf
@@ -114,6 +114,7 @@ resource "helm_release" "prometheus_operator" {
   depends_on = [
     "null_resource.deploy",
     "kubernetes_secret.grafana_secret",
+    "helm_release.open-policy-agent",
   ]
 
   provisioner "local-exec" {
@@ -165,6 +166,7 @@ resource "helm_release" "prometheus_proxy" {
   depends_on = [
     "null_resource.deploy",
     "random_id.session_secret",
+    "helm_release.open-policy-agent",
   ]
 
   lifecycle {


### PR DESCRIPTION
When building a new cluster, during the `terraform apply` step for the
terraform/cloud-platform-components, we were seeing a lot of errors. So,
the build script executes a second pass, during which all the errors are
resolved.

This commit adds explicit dependencies in the terraform code so that the
components are installed in the correct order, meaning `terraform apply`
only needs to be executed once to install all the components.

For reference, the errors which occurred during the development of this
PR were as follows (not all in the same build, and not in order):

        * helm_release.open-policy-agent: 1 error occurred:
        * helm_release.open-policy-agent: error creating tunnel: "could not find a ready tiller pod"

        * kubernetes_secret.cert_manager_dsd: 1 error occurred:
        * kubernetes_secret.cert_manager_dsd: namespaces "cert-manager" not found

        * helm_release.prometheus_operator: 1 error occurred:
        * helm_release.prometheus_operator: rpc error: code = Unknown desc = release prometheus-operator failed: Internal error occurred: failed calling admission webhook "webhook.openpolicyagent.org": Post https://opa.opa.svc:443/?timeout=30s: dial tcp 100.67.8.61:443: connect: connection refused

        * kubernetes_service.agent-metrics: 1 error occurred:
        * kubernetes_service.agent-metrics: Internal error occurred: failed calling admission webhook "webhook.openpolicyagent.org": Post https://opa.opa.svc:443/?timeout=30s: dial tcp 100.67.8.61:443: connect: connection refused

        * helm_release.external_dns: 1 error occurred:
        * helm_release.external_dns: rpc error: code = Unknown desc = release external-dns failed: Internal error occurred: failed calling admission webhook "webhook.openpolicyagent.org": Post https://opa.opa.svc:443/?timeout=30s: dial tcp 100.67.8.61:443: connect: connection refused

        * kubernetes_service.server-metrics: 1 error occurred:
        * kubernetes_service.server-metrics: Internal error occurred: failed calling admission webhook "webhook.openpolicyagent.org": Post https://opa.opa.svc:443/?timeout=30s: dial tcp 100.67.8.61:443: connect: connection refused

        * helm_release.prometheus_operator: 1 error occurred:
        * helm_release.prometheus_operator: rpc error: code = Unknown desc = release prometheus-operator failed: Internal error occurred: failed calling admission webhook "webhook.openpolicyagent.org": Post https://opa.opa.svc:443/?timeout=30s: dial tcp 100.67.8.61:443: connect: connection refused

        * kubernetes_service.agent-metrics: 1 error occurred:
        * kubernetes_service.agent-metrics: Internal error occurred: failed calling admission webhook "webhook.openpolicyagent.org": Post https://opa.opa.svc:443/?timeout=30s: dial tcp 100.67.8.61:443: connect: connection refused

        * helm_release.external_dns: 1 error occurred:
        * helm_release.external_dns: rpc error: code = Unknown desc = release external-dns failed: Internal error occurred: failed calling admission webhook "webhook.openpolicyagent.org": Post https://opa.opa.svc:443/?timeout=30s: dial tcp 100.67.8.61:443: connect: connection refused

        * kubernetes_service.server-metrics: 1 error occurred:
        * kubernetes_service.server-metrics: Internal error occurred: failed calling admission webhook "webhook.openpolicyagent.org": Post https://opa.opa.svc:443/?timeout=30s: dial tcp 100.67.8.61:443: connect: connection refused

        * helm_release.cert-manager: 1 error occurred:
        * helm_release.cert-manager: rpc error: code = Unknown desc = release cert-manager failed: Internal error occurred: failed calling admission webhook "webhook.openpolicyagent.org": Post https://opa.opa.svc:443/?timeout=30s: dial tcp 100.66.115.129:443: connect: connection refused

        * helm_release.nginx_ingress_acme: 1 error occurred:
        * helm_release.nginx_ingress_acme: rpc error: code = Unknown desc = release nginx-ingress-acme failed: Internal error occurred: failed calling admission webhook "webhook.openpolicyagent.org": Post https://opa.opa.svc:443/?timeout=30s: dial tcp 100.66.115.129:443: connect: connection refused

        * helm_release.prometheus_proxy: 1 error occurred:
        * helm_release.prometheus_proxy: rpc error: code = Unknown desc = release prometheus-proxy failed: Internal error occurred: failed calling admission webhook "webhook.openpolicyagent.org": Post https://opa.opa.svc:443/?timeout=30s: dial tcp 100.66.115.129:443: connect: connection refused