### PR TITLE
Increase delay for ingress 'happy path' test

### DIFF
--- a/smoke-tests/spec/ingress_spec.rb
+++ b/smoke-tests/spec/ingress_spec.rb
@@ -24,7 +24,7 @@ describe "nginx ingress", cluster: "live-1" do
         binding: binding
       )
       wait_for(namespace, "ingress", "ingress-smoketest-app-ing")
-      sleep 7 # Without this, the test fails
+      sleep 20 # Without this, the test fails
     end
 
     after do


### PR DESCRIPTION
Around four times per day, we see this, in the integration-tests
pipeline;

```
  1) nginx ingress when ingress is deployed returns 200 for http get
     Failure/Error: result = URI.open(url)

     OpenURI::HTTPError:
       503 Service Unavailable
     # ./spec/ingress_spec.rb:35:in `block (3 levels) in <top (required)>'

  Finished in 5 minutes 57 seconds (files took 1.63 seconds to load)
  16 examples, 1 failure, 2 pending

  Failed examples:

  rspec ./spec/ingress_spec.rb:34 # nginx ingress when ingress is deployed returns 200 for http get
```

Usually, a subsquent test run will pass without any failures.

This commit is an attempt to reduce the frequency of these
failures, hopefully to zero.