### PR TITLE
Accomodate paginated list_roles responses

### DIFF
--- a/smoke-tests/spec/kiam_helper.rb
+++ b/smoke-tests/spec/kiam_helper.rb
@@ -25,8 +25,7 @@ class KiamRole
 
   def fetch_or_create_role
     role = Aws::IAM::Role.new(client: client, name: role_name)
-
-    if client.list_roles.roles.find { |r| r.role_name == role_name }
+    if list_roles(client).find { |r| r.role_name == role_name }
       role.load
       ensure_cluster_nodes_are_trusted(role)
     else
@@ -47,6 +46,21 @@ class KiamRole
   end
 
   private
+
+  def list_roles(client)
+    rtn = []
+    is_truncated = true
+    marker = nil
+
+    while is_truncated
+      roles = client.list_roles(marker: marker)
+      rtn += roles.roles
+      is_truncated = roles.is_truncated
+      marker = roles.marker
+    end
+
+    rtn
+  end
 
   # If the role was created during a test run for a different cluster, the current
   # cluster's nodes will not be included as principals in the role's trust


### PR DESCRIPTION
This test calls list_roles. It started failing
because we (MoJ Digital) hit 100 roles in the AWS
account, which is the maximum number of roles we
can get in the response. 

This change keeps calling list_roles until all 
defined roles have been returned, which makes the
test pass again.