### PR TITLE
Use a random hostname for the error page tests

### DIFF
--- a/smoke-tests/spec/error_page_spec.rb
+++ b/smoke-tests/spec/error_page_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe "custom error pages" do
   context "404" do
     let(:url) do
-      "https://foobar.apps.#{current_cluster}"
+      "https://#{random_string}.apps.#{current_cluster}"
     end
 
     it "gets a 404 status" do

--- a/smoke-tests/spec/spec_helper.rb
+++ b/smoke-tests/spec/spec_helper.rb
@@ -107,3 +107,8 @@ require "date"
 def readable_timestamp
   Time.now.strftime("%Y%m%d%H%M%S")
 end
+
+# String of random upper-case letters
+def random_string(length = 8)
+  (0...length).map { (65 + rand(26)).chr }.join
+end


### PR DESCRIPTION
Previously, we were using a constant string 'foobar' for this
test. Sometimes, an initial failure in this test (perhaps because
the cluster wasn't quite ready?) would then result in every
subsequent test, using the same string, getting the same 500 error,
even though any other unknown hostname would work fine.
This commit attempts to mitigate this by using a random hostname
every time this test runs.