### PR TITLE
Tidy up the kubernetes_helper methods

### DIFF
--- a/smoke-tests/spec/fluentd_spec.rb
+++ b/smoke-tests/spec/fluentd_spec.rb
@@ -2,10 +2,9 @@ require "spec_helper"
 
 # We want a fluentd pod running on each node, including masters
 describe "Log shipping" do
-
   # gets all node IPs, then the fluentd pods, compares the lists
   it "runs fluentd" do
-    cluster_nodes = get_cluster_ips()
+    cluster_nodes = get_cluster_ips
     app_nodes = get_app_node_ips("logging", "fluentd-es")
     expect(cluster_nodes).to eq(app_nodes)
   end

--- a/smoke-tests/spec/kiam_helper.rb
+++ b/smoke-tests/spec/kiam_helper.rb
@@ -88,7 +88,7 @@ class KiamRole
         {
           Effect: "Allow",
           Principal: {
-            AWS: ["#{cluster_nodes_policy_principal}"]
+            AWS: [cluster_nodes_policy_principal.to_s],
           },
           Action: "sts:AssumeRole",
         },

--- a/smoke-tests/spec/kiam_helper.rb
+++ b/smoke-tests/spec/kiam_helper.rb
@@ -187,13 +187,13 @@ def create_deployment(args)
 
   `#{cmd}`
 
-  pod = ""
+  pods = []
 
   60.times do
-    pod = get_running_pod_name(namespace, 1)
-    break if pod.length > 0
+    pods = get_running_pods(namespace)
+    break if pods.count > 0
     sleep 1
   end
 
-  pod
+  pods.first.dig("metadata", "name")
 end

--- a/smoke-tests/spec/kubernetes_helper.rb
+++ b/smoke-tests/spec/kubernetes_helper.rb
@@ -125,6 +125,12 @@ def get_pod_name(namespace, index, options = "")
   `kubectl get pods -n #{namespace} #{options} 2>/dev/null | awk 'FNR == #{index + 1} {print $1}'`.chomp
 end
 
+def get_pod_matching_name(namespace, prefix)
+  get_pods(namespace)
+    .filter { |pod| pod.dig("metadata", "name") =~ %r{^#{prefix}} }
+    .first
+end
+
 # Get all nodes an app runs on
 def get_app_node_ips(namespace, app, status = "Running")
   get_running_app_pods(namespace, app)

--- a/smoke-tests/spec/kubernetes_helper.rb
+++ b/smoke-tests/spec/kubernetes_helper.rb
@@ -107,7 +107,7 @@ end
 
 def get_running_app_pods(namespace, app)
   get_pods(namespace)
-    .filter { |pod|  pod.dig("status", "phase") == "Running" }
+    .filter { |pod| pod.dig("status", "phase") == "Running" }
     .filter { |pod| pod.dig("metadata", "labels", "app") == app }
 end
 

--- a/smoke-tests/spec/kubernetes_helper.rb
+++ b/smoke-tests/spec/kubernetes_helper.rb
@@ -97,18 +97,18 @@ def get_pod_logs(namespace, pod_name)
   `kubectl -n #{namespace} logs #{pod_name}`
 end
 
-def get_running_pod_name(namespace, index)
-  get_pod_name(namespace, index, "--field-selector=status.phase=Running")
-end
-
 def get_pods(namespace)
   JSON.parse(`kubectl -n #{namespace} get pods -o json`).fetch("items")
 end
 
 def get_running_app_pods(namespace, app)
+  get_running_pods(namespace)
+    .filter { |pod| pod.dig("metadata", "labels", "app") == app }
+end
+
+def get_running_pods(namespace)
   get_pods(namespace)
     .filter { |pod| pod.dig("status", "phase") == "Running" }
-    .filter { |pod| pod.dig("metadata", "labels", "app") == app }
 end
 
 def all_containers_running?(pods)
@@ -118,11 +118,6 @@ def all_containers_running?(pods)
     .flatten
 
   all_container_states.uniq == ["running"]
-end
-
-# Get the name of the Nth pod in the namespace
-def get_pod_name(namespace, index, options = "")
-  `kubectl get pods -n #{namespace} #{options} 2>/dev/null | awk 'FNR == #{index + 1} {print $1}'`.chomp
 end
 
 def get_pod_matching_name(namespace, prefix)

--- a/smoke-tests/spec/logging_spec.rb
+++ b/smoke-tests/spec/logging_spec.rb
@@ -24,7 +24,7 @@ describe "Log collection", cluster: "live-1" do
     # consistently, but it's possible it may break unexpectedly, at some point.
 
     sleep 120 # TODO: this is an experimental change (from 60), to see if a longer sleep fixes
-              #       intermittent pipeline failures
+    #       intermittent pipeline failures
 
     date = Date.today.strftime("%Y.%m.%d")
     search_url = "#{ELASTIC_SEARCH}/logstash-#{date}/_search"

--- a/smoke-tests/spec/logging_spec.rb
+++ b/smoke-tests/spec/logging_spec.rb
@@ -35,7 +35,8 @@ describe "Log collection", cluster: "live-1" do
       search_url: search_url,
     })
 
-    pod_name = get_pod_name(namespace, 2) # We created 2 jobs, so the pod we want is the 2nd one
+    pod = get_pod_matching_name(namespace, "smoketest-logging-job")
+    pod_name = pod.dig("metadata", "name")
     json = get_pod_logs(namespace, pod_name) # results from the elasticsearch query
     hash = JSON.parse(json)
     total_hits = hash.fetch("hits").fetch("total")


### PR DESCRIPTION
There were a variety of different ways of getting pod information from the
cluster, in this helper file. Some of these were hacky, some were just hard to
read.

This change rationalises these methods, so that they all work in roughly the
same way (grab all the pod data as JSON and dig into it for the bits you need).
This should make it easier to create new methods by composing existing ones, as
well as making it easier for people to see what's going on, when reading the
code.