### PR TITLE
Bump number of worker nodes in instance group

### DIFF
--- a/kops/live-1.yaml
+++ b/kops/live-1.yaml
@@ -400,8 +400,8 @@ metadata:
 spec:
   image: kope.io/k8s-1.11-debian-stretch-amd64-hvm-ebs-2018-08-17
   machineType: r5.xlarge
-  maxSize: 18
-  minSize: 18
+  maxSize: 40
+  minSize: 40
   rootVolumeSize: 256
   nodeLabels:
     kops.k8s.io/instancegroup: nodes


### PR DESCRIPTION
Why? 
An incident occurred on 15th July 2019 that was caused by a lack of resource. It was decided that we'd expand the capacity.  