### PR TITLE
add delete_zone and delete_delegation_set

### DIFF
--- a/smoke-tests/spec/route53_helper.rb
+++ b/smoke-tests/spec/route53_helper.rb
@@ -60,7 +60,7 @@ def delete_zone(zone_id)
   client = Aws::Route53::Client.new
   client.delete_hosted_zone(
     id: zone_id,
-  })
+  )
 end
 
 # Deletes a Delegation set (NS)

--- a/smoke-tests/spec/route53_helper.rb
+++ b/smoke-tests/spec/route53_helper.rb
@@ -52,3 +52,34 @@ def get_zone_records(zone_id)
 
   records.resource_record_sets.collect { |r| {type: r.type, name: r.name, value: r.resource_records.map { |item| item.value }} }
 end
+
+# Deletes a hosted zone.
+# Expects a zone_id in input
+# Be careful
+def delete_zone(zone_id)
+  client = Aws::Route53::Client.new
+  client.delete_hosted_zone({
+    id: zone_id,
+  })
+end
+
+def delete_delegation_set(child_zone, parent_id)
+  client = Aws::Route53::Client.new
+  client.change_resource_record_sets(
+    change_batch: {
+      changes: [
+        {
+          action: "DELETE",
+          resource_record_set: {
+            name: child_zone.hosted_zone.name,
+            resource_records: child_zone.delegation_set.name_servers.map { |ns| {value: ns} },
+            ttl: 60,
+            type: "NS",
+          },
+        },
+      ],
+      comment: "FOR TESTING PURPOSES ONLY",
+    },
+    hosted_zone_id: parent_id,
+  )
+end

--- a/smoke-tests/spec/route53_helper.rb
+++ b/smoke-tests/spec/route53_helper.rb
@@ -7,7 +7,7 @@ def create_zone(domain)
     name: domain,
     caller_reference: readable_timestamp, # required, different each time
     hosted_zone_config: {
-      comment: "FOR TESTING PURPOSES ONLY",
+      comment: "integrationtest",
       private_zone: false,
     },
   )
@@ -30,7 +30,7 @@ def create_delegation_set(child_zone, parent_id)
           },
         },
       ],
-      comment: "FOR TESTING PURPOSES ONLY",
+      comment: "integrationtest",
     },
     hosted_zone_id: parent_id,
   )
@@ -58,11 +58,13 @@ end
 # Be careful
 def delete_zone(zone_id)
   client = Aws::Route53::Client.new
-  client.delete_hosted_zone({
+  client.delete_hosted_zone(
     id: zone_id,
   })
 end
 
+# Deletes a Delegation set (NS)
+# Expects a parent and child zone, see create_delegation_set
 def delete_delegation_set(child_zone, parent_id)
   client = Aws::Route53::Client.new
   client.change_resource_record_sets(
@@ -78,7 +80,7 @@ def delete_delegation_set(child_zone, parent_id)
           },
         },
       ],
-      comment: "FOR TESTING PURPOSES ONLY",
+      comment: "integrationtest",
     },
     hosted_zone_id: parent_id,
   )


### PR DESCRIPTION
- add deletion methods to route53_helper.rb
- delete_zone deletes a route53 zone
- delete_delegation_set deletes the set of NS record pointing from a parent to a child zone