### PR TITLE
Add live-1 tag to namespace annotation test

### DIFF
--- a/smoke-tests/spec/namespace_annotations_spec.rb
+++ b/smoke-tests/spec/namespace_annotations_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe "namespaces" do
+describe "namespaces", cluster: "live-1" do
   # Monitoring is automatically set up for all namespaces which have specific
   # annotations. So, if any namespaces don't have any, it's a problem.
   specify "must have annotations" do


### PR DESCRIPTION
This was failing all test clusters that applied annotations via the cloud-platform-environment pipeline. By adding this cluster tag, we can ensure the test will only run against live-1