### PR TITLE
WIP: Change KIAM agent gatewaytimeoutcreation

### DIFF
--- a/terraform/cloud-platform-components/templates/kiam.yaml.tpl
+++ b/terraform/cloud-platform-components/templates/kiam.yaml.tpl
@@ -4,7 +4,7 @@ agent:
   image:
     tag: ${ kiam_version }
 
-  gatewayTimeoutCreation: 500ms
+  gatewayTimeoutCreation: 5000ms
 
   ## Host networking settings
   ##


### PR DESCRIPTION
This fix was required as we have scaled to 40 nodes, the scale causes crashlooping of the agent pods. By increasing the gateway timeout we allow the pods enough time to create