### PR TITLE
Add kiam integration tests

### DIFF
--- a/smoke-tests/Gemfile
+++ b/smoke-tests/Gemfile
@@ -6,3 +6,5 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 gem "rspec"
 gem "pry-byebug"
+gem "aws-sdk-core", "~> 3.59"
+gem "aws-sdk-iam", '~> 1.3'

--- a/smoke-tests/Gemfile.lock
+++ b/smoke-tests/Gemfile.lock
@@ -1,9 +1,22 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    aws-eventstream (1.0.3)
+    aws-partitions (1.191.0)
+    aws-sdk-core (3.60.0)
+      aws-eventstream (~> 1.0, >= 1.0.2)
+      aws-partitions (~> 1.0)
+      aws-sigv4 (~> 1.1)
+      jmespath (~> 1.0)
+    aws-sdk-iam (1.28.0)
+      aws-sdk-core (~> 3, >= 3.58.0)
+      aws-sigv4 (~> 1.1)
+    aws-sigv4 (1.1.0)
+      aws-eventstream (~> 1.0, >= 1.0.2)
     byebug (11.0.1)
     coderay (1.1.2)
     diff-lcs (1.3)
+    jmespath (1.4.0)
     method_source (0.9.2)
     pry (0.12.2)
       coderay (~> 1.1.0)
@@ -29,8 +42,10 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  aws-sdk-core (~> 3.59)
+  aws-sdk-iam (~> 1.3)
   pry-byebug
   rspec
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/smoke-tests/README.md
+++ b/smoke-tests/README.md
@@ -11,15 +11,15 @@ The smoke tests will run inside a docker container against your current Kubernet
 - `git`
 - `docker`
 - `cluster-admin` access to a Cloud Platform cluster
+- `aws-credentials` your aws credentials must be located in the default location `${HOME}/.aws`
 
 ### Build or pull the image
 You'll need to have pulled the image locally, you can do this with the following:
 
 #### Pull
-- `docker pull ministryofjustice/cloud-platform-smoke-tests:1.0`
--
+- `docker pull ministryofjustice/cloud-platform-smoke-tests:${TAG}`
+
 #### Build
-- git clone the [smoke-tests]() repository.
 - run `make build`
 
 ### Run tests

--- a/smoke-tests/makefile
+++ b/smoke-tests/makefile
@@ -1,5 +1,6 @@
 IMAGE := ministryofjustice/cloud-platform-smoke-tests:1.2
 KUBE_CONFIG := ~/.kube/config
+AWS_PROFILE := moj-cp # Cloud Platform AWS account
 
 build:
 	docker build -t $(IMAGE) .
@@ -12,22 +13,34 @@ shell:
 	docker run --rm -it \
 		-v $(KUBE_CONFIG):/app/config \
 		-v $${PWD}/spec:/app/spec \
-		-e KUBECONFIG=/app/config
-	$(IMAGE) sh
+		-v $${HOME}/.aws:/app/.aws \
+		-e AWS_CONFIG_FILE=/app/.aws/config \
+		-e AWS_PROFILE=$(AWS_PROFILE) \
+		-e AWS_SHARED_CREDENTIALS_FILE=/app/.aws/credentials \
+		-e KUBECONFIG=/app/config \
+		$(IMAGE) sh
 
 # Runs all tests, against whichever cluster your .kube/config points to
 test:
 	docker run --rm \
 		-v $(KUBE_CONFIG):/app/config \
 		-v $${PWD}/spec:/app/spec \
+		-v $${HOME}/.aws:/app/.aws \
+		-e AWS_CONFIG_FILE=/app/.aws/config \
+		-e AWS_PROFILE=$(AWS_PROFILE) \
+		-e AWS_SHARED_CREDENTIALS_FILE=/app/.aws/credentials \
 		-e KUBECONFIG=/app/config \
-	$(IMAGE) rspec
+		$(IMAGE) rspec
 
 # Only run tests tagged with cluster: live-1
 test-live-1:
 	docker run --rm \
 		-v $(KUBE_CONFIG):/app/config \
 		-v $${PWD}/spec:/app/spec \
