### PR TITLE
Get the tools image from docker hub

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-TOOLS_IMAGE := 754256621582.dkr.ecr.eu-west-2.amazonaws.com/cloud-platform/tools
+TOOLS_IMAGE := ministryofjustice/cloud-platform-tools
 
 tools-shell:
 	docker pull $(TOOLS_IMAGE)

--- a/smoke-tests/spec/constants.rb
+++ b/smoke-tests/spec/constants.rb
@@ -1,4 +1,4 @@
-TOOLS_IMAGE = "754256621582.dkr.ecr.eu-west-2.amazonaws.com/cloud-platform/tools"
+TOOLS_IMAGE = "ministryofjustice/cloud-platform-tools"
 AWS = {
   account_id: "754256621582",
   region: "eu-west-2"


### PR DESCRIPTION
Eventually, the ECR version will be removed, so we
should start using the docker hub version ASAP