### PR TITLE
making the FreeStorageSpace RDS metric not an average

### DIFF
--- a/terraform/cloud-platform-components/resources/cloudwatch-exporter.yaml
+++ b/terraform/cloud-platform-components/resources/cloudwatch-exporter.yaml
@@ -41,7 +41,6 @@ config: |-
   - aws_namespace: AWS/RDS
     aws_metric_name: FreeStorageSpace
     aws_dimensions: [DBInstanceIdentifier]
-    aws_statistics: [Average]
   
   - aws_namespace: AWS/RDS
     aws_metric_name: ReadIOPS


### PR DESCRIPTION
- Removing the `aws_statistics` field from the FreeStorageSpace metrics 
That way, the Prometheus CloudWatch Exporter will not produce an average of the RDS disk space. 