### PR TITLE
Instead of test-namespace-1566221162, create test-namespace-20190819142557

### DIFF
--- a/smoke-tests/spec/ingress_spec.rb
+++ b/smoke-tests/spec/ingress_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe "nginx ingress", cluster: 'live-1' do
   let(:cluster_domain) { "apps.live-1.cloud-platform.service.justice.gov.uk" }
-  let(:namespace) { "smoketest-ingress-#{Time.now.to_i}" }
+  let(:namespace) { "smoketest-ingress-#{readable_timestamp}" }
   let(:host) { "#{namespace}.#{cluster_domain}" }
   let(:url) { "https://#{host}" }
 

--- a/smoke-tests/spec/logging_spec.rb
+++ b/smoke-tests/spec/logging_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 # Use the cluster: 'live-1' tag to identify tests which can only run against the live-1 cluster
 # (in this case, because that's the only place where elasticsearch is set up with these values)
 describe "Log collection", cluster: 'live-1' do
-  let(:namespace) { "smoketest-logging-#{Time.now.to_i}" }
+  let(:namespace) { "smoketest-logging-#{readable_timestamp}" }
 
   ELASTIC_SEARCH = "https://search-cloud-platform-live-dibidbfud3uww3lpxnhj2jdws4.eu-west-2.es.amazonaws.com"
 

--- a/smoke-tests/spec/namespace_spec.rb
+++ b/smoke-tests/spec/namespace_spec.rb
@@ -37,7 +37,7 @@ describe "namespace" do
   end
 
   context "when group is test-webops" do
-    namespace = "smoketest-namespace-#{Time.now.to_i}"
+    namespace = "smoketest-namespace-#{readable_timestamp}"
     before(:all) do
       apply_template_file(
         namespace: namespace,

--- a/smoke-tests/spec/spec_helper.rb
+++ b/smoke-tests/spec/spec_helper.rb
@@ -103,3 +103,7 @@ require "kubernetes_helper"
 require "erb"
 require "json"
 require "date"
+
+def readable_timestamp
+  Time.now.to_i
+end

--- a/smoke-tests/spec/spec_helper.rb
+++ b/smoke-tests/spec/spec_helper.rb
@@ -105,5 +105,5 @@ require "json"
 require "date"
 
 def readable_timestamp
-  Time.now.to_i
+  Time.now.strftime("%Y%m%d%H%M%S")
 end


### PR DESCRIPTION
Test objects are often left lying around in the cluster, if tests fail to
finish cleanly. Using human-readable values in their names makes it easier
to identify these leftovers when manually deleting them, so that we don't
accidentaly delete the objects that are being used by tests running now.