### PR TITLE
Fluentd smoketest

### DIFF
--- a/smoke-tests/spec/fluentd_spec.rb
+++ b/smoke-tests/spec/fluentd_spec.rb
@@ -6,7 +6,7 @@ describe "Log shipping" do
   # gets all node IPs, then the fluentd pods, compares the lists
   it "runs fluentd" do
     cluster_nodes = get_cluster_ips()
-    app_nodes = get_app_nodes("logging", "fluentd-es")
+    app_nodes = get_app_node_ips("logging", "fluentd-es")
     expect(cluster_nodes).to eq(app_nodes)
   end
 

--- a/smoke-tests/spec/fluentd_spec.rb
+++ b/smoke-tests/spec/fluentd_spec.rb
@@ -1,0 +1,13 @@
+require "spec_helper"
+
+# We want a fluentd pod running on each node, including masters
+describe "Log shipping" do
+
+  # gets the node IPs, then the 
+  it "runs fluentd" do
+    nodes = `kubectl get nodes -o json -o jsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}' --sort-by='.status.addresses[?(@.type=="InternalIP")].address'`.chomp
+    pods = `kubectl -n logging get pods -o json -o jsonpath='{..items[*].status.hostIP}' --field-selector status.phase='Running' --selector app=='fluentd-es' --sort-by='.status.hostIP'`.chomp
+    expect(nodes).to eq(pods)
+  end
+
+end

--- a/smoke-tests/spec/fluentd_spec.rb
+++ b/smoke-tests/spec/fluentd_spec.rb
@@ -5,9 +5,9 @@ describe "Log shipping" do
 
   # gets all node IPs, then the fluentd pods, compares the lists
   it "runs fluentd" do
-    nodes = `kubectl get nodes -o json -o jsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}' --sort-by='.status.addresses[?(@.type=="InternalIP")].address'`.chomp
-    pods = `kubectl -n logging get pods -o json -o jsonpath='{..items[*].status.hostIP}' --field-selector status.phase='Running' --selector app=='fluentd-es' --sort-by='.status.hostIP'`.chomp
-    expect(nodes).to eq(pods)
+    cluster_nodes = get_cluster_ips()
+    app_nodes = get_app_nodes("logging", "fluentd-es")
+    expect(cluster_nodes).to eq(app_nodes)
   end
 
 end

--- a/smoke-tests/spec/kubernetes_helper.rb
+++ b/smoke-tests/spec/kubernetes_helper.rb
@@ -107,7 +107,7 @@ def get_pod_name(namespace, index, options = "")
 end
 
 # Get all nodes an app runs on
-def get_app_nodes(namespace, app, status = "Running")
+def get_app_node_ips(namespace, app, status = "Running")
   `kubectl -n #{namespace} get pods -o json -o jsonpath='{..items[*].status.hostIP}' --field-selector status.phase='#{status}' --selector app=='#{app}' --sort-by='.status.hostIP'`.chomp
 end
 

--- a/smoke-tests/spec/kubernetes_helper.rb
+++ b/smoke-tests/spec/kubernetes_helper.rb
@@ -105,3 +105,13 @@ end
 def get_pod_name(namespace, index, options = "")
   `kubectl get pods -n #{namespace} #{options} 2>/dev/null | awk 'FNR == #{index + 1} {print $1}'`.chomp
 end
+
+# Get all nodes an app runs on
+def get_app_nodes(namespace, app, status = "Running")
+  `kubectl -n #{namespace} get pods -o json -o jsonpath='{..items[*].status.hostIP}' --field-selector status.phase='#{status}' --selector app=='#{app}' --sort-by='.status.hostIP'`.chomp
+end
+
+# Get the internal IPs of all cluster VMs
+def get_cluster_ips
+  `kubectl get nodes -o json -o jsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}' --sort-by='.status.addresses[?(@.type=="InternalIP")].address'`.chomp
+end


### PR DESCRIPTION
**Why**
https://github.com/ministryofjustice/cloud-platform/issues/1134

Test with e.g. `kubectl -n logging edit daemonset fluentd-es` and change the `image` with something invalid, this will kill just 1 pod as the daemonset will not continue with the change 