### PR TITLE
Add AWS CLI to Smoke Test Image

### DIFF
--- a/smoke-tests/Dockerfile
+++ b/smoke-tests/Dockerfile
@@ -1,8 +1,26 @@
 FROM ruby:2.6.3-alpine
 
-RUN apk --update add --virtual build_deps \
-    build-base ruby-dev libc-dev linux-headers \
-    openssl-dev libxml2-dev libxslt-dev
+ENV KUBECTL_VERSION=1.11.10
+
+RUN \
+  apk add \
+    --no-cache \
+    --no-progress \
+    --update \
+    --virtual \
+    build_deps \
+    build-base \
+    libc-dev \
+    libxml2-dev \
+    libxslt-dev \
+    linux-headers \
+    openssl-dev \
+    python3 \
+    ruby-dev \
+  && pip3 install --upgrade pip \
+  && pip3 install awscli \
+  && wget https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl \
+  && chmod +x /usr/local/bin/kubectl
 
 RUN addgroup -g 1000 -S appgroup && \
     adduser -u 1000 -S appuser -G appgroup
@@ -11,11 +29,6 @@ WORKDIR /app
 
 COPY Gemfile* ./
 RUN bundle install
-
-ENV KUBECTL_VERSION=1.11.10
-
-RUN wget https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl
-RUN chmod +x /usr/local/bin/kubectl
 
 COPY . .
 

--- a/smoke-tests/makefile
+++ b/smoke-tests/makefile
@@ -1,4 +1,4 @@
-IMAGE := ministryofjustice/cloud-platform-smoke-tests:1.1
+IMAGE := ministryofjustice/cloud-platform-smoke-tests:1.2
 KUBE_CONFIG := ~/.kube/config
 
 build:


### PR DESCRIPTION
**Overview**
---
This PR connects to https://github.com/ministryofjustice/cloud-platform/issues/1117 and relates to the addition of the AWS cli to the smoke-tests image.  

We would like to use the AWS cli to grab an auth token from s3. This will allow us to authenticate against live-1 for https://github.com/ministryofjustice/cloud-platform-concourse/pull/91. 

The cli is installed via pip3 which needs python3.  