### PR TITLE
Add a test that all namespaces are annotated

### DIFF
--- a/smoke-tests/spec/kubernetes_helper.rb
+++ b/smoke-tests/spec/kubernetes_helper.rb
@@ -2,6 +2,11 @@ def current_cluster
   `kubectl config current-context`.chomp
 end
 
+def all_namespaces
+  json = `kubectl get namespaces -o json`
+  JSON.parse(json).fetch("items")
+end
+
 def create_namespace(namespace)
   unless namespace_exists?(namespace)
     `kubectl create namespace #{namespace}`

--- a/smoke-tests/spec/namespace_annotations_spec.rb
+++ b/smoke-tests/spec/namespace_annotations_spec.rb
@@ -4,7 +4,7 @@ describe "namespaces" do
 
   # Monitoring is automatically set up for all namespaces which have specific
   # annotations. So, if any namespaces don't have any, it's a problem.
-  specify "must have annotations" do
+  xspecify "must have annotations" do
     # This finds namespaces which either don't have an annotations entry, or which
     # have one but it's empty. This might be overkill, but it doesn't add much
     # complexity to the test.

--- a/smoke-tests/spec/namespace_annotations_spec.rb
+++ b/smoke-tests/spec/namespace_annotations_spec.rb
@@ -1,0 +1,22 @@
+require "spec_helper"
+
+describe "namespaces" do
+
+  # Monitoring is automatically set up for all namespaces which have specific
+  # annotations. So, if any namespaces don't have any, it's a problem.
+  specify "must have annotations" do
+    # This finds namespaces which either don't have an annotations entry, or which
+    # have one but it's empty. This might be overkill, but it doesn't add much
+    # complexity to the test.
+    unannotated_namespaces = all_namespaces.map {|ns| ns.fetch("metadata")}
+      .map {|metadata| [metadata.fetch("name"), metadata.fetch("annotations", {}).keys.length] }
+      .filter {|i| i[1] == 0 }
+      .map {|i| i[0]}
+
+    # These namespaces are allowed to not have annotations
+    %w(default kube-public).map { |ns| unannotated_namespaces.delete(ns) }
+
+    expect(unannotated_namespaces).to eq([])
+  end
+
+end


### PR DESCRIPTION
This test is marked to be skipped, because it currently fails when run against
live-1. That's because namespaces should be annotated, but aren't. So, the test
is correct, but live-1 is wrong.

Once all the namespaces in live-1 are annotated, this test should be reinstated

related to https://github.com/ministryofjustice/cloud-platform/issues/1150