### PR TITLE
Create a shell on a non-root tools image

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,4 +1,5 @@
 TOOLS_IMAGE := 754256621582.dkr.ecr.eu-west-2.amazonaws.com/cloud-platform/tools
+TOOLS_HOME := /home/toolsuser
 
 tools-shell:
 	docker pull $(TOOLS_IMAGE)
@@ -8,8 +9,8 @@ tools-shell:
     -e AUTH0_CLIENT_ID=$${AUTH0_CLIENT_ID} \
     -e AUTH0_CLIENT_SECRET=$${AUTH0_CLIENT_SECRET} \
     -e KOPS_STATE_STORE=$${KOPS_STATE_STORE} \
-		-v $$(pwd):/app \
-		-v $${HOME}/.aws:/root/.aws \
-		-v $${HOME}/.gnupg:/root/.gnupg \
-		-w /app \
+		-v $${HOME}/.aws:$(TOOLS_HOME)/.aws \
+		-v $${HOME}/.gnupg:$(TOOLS_HOME)/.gnupg \
+		-v $$(pwd):$(TOOLS_HOME)/infra \
+		-w $(TOOLS_HOME)/infra \
 		$(TOOLS_IMAGE) bash

--- a/makefile
+++ b/makefile
@@ -1,8 +1,5 @@
 TOOLS_IMAGE := 754256621582.dkr.ecr.eu-west-2.amazonaws.com/cloud-platform/tools
 
-# The AWS_SHARED_CREDENTIALS_FILE variable is only needed if you have
-# the .aws directory mounted somewhere other than /root/.aws I'm just
-# leaving it in place for clarity.
 tools-shell:
 	docker pull $(TOOLS_IMAGE)
 	docker run --rm -it \
@@ -13,7 +10,6 @@ tools-shell:
     -e KOPS_STATE_STORE=$${KOPS_STATE_STORE} \
 		-v $$(pwd):/app \
 		-v $${HOME}/.aws:/root/.aws \
-		-e AWS_SHARED_CREDENTIALS_FILE=/root/.aws/credentials \
 		-v $${HOME}/.gnupg:/root/.gnupg \
 		-w /app \
 		$(TOOLS_IMAGE) bash


### PR DESCRIPTION
depends on
https://github.com/ministryofjustice/cloud-platform-tools-image/pull/28

This is a step towards getting the cluster build script to run via a
kubernetes job.