### PR TITLE
add route53_helper, and relevant config

### DIFF
--- a/smoke-tests/Gemfile
+++ b/smoke-tests/Gemfile
@@ -8,3 +8,4 @@ gem "rspec"
 gem "pry-byebug"
 gem "aws-sdk-core", "~> 3.59"
 gem "aws-sdk-iam", '~> 1.3'
+gem "aws-sdk-route53", '~> 1.27'

--- a/smoke-tests/Gemfile.lock
+++ b/smoke-tests/Gemfile.lock
@@ -11,6 +11,9 @@ GEM
     aws-sdk-iam (1.28.0)
       aws-sdk-core (~> 3, >= 3.58.0)
       aws-sigv4 (~> 1.1)
+    aws-sdk-route53 (1.27.0)
+      aws-sdk-core (~> 3, >= 3.58.0)
+      aws-sigv4 (~> 1.1)
     aws-sigv4 (1.1.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
     byebug (11.0.1)
@@ -44,8 +47,9 @@ PLATFORMS
 DEPENDENCIES
   aws-sdk-core (~> 3.59)
   aws-sdk-iam (~> 1.3)
+  aws-sdk-route53 (~> 1.27)
   pry-byebug
   rspec
 
 BUNDLED WITH
-   1.17.3
+   2.0.2

--- a/smoke-tests/spec/route53_helper.rb
+++ b/smoke-tests/spec/route53_helper.rb
@@ -1,0 +1,55 @@
+# Create new Route53 zone
+# Expect a domain name in input
+# Return route53 zone object https://docs.aws.amazon.com/sdkforruby/api/Aws/Route53/Types/CreateHostedZoneResponse.html
+def create_zone(domain)
+  client = Aws::Route53::Client.new
+  client.create_hosted_zone(
+    name: domain, 
+    caller_reference: readable_timestamp, # required, different each time
+    hosted_zone_config: {
+      comment: "FOR TESTING PURPOSES ONLY",
+      private_zone: false,
+    },
+  )
+end
+
+# Delegate a Route53 zone (child -> Parent)
+# Expect a Route53 zone object and the parent zone_id
+def create_delegation_set(child_zone, parent_id)
+  client = Aws::Route53::Client.new
+  client.change_resource_record_sets(
+    change_batch: {
+      changes: [
+        {
+          action: "CREATE",
+          resource_record_set: {
+            name: child_zone.hosted_zone.name,
+            resource_records: child_zone.delegation_set.name_servers.map { |ns| {value: ns} },
+            ttl: 60,
+            type: "NS",
+          },
+        },
+      ],
+      comment: "FOR TESTING PURPOSES ONLY",
+    },
+    hosted_zone_id: parent_id,
+  )
+end
+
+# Retrieves a list of records from an existing Route53 zones
+# Expect a zone_id in input
+# Returns an array of hashes {type, name, value} of records.
+# example:
+  # [
+  #   {:type=>"NS", :name=>"test.service.justice.gov.uk.", :value=>["ns-000.awsdns-00.net.", "ns-000.awsdns-00.net.", "ns-000.awsdns-00.net.", "ns-000.awsdns-00.net."]},
+  #   {:type=>"SOA", :name=>"mourad2.service.justice.gov.uk.", :value=>["ns-000.awsdns-00.net. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400"]}
+  # ]
+def get_zone_records(zone_id)
+  client = Aws::Route53::Client.new
+  records = client.list_resource_record_sets(
+    hosted_zone_id: zone_id, # required
+  )
+
+  records.resource_record_sets.collect { |r| {type: r.type, name: r.name, value: r.resource_records.map { |item| item.value }} }
+  
+end

--- a/smoke-tests/spec/spec_helper.rb
+++ b/smoke-tests/spec/spec_helper.rb
@@ -97,6 +97,7 @@ RSpec.configure do |config|
   #   Kernel.srand config.seed
 end
 
+require "aws-sdk-route53"
 require "aws-sdk-iam"
 require "open-uri"
 require "pry-byebug"
@@ -106,6 +107,9 @@ require "json"
 require "date"
 require "./spec/constants"
 require "./spec/kiam_helper"
+require "./spec/route53_helper"
+require "./spec/kubernetes_helper"
+
 
 def readable_timestamp
   Time.now.strftime("%Y%m%d%H%M%S")


### PR DESCRIPTION
- added route53_helper, to create_zone, create_delegation_set and get_zone_records.

- added aws-sdk-route53 gem as a dependency in Gemfile, and spec_helper.

- Gemfile.lock