### PR TITLE
Adjust resource request/limit for fluentd pods

### DIFF
--- a/helm-charts/fluentd-es/templates/daemonset.yaml
+++ b/helm-charts/fluentd-es/templates/daemonset.yaml
@@ -54,11 +54,11 @@ spec:
           value: {{ .Values.fluent_kubernetes_cluster_name }}
         resources:
           limits:
-            cpu: 250m
+            cpu: 500m
             memory: 1000Mi
           requests:
-            cpu: 100m
-            memory: 200Mi
+            cpu: 10m
+            memory: 400Mi
         volumeMounts:
         - name: varlog
           mountPath: /var/log


### PR DESCRIPTION
This change had no effect:
https://github.com/ministryofjustice/cloud-platform-environments/commit/b79fb5505fd3689613c813752aafdd2d23c11fcb#diff-16341c618c10e25b6523a3767819dc66

This is because values in the helm chart specify
resources for the fluentd containers, overriding
the namespace default values in the limitrange.

This change alters the resource requests and
limits for the logging containers to use values
which are more representative of how they run in
production.

After this change, the daemonset will need to be
redeployed using a targeted terraform taint &
apply