### PR TITLE
Increase fluentd container memory resource limit

### DIFF
--- a/helm-charts/fluentd-es/templates/daemonset.yaml
+++ b/helm-charts/fluentd-es/templates/daemonset.yaml
@@ -55,7 +55,7 @@ spec:
         resources:
           limits:
             cpu: 250m
-            memory: 500Mi
+            memory: 1000Mi
           requests:
             cpu: 100m
             memory: 200Mi


### PR DESCRIPTION
Fluentd containers on the master nodes are getting
OOM killed. This change increases the allowed
memory from 500Mi to 1000Mi to attempt to fix this