### PR TITLE
Add a test that all fluentd containers are running

### DIFF
--- a/smoke-tests/spec/fluentd_spec.rb
+++ b/smoke-tests/spec/fluentd_spec.rb
@@ -10,4 +10,8 @@ describe "Log shipping" do
     expect(cluster_nodes).to eq(app_nodes)
   end
 
+  specify "all fluentd containers are running" do
+    pods = get_running_app_pods("logging", "fluentd-es")
+    expect(all_containers_running?(pods)).to eq(true)
+  end
 end

--- a/smoke-tests/spec/kubernetes_helper.rb
+++ b/smoke-tests/spec/kubernetes_helper.rb
@@ -101,6 +101,25 @@ def get_running_pod_name(namespace, index)
   get_pod_name(namespace, index, "--field-selector=status.phase=Running")
 end
 
+def get_pods(namespace)
+  JSON.parse(`kubectl -n #{namespace} get pods -o json`).fetch("items")
+end
+
+def get_running_app_pods(namespace, app)
+  get_pods(namespace)
+    .filter { |pod|  pod.dig("status", "phase") == "Running" }
+    .filter { |pod| pod.dig("metadata", "labels", "app") == app }
+end
+
+def all_containers_running?(pods)
+  all_container_states = pods.map { |pod| pod.dig("status", "containerStatuses") }
+    .flatten
+    .map { |container| container.fetch("state").keys }
+    .flatten
+
+  all_container_states.uniq == ["running"]
+end
+
 # Get the name of the Nth pod in the namespace
 def get_pod_name(namespace, index, options = "")
   `kubectl get pods -n #{namespace} #{options} 2>/dev/null | awk 'FNR == #{index + 1} {print $1}'`.chomp


### PR DESCRIPTION
This test currently fails in live-1, but passes on a test cluster, which is
expected because one fluentd container is currently CrashLoopBackoff