### PR TITLE
removed "helpwithchildarrangements" under dsd zone

### DIFF
--- a/terraform/cloud-platform-components/main.tf
+++ b/terraform/cloud-platform-components/main.tf
@@ -60,7 +60,6 @@ locals {
   dsd_zones = [
     "find-legal-advice.justice.gov.uk.",
     "checklegalaid.service.gov.uk.",
-    "helpwithchildarrangements.service.justice.gov.uk.",
   ]
 
   live_workspace = "live-1"


### PR DESCRIPTION
As "helpwithchildarrangements.service.justice.gov.uk." is moved from dsd to cp account.

This should be removed and applied so the zone created in dsd will be removed