### PR TITLE
Skip failing error pages spec

### DIFF
--- a/smoke-tests/spec/error_page_spec.rb
+++ b/smoke-tests/spec/error_page_spec.rb
@@ -12,7 +12,7 @@ describe "custom error pages" do
       }.to raise_error(OpenURI::HTTPError, "404 Not Found")
     end
 
-    it "serves a 404 response" do
+    xit "serves a 404 response" do
       begin
         URI.open(url)
       rescue OpenURI::HTTPError => e


### PR DESCRIPTION
This spec is currently failing, on new test clusters (although it
passes on live-1).

This commit marked the failing spec so that rspec will not try to
execute it.

After the underlying problem has been fixed, this spec should be
reinstated.

related to
https://github.com/ministryofjustice/cloud-platform/issues/1182