### PR TITLE
Revert "Create a shell on a non-root tools image"

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,5 +1,4 @@
 TOOLS_IMAGE := 754256621582.dkr.ecr.eu-west-2.amazonaws.com/cloud-platform/tools
-TOOLS_HOME := /home/toolsuser
 
 tools-shell:
 	docker pull $(TOOLS_IMAGE)
@@ -9,8 +8,8 @@ tools-shell:
     -e AUTH0_CLIENT_ID=$${AUTH0_CLIENT_ID} \
     -e AUTH0_CLIENT_SECRET=$${AUTH0_CLIENT_SECRET} \
     -e KOPS_STATE_STORE=$${KOPS_STATE_STORE} \
-		-v $${HOME}/.aws:$(TOOLS_HOME)/.aws \
-		-v $${HOME}/.gnupg:$(TOOLS_HOME)/.gnupg \
-		-v $$(pwd):$(TOOLS_HOME)/infra \
-		-w $(TOOLS_HOME)/infra \
+		-v $$(pwd):/app \
+		-v $${HOME}/.aws:/root/.aws \
+		-v $${HOME}/.gnupg:/root/.gnupg \
+		-w /app \
 		$(TOOLS_IMAGE) bash


### PR DESCRIPTION
This reverts commit d0108a47d43a78b80ddf430bf91c42d59f17d66e.

Running a non-root tools image breaks our concourse pipelines, so
that change has been reverted, and so this one must be reverted
also.