+		-v $${HOME}/.aws:/app/.aws \
+		-e AWS_CONFIG_FILE=/app/.aws/config \
+		-e AWS_PROFILE=$(AWS_PROFILE) \
+		-e AWS_SHARED_CREDENTIALS_FILE=/app/.aws/credentials \
 		-e KUBECONFIG=/app/config \
 		$(IMAGE) rspec --tag cluster:live-1
 
@@ -36,5 +49,9 @@ test-non-live-1:
 	docker run --rm \
 		-v $(KUBE_CONFIG):/app/config \
 		-v $${PWD}/spec:/app/spec \
+		-v $${HOME}/.aws:/app/.aws \
+		-e AWS_CONFIG_FILE=/app/.aws/config \
+		-e AWS_PROFILE=$(AWS_PROFILE) \
+		-e AWS_SHARED_CREDENTIALS_FILE=/app/.aws/credentials \
 		-e KUBECONFIG=/app/config \
 		$(IMAGE) rspec --tag ~cluster:live-1

--- a/smoke-tests/spec/constants.rb
+++ b/smoke-tests/spec/constants.rb
@@ -1,0 +1,6 @@
+TOOLS_IMAGE = "754256621582.dkr.ecr.eu-west-2.amazonaws.com/cloud-platform/tools"
+AWS = {
+  account_id: "754256621582",
+  region: "eu-west-2"
+}
+

