### PR TITLE
Increase logging test sleep from 60 to 120 seconds

### DIFF
--- a/smoke-tests/spec/logging_spec.rb
+++ b/smoke-tests/spec/logging_spec.rb
@@ -22,7 +22,9 @@ describe "Log collection", cluster: "live-1" do
     # It takes time for the 'helloworld' job output to be shipped to elasticsearch, and there
     # is no easy way to figure out when this has/hasn't happened. This sleep seems to work
     # consistently, but it's possible it may break unexpectedly, at some point.
-    sleep 60
+
+    sleep 120 # TODO: this is an experimental change (from 60), to see if a longer sleep fixes
+              #       intermittent pipeline failures
 
     date = Date.today.strftime("%Y.%m.%d")
     search_url = "#{ELASTIC_SEARCH}/logstash-#{date}/_search"


### PR DESCRIPTION
The logging spec has been failing intermittently in the concourse
pipeline. e.g.

* [build 547](https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/integration-tests/jobs/apply-tests-live-1/builds/547)
* [build 533](https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/integration-tests/jobs/apply-tests-live-1/builds/533)
* [build 526](https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/integration-tests/jobs/apply-tests-live-1/builds/526)
* [build 517](https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/integration-tests/jobs/apply-tests-live-1/builds/517)

This commit is an experiment to see if a larger sleep delay makes
these intermittent failures go away.

If it does, subsequent commits will attempt to zero in on the
lowest delay which gives us consistently passing tests.

If it doesn't, we know the problem is something else, and we can
focus efforts elsewhere to find the real issue.