### PR TITLE
upgrade cert-manager

### DIFF
--- a/terraform/cloud-platform-components/cert-manager.tf
+++ b/terraform/cloud-platform-components/cert-manager.tf
@@ -154,16 +154,6 @@ resource "null_resource" "cert_manager_issuers" {
   }
 }
 
-// This is likely not needed beyond the 0.6 upgrade, see:
-//   http://docs.cert-manager.io/en/latest/admin/upgrading/upgrading-0.4-0.5.html
-// resource "null_resource" "cert_manager_webhook_label" {
-//  provisioner "local-exec" {
-//    command = "kubectl label --overwrite namespace cert-manager 'certmanager.k8s.io/disable-validation=true'"
-//  }
-//
-//  depends_on = ["helm_release.cert-manager"]
-// }
-
 resource "null_resource" "cert_manager_monitoring" {
   depends_on = ["helm_release.prometheus_operator", "helm_release.cert-manager"]
 

--- a/terraform/cloud-platform-components/cert-manager.tf
+++ b/terraform/cloud-platform-components/cert-manager.tf
@@ -1,5 +1,5 @@
 locals {
-  cert-manager-version = "v0.6.6"
+  cert-manager-version = "0.8.1"
 }
 
 resource "kubernetes_namespace" "cert_manager" {
@@ -66,7 +66,7 @@ resource "aws_iam_role_policy" "cert_manager" {
 }
 
 data "http" "cert-manager-crds" {
-  url = "https://raw.githubusercontent.com/jetstack/cert-manager/release-${replace(local.cert-manager-version, "/^v?(\\d+\\.\\d+)\\.\\d+$/", "$1")}/deploy/manifests/00-crds.yaml"
+  url = "https://raw.githubusercontent.com/jetstack/cert-manager/v${local.cert-manager-version}/deploy/manifests/00-crds.yaml"
 }
 
 resource "null_resource" "cert-manager-crds" {
@@ -95,7 +95,7 @@ EOS
 
 resource "helm_release" "cert-manager" {
   name          = "cert-manager"
-  chart         = "stable/cert-manager"
+  chart         = "jetstack/cert-manager"
   namespace     = "cert-manager"
   version       = "${local.cert-manager-version}"
   recreate_pods = true
@@ -149,20 +149,20 @@ resource "null_resource" "cert_manager_issuers" {
   }
 
   triggers {
-    contents_production = "${sha1(file("${path.module}/templates/cert-manager/letsencrypt-staging.yaml"))}"
+    contents_production = "${sha1(file("${path.module}/templates/cert-manager/letsencrypt-production.yaml"))}"
     contents_staging    = "${sha1(file("${path.module}/templates/cert-manager/letsencrypt-staging.yaml"))}"
   }
 }
 
 // This is likely not needed beyond the 0.6 upgrade, see:
 //   http://docs.cert-manager.io/en/latest/admin/upgrading/upgrading-0.4-0.5.html
-resource "null_resource" "cert_manager_webhook_label" {
-  provisioner "local-exec" {
-    command = "kubectl label --overwrite namespace cert-manager 'certmanager.k8s.io/disable-validation=true'"
-  }
-
-  depends_on = ["helm_release.cert-manager"]
-}
+// resource "null_resource" "cert_manager_webhook_label" {
+//  provisioner "local-exec" {
+//    command = "kubectl label --overwrite namespace cert-manager 'certmanager.k8s.io/disable-validation=true'"
+//  }
+//
+//  depends_on = ["helm_release.cert-manager"]
+// }
 
 resource "null_resource" "cert_manager_monitoring" {
   depends_on = ["helm_release.prometheus_operator", "helm_release.cert-manager"]


### PR DESCRIPTION
**Why**
https://github.com/ministryofjustice/cloud-platform/issues/1161

**WARNING**: the repo has moved, but as we're not on the latest release we'll need to check 2 locations: 
https://github.com/helm/charts/tree/master/stable/cert-manager
and
https://hub.helm.sh/charts/jetstack/cert-manager

**HOWTO**
using the tools image, to ensure all the bits are in place
```
make tools-shell
kops export kubecfg <cluster>
helm ls cert-manager
helm repo add jetstack https://charts.jetstack.io
helm repo update
```
a `helm search cert-manager` must return results from both repos now, one 0.6 the other at 0.10
```
terraform apply --target=helm_release.cert-manager --target=null_resource.cert-manager-crds --target=null_resource.cert_manager_webhook_label
```
at this point, the chart deleted the LE ClusterIssuers, but terraform wasn't aware so also had to cleanup and
```
terraform apply --target=null_resource.cert_manager_issuers
```
the deployment must be ready, no errors in the cert-manager pod

**Smoke-test**
```
git checkout add/cert-manager-test
make shell
rspec spec/cert_manager_spec.rb
```