--- a/smoke-tests/spec/kiam_helper.rb
+++ b/smoke-tests/spec/kiam_helper.rb
@@ -1,0 +1,163 @@
+class KiamRole
+  attr_reader :kubernetes_cluster, :account_id, :aws_region, :role_name
+
+  ASSUME_ROLE_POLICY_DOCUMENT = {
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Effect: "Allow",
+        Action: [
+          "sts:AssumeRole"
+        ],
+        Resource: [
+          "*"
+        ]
+      }
+    ]
+  }
+
+  def initialize(args)
+    @kubernetes_cluster = args.fetch(:kubernetes_cluster)
+    @account_id = args.fetch(:account_id)
+    @aws_region = args.fetch(:aws_region)
+    @role_name = args.fetch(:role_name)
+  end
+
+  def fetch_or_create_role
+    role = Aws::IAM::Role.new(client: client, name: role_name)
+
+    if client.list_roles.roles.find {|r| r.role_name == role_name}
+      role.load
+    else
+      role = create_role
+    end
+
+    assume_role_policy = fetch_or_create_policy(
+      policy_document: ASSUME_ROLE_POLICY_DOCUMENT.to_json,
+      policy_name: "integration-test-kiam-policy"
+    )
+    arn = assume_role_policy.arn
+
+    unless role.attached_policies.map(&:arn).include?(arn)
+      role.attach_policy(policy_arn: arn)
+    end
+
+    role
+  end
+
+  private
+
+  def create_role
+    iam = Aws::IAM::Resource.new(client: client)
+
+    node_assume_role_policy_doc = {
+      Version:"2012-10-17",
+      Statement:[
+        {
+          Effect:"Allow",
+          Principal:{
+            AWS: "arn:aws:iam::#{account_id}:role/nodes.#{kubernetes_cluster}"
+          },
+          Action:"sts:AssumeRole"
+        }
+      ]
+    }
+
+    role = iam.create_role(
+      role_name: role_name,
+      assume_role_policy_document: node_assume_role_policy_doc.to_json,
+    )
+
+    client.wait_until(:role_exists, role_name: role_name)
+
+    role
+  end
+
+  def fetch_or_create_policy(args)
+    policy_name = args.fetch(:policy_name)
+
+    if policy = client.list_policies.policies.find {|p| p.policy_name == args.fetch(:policy_name) }
+      arn = policy.arn
+    else
+      resp = client.create_policy(
+        policy_document: args.fetch(:policy_document),
+        policy_name: policy_name
+      )
+      arn = resp.policy.arn
+    end
+
+    Aws::IAM::Policy.new(client: client, arn: arn)
+  end
+
+  def client
+    @client ||= Aws::IAM::Client.new(region: aws_region)
+  end
+end
+
+def fetch_or_create_role(args)
+  KiamRole.new(args).fetch_or_create_role
+end
+
+# Run a command, on the pod in the namespace, to try and assume the role, and capture the output from it.
+def try_to_assume_role(args)
+  namespace = args.fetch(:namespace)
+  role_arn = args.fetch(:role_arn)
+  pod = args.fetch(:pod)
+
+  cmd = %[kubectl exec -n #{namespace} #{pod} -- aws sts assume-role --role-arn "#{role_arn}" --role-session-name dummy]
+  `#{cmd} 2>&1`
+end
+
+# Deploy a container into a namespace. The container just runs 'sleep 86400'.
+# We will run commands on the container using kubectl exec, and capture the output
+def create_deployment(args)
+  namespace = args.fetch(:namespace)
+  pod_annotations = args.fetch(:pod_annotations)
+
+  json = <<~EOF
+  {
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "metadata": { "name": "integration-test-kiam-deployment" },
+    "spec": {
+      "selector": { "matchLabels": { "app": "not-needed" } },
+      "template": {
+        "metadata": {
+          "annotations": #{pod_annotations.to_json},
+          "labels": { "app": "not-needed" }
+        },
+        "spec": {
+          "securityContext": {
+            "runAsUser": 1000,
+            "runAsGroup": 3000
+          },
+          "containers": [
+            {
+              "name": "tools-image",
+              "image": "#{TOOLS_IMAGE}",
+              "command": [ "sleep", "86400" ]
+            }
+          ]
+        }
+      }
+    }
+  }
+  EOF
+
+  # collapse the json onto a single line
+  jsn = JSON.parse(json).to_json
+
+  cmd = %[echo '#{jsn}' | kubectl -n #{namespace} apply -f -]
+
+  `#{cmd}`
+
+  pod = ""
+
+  60.times do
+    pod = get_running_pod_name(namespace, 1)
+    break if pod.length > 0
+    sleep 1
+  end
+
+  pod
+end

--- a/smoke-tests/spec/kiam_spec.rb
+++ b/smoke-tests/spec/kiam_spec.rb
@@ -1,0 +1,89 @@
+require "spec_helper"
+
+# Kiam will enable code running in the cluster to assume an AWS role if
+# both the pod and the namespace are annotated appropriately.
+describe "kiam" do
+  KIAM_ROLE_NAME = "integration-test-kiam-iam-role"
+
+  # Do not use a dynamically-generated role_name here. This test
+  # only works using a stable set of AWS entities
+  # Note: If you run these tests when the role/policy setup does not exist, the
+  # test will create it. But, you might see failures on the first few runs. It
+  # seems to take a while for things to 'settle' on AWS.
+  # The error you might see includes 'An error occurred (InvalidClientTokenId)'
+  # If you see that error, wait a few minutes and retry.
+  role_args = {
+    role_name: KIAM_ROLE_NAME,
+    account_id: AWS[:account_id],
+    aws_region: AWS[:region],
+    kubernetes_cluster: current_cluster
+  }
+
+  pod = ""  # name of the running pod in our test namespace
+
+  # we want to use the same role every time, so we're not going to clean this up
+  role = fetch_or_create_role(role_args)
+
+  let(:namespace) { "integrationtest-kiam-#{random_string}-#{readable_timestamp}" }
+
+  let(:assume_role_args) { {
+    namespace: namespace,
+    pod: pod,
+    role_arn: role.arn,
+    pod_annotations: pod_annotations
+  } }
+
+  before do
+    create_namespace(namespace, namespace_annotations)
+    pod = create_deployment(namespace: namespace, pod_annotations: pod_annotations)
+  end
+
+  after do
+    delete_namespace(namespace)
+  end
+
+  context "namespace has annotations" do
+    let(:namespace_annotations) { { annotations: "iam.amazonaws.com/permitted=.*" } }
+
+    context "pod has annotations" do
+      let(:pod_annotations) { { "iam.amazonaws.com/role" => KIAM_ROLE_NAME } }
+
+      it "can assume role" do
+        json = try_to_assume_role(assume_role_args)
+        result = JSON.parse(json).has_key?("Credentials")
+        expect(result).to be true
+      end
+    end
+
+    context "pod does not have annotations" do
+      let(:pod_annotations) { {} }
+
+      it "cannot assume role" do
+        result = try_to_assume_role(assume_role_args)
+        expect(result).to match(/Unable to locate credentials/)
+      end
+    end
+  end
+
+  context "namespace has no annotations" do
+    let(:namespace_annotations) { {} }
+
+    context "pod has annotations" do
+      let(:pod_annotations) { { "iam.amazonaws.com/role" => KIAM_ROLE_NAME } }
+
+      it "cannot assume role" do
+        result = try_to_assume_role(assume_role_args)
+        expect(result).to match(/Unable to locate credentials/)
+      end
+    end
+
+    context "pod does not have annotations" do
+      let(:pod_annotations) { {} }
+
+      it "cannot assume role" do
+        result = try_to_assume_role(assume_role_args)
+        expect(result).to match(/Unable to locate credentials/)
+      end
+    end
+  end
+end

--- a/smoke-tests/spec/kubernetes_helper.rb
+++ b/smoke-tests/spec/kubernetes_helper.rb
@@ -7,7 +7,7 @@ def all_namespaces
   JSON.parse(json).fetch("items")
 end
 
-def create_namespace(namespace)
+def create_namespace(namespace, opts = {})
   unless namespace_exists?(namespace)
     `kubectl create namespace #{namespace}`
 
@@ -15,6 +15,10 @@ def create_namespace(namespace)
       break if namespace_exists?(namespace)
       sleep 1
     end
+
+    if annotations = opts[:annotations]
+      `kubectl annotate --overwrite namespace #{namespace} '#{annotations}'`
+     end
   end
 end
 

--- a/smoke-tests/spec/kubernetes_helper.rb
+++ b/smoke-tests/spec/kubernetes_helper.rb
@@ -97,8 +97,11 @@ def get_pod_logs(namespace, pod_name)
   `kubectl -n #{namespace} logs #{pod_name}`
 end
 
-# Get the name of the Nth pod in the namespace
-def get_pod_name(namespace, index)
-  `kubectl get pods -n #{namespace} | awk 'FNR == #{index + 1} {print $1}'`.chomp
+def get_running_pod_name(namespace, index)
+  get_pod_name(namespace, index, "--field-selector=status.phase=Running")
 end
 
+# Get the name of the Nth pod in the namespace
+def get_pod_name(namespace, index, options = "")
+  `kubectl get pods -n #{namespace} #{options} 2>/dev/null | awk 'FNR == #{index + 1} {print $1}'`.chomp
+end

--- a/smoke-tests/spec/spec_helper.rb
+++ b/smoke-tests/spec/spec_helper.rb
@@ -97,12 +97,15 @@ RSpec.configure do |config|
   #   Kernel.srand config.seed
 end
 
+require "aws-sdk-iam"
 require "open-uri"
 require "pry-byebug"
 require "kubernetes_helper"
 require "erb"
 require "json"
 require "date"
+require "./spec/constants"
+require "./spec/kiam_helper"
 
 def readable_timestamp
   Time.now.strftime("%Y%m%d%H%M%S")

--- a/smoke-tests/spec/spec_helper.rb
+++ b/smoke-tests/spec/spec_helper.rb
@@ -110,5 +110,5 @@ end
 
 # String of random upper-case letters
 def random_string(length = 8)
-  (0...length).map { (65 + rand(26)).chr }.join
+  (0...length).map { (65 + rand(26)).chr }.join.downcase
 end

--- a/smoke-tests/tags
+++ b/smoke-tests/tags
@@ -1,6 +1,0 @@
-!_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
-!_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
-!_TAG_PROGRAM_AUTHOR	Darren Hiebert	/dhiebert@users.sourceforge.net/
-!_TAG_PROGRAM_NAME	Exuberant Ctags	//
-!_TAG_PROGRAM_URL	http://ctags.sourceforge.net	/official site/
-!_TAG_PROGRAM_VERSION	5.9~svn20110310	//


### PR DESCRIPTION
Connects to https://github.com/ministryofjustice/cloud-platform/issues/1112

The test proves that, if a pod and namespace have appropriate annotations (and if the corresponding IAM role and policies are set up correctly), code running in the cluster can assume AWS IAM roles.

Co-authored-by: Poornima Krishnasamy <poornima.krishnasamy@digital.justice.gov.uk>, Jason Birchall <jason.birchall@digital.justice.gov.uk>