### PR TITLE
Alter the build script to make it possible to build clusters from the tools image

### DIFF
--- a/create-cluster.rb
+++ b/create-cluster.rb
@@ -92,8 +92,13 @@ def wait_for_kops_validate
       validated = true
       break
     else
-      log "Flushing DNS and sleeping before retry..."
-      cmd_successful?(DNS_FLUSH_COMMAND)
+      unless i_am_root?
+        # If we are root, then we're running inside the
+        # tools image, and there's no point running the
+        # DNS_FLUSH_COMMAND
+        log "Flushing DNS and sleeping before retry..."
+        cmd_successful?(DNS_FLUSH_COMMAND)
+      end
       sleep 60
     end
   end
@@ -165,7 +170,7 @@ def run_and_output(cmd, opts = {})
 end
 
 def get_sudo
-  execute "sudo true"
+  execute("sudo true") unless i_am_root?
 end
 
 def usage
@@ -180,6 +185,10 @@ end
 def cmd_successful?(cmd)
   log cmd
   system cmd
+end
+
+def i_am_root?
+  `whoami`.chomp == "root"
 end
 
 ############################################################

--- a/create-cluster.rb
+++ b/create-cluster.rb
@@ -63,7 +63,7 @@ def install_components(cluster_name)
   switch_terraform_workspace(dir, cluster_name)
 
   # Ensure we have the latest helm charts for all the required components
-  execute "helm repo update"
+  execute "helm init --client-only; helm repo update"
   # Without this step, you may get errors like this:
   #
   #     helm_release.open-policy-agent: chart “opa” matching 1.3.2 not found in stable index. (try ‘helm repo update’). No chart version found for opa-1.3.2

--- a/create-cluster.rb
+++ b/create-cluster.rb
@@ -17,6 +17,7 @@ DNS_FLUSH_COMMAND = 'sudo killall -HUP mDNSResponder' # Mac OSX Mojave
 REQUIRED_ENV_VARS = %w( AWS_PROFILE AUTH0_DOMAIN AUTH0_CLIENT_ID AUTH0_CLIENT_SECRET KOPS_STATE_STORE )
 REQUIRED_EXECUTABLES = %w( git-crypt terraform helm aws kops ssh-keygen )
 REQUIRED_AWS_PROFILES = %w( moj-cp moj-dsd )
+ROOT_USER = "root"
 
 def main(cluster_name)
   usage if cluster_name.nil?
@@ -188,7 +189,7 @@ def cmd_successful?(cmd)
 end
 
 def i_am_root?
-  `whoami`.chomp == "root"
+  `whoami`.chomp == ROOT_USER
 end
 
 ############################################################

--- a/makefile
+++ b/makefile
@@ -1,0 +1,14 @@
+TOOLS_IMAGE := tools-ruby # TODO: replace with full ECR image reference
+
+tools-shell:
+	docker run --rm -it \
+    -e AWS_PROFILE=$${AWS_PROFILE} \
+    -e AUTH0_DOMAIN=$${AUTH0_DOMAIN} \
+    -e AUTH0_CLIENT_ID=$${AUTH0_CLIENT_ID} \
+    -e AUTH0_CLIENT_SECRET=$${AUTH0_CLIENT_SECRET} \
+    -e KOPS_STATE_STORE=$${KOPS_STATE_STORE} \
+		-v $$(pwd):/app \
+		-v $${HOME}/.aws:/app/.aws \
+		-e AWS_SHARED_CREDENTIALS_FILE=/app/.aws/credentials \
+		-w /app \
+		$(TOOLS_IMAGE) bash

--- a/makefile
+++ b/makefile
@@ -13,5 +13,6 @@ tools-shell:
 		-v $$(pwd):/app \
 		-v $${HOME}/.aws:/root/.aws \
 		-e AWS_SHARED_CREDENTIALS_FILE=/root/.aws/credentials \
+		-v $${HOME}/.gnupg:/root/.gnupg \
 		-w /app \
 		$(TOOLS_IMAGE) bash

--- a/makefile
+++ b/makefile
@@ -1,5 +1,8 @@
 TOOLS_IMAGE := tools-ruby # TODO: replace with full ECR image reference
 
+# The AWS_SHARED_CREDENTIALS_FILE variable is only needed if you have
+# the .aws directory mounted somewhere other than /root/.aws I'm just
+# leaving it in place for clarity.
 tools-shell:
 	docker run --rm -it \
     -e AWS_PROFILE=$${AWS_PROFILE} \
@@ -8,7 +11,7 @@ tools-shell:
     -e AUTH0_CLIENT_SECRET=$${AUTH0_CLIENT_SECRET} \
     -e KOPS_STATE_STORE=$${KOPS_STATE_STORE} \
 		-v $$(pwd):/app \
-		-v $${HOME}/.aws:/app/.aws \
-		-e AWS_SHARED_CREDENTIALS_FILE=/app/.aws/credentials \
+		-v $${HOME}/.aws:/root/.aws \
+		-e AWS_SHARED_CREDENTIALS_FILE=/root/.aws/credentials \
 		-w /app \
 		$(TOOLS_IMAGE) bash

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-TOOLS_IMAGE := tools-ruby # TODO: replace with full ECR image reference
+TOOLS_IMAGE := 754256621582.dkr.ecr.eu-west-2.amazonaws.com/cloud-platform/tools
 
 # The AWS_SHARED_CREDENTIALS_FILE variable is only needed if you have
 # the .aws directory mounted somewhere other than /root/.aws I'm just


### PR DESCRIPTION
This change reduces the possible variance in the process of building a new
cluster, e.g. due to different operating systems or package versions on
different team members' machines.

This is a step towards being able to build test clusters via a pipeline or a
kubernetes job, although more needs to be done before that is possible.

Blocked by:
https://github.com/ministryofjustice/cloud-platform-tools-image/pull/23