### PR TITLE
Add ModSec Intergration Test

### DIFF
--- a/smoke-tests/spec/fixtures/modsec-integrationtest.yaml.erb
+++ b/smoke-tests/spec/fixtures/modsec-integrationtest.yaml.erb
@@ -1,13 +1,13 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: modsec-smoketest-app
+  name: modsec-integrationtest-app
 spec:
   replicas: 1
   template:
     metadata:
       labels:
-        app: modsec-smoketest-app
+        app: modsec-integrationtest-app
     spec:
       containers:
       - name: nginx
@@ -18,21 +18,21 @@ spec:
 kind: Service
 apiVersion: v1
 metadata:
-  name: modsec-smoketest-svc
+  name: modsec-integrationtest-svc
   labels:
-    app: modsec-smoketest-svc
+    app: modsec-integrationtest-svc
 spec:
   ports:
   - port: 80
     name: http
     targetPort: 8080
   selector:
-    app: modsec-smoketest-app
+    app: modsec-integrationtest-app
 ---
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: modsec-smoketest-app-ing
+  name: modsec-integrationtest-app-ing
   annotations:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
@@ -50,6 +50,6 @@ spec:
       paths:
       - path: /
         backend:
-          serviceName: modsec-smoketest-svc
+          serviceName: modsec-integrationtest-svc
           servicePort: 80
 

--- a/smoke-tests/spec/fixtures/modsec-smoketest.yaml.erb
+++ b/smoke-tests/spec/fixtures/modsec-smoketest.yaml.erb
@@ -1,0 +1,55 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: modsec-smoketest-app
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: modsec-smoketest-app
+    spec:
+      containers:
+      - name: nginx
+        image: bitnami/nginx
+        ports:
+        - containerPort: 8080
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: modsec-smoketest-svc
+  labels:
+    app: modsec-smoketest-svc
+spec:
+  ports:
+  - port: 80
+    name: http
+    targetPort: 8080
+  selector:
+    app: modsec-smoketest-app
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: modsec-smoketest-app-ing
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      Include /etc/nginx/modsecurity/modsecurity.conf
+      Include /etc/nginx/owasp-modsecurity-crs/nginx-modsecurity.conf
+      SecRuleEngine On
+spec:
+  tls:
+  - hosts:
+    - <%= host %>
+  rules:
+  - host: <%= host %>
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: modsec-smoketest-svc
+          servicePort: 80
+

--- a/smoke-tests/spec/kubernetes_helper.rb
+++ b/smoke-tests/spec/kubernetes_helper.rb
@@ -134,3 +134,8 @@ end
 def get_cluster_ips
   `kubectl get nodes -o json -o jsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}' --sort-by='.status.addresses[?(@.type=="InternalIP")].address'`.chomp
 end
+
+#Set the enable-modsecurity flag to false on the ingress annotation
+def set_modsec_ing_annotation_false(namespace, ingress_name)
+  `kubectl -n #{namespace} annotate --overwrite ingresses/#{ingress_name} nginx.ingress.kubernetes.io/enable-modsecurity='false'`.chomp
+end

--- a/smoke-tests/spec/modsec_spec.rb
+++ b/smoke-tests/spec/modsec_spec.rb
@@ -1,0 +1,29 @@
+require "spec_helper"
+
+describe "modsec ingress" do
+  let(:namespace) { "smoketest-modsec-#{readable_timestamp}" }
+  let(:host) { "#{namespace}.apps.#{current_cluster}" }
+  let(:url) { "https://#{host}?exec=/bin/bash" }
+
+  context "deploy modsec ingress" do
+    before do
+      create_namespace(namespace)
+
+      apply_template_file(
+        namespace: namespace,
+        file: "spec/fixtures/modsec-smoketest.yaml.erb",
+        binding: binding,
+      )
+      wait_for(namespace, "ingress", "modsec-smoketest-app-ing")
+      sleep 20
+    end
+
+    it "gets a 403 Forbidden error" do
+      expect { URI.open(url) }.to raise_error(OpenURI::HTTPError, "403 Forbidden")
+    end
+
+    after do
+      delete_namespace(namespace)
+    end
+  end
+end

--- a/smoke-tests/spec/modsec_spec.rb
+++ b/smoke-tests/spec/modsec_spec.rb
@@ -1,13 +1,14 @@
 require "spec_helper"
 
 describe "Testing modsec" do
-  let(:namespace) { "smoketest-modsec-#{readable_timestamp}" }
-  let(:host) { "#{namespace}.apps.#{current_cluster}" }
+  namespace = "smoketest-modsec-#{readable_timestamp}"
+  host = "#{namespace}.apps.#{current_cluster}"
+  ingress_name = "modsec-smoketest-app-ing"
+
   let(:good_url) { "https://#{host}" }
   let(:bad_url) { "https://#{host}?exec=/bin/bash" }
-  let(:ingress_name) { "modsec-smoketest-app-ing" }
 
-  before do
+  before(:all) do
     create_namespace(namespace)
 
     apply_template_file(
@@ -19,7 +20,7 @@ describe "Testing modsec" do
     sleep 10
   end
 
-  after do
+  after(:all) do
     delete_namespace(namespace)
   end
 
@@ -28,6 +29,7 @@ describe "Testing modsec" do
       let(:url) { good_url }
 
       specify "request succeeds" do
+        binding.pry
         expect(URI.open(url).status).to eq(["200", "OK"])
       end
     end

--- a/smoke-tests/spec/modsec_spec.rb
+++ b/smoke-tests/spec/modsec_spec.rb
@@ -3,51 +3,63 @@ require "spec_helper"
 describe "Testing modsec" do
   let(:namespace) { "smoketest-modsec-#{readable_timestamp}" }
   let(:host) { "#{namespace}.apps.#{current_cluster}" }
-  let(:url1) { "https://#{host}" }
-  let(:url2) { "https://#{host}?exec=/bin/bash" }
+  let(:good_url) { "https://#{host}" }
+  let(:bad_url) { "https://#{host}?exec=/bin/bash" }
   let(:ingress_name) { "modsec-smoketest-app-ing" }
 
-  context "deploy ingress with modsec" do
-    before do
-      create_namespace(namespace)
+  before do
+    create_namespace(namespace)
 
-      apply_template_file(
-        namespace: namespace,
-        file: "spec/fixtures/modsec-smoketest.yaml.erb",
-        binding: binding,
-      )
-      wait_for(namespace, "ingress", ingress_name)
-      sleep 10
+    apply_template_file(
+      namespace: namespace,
+      file: "spec/fixtures/modsec-smoketest.yaml.erb",
+      binding: binding,
+    )
+    wait_for(namespace, "ingress", ingress_name)
+    sleep 10
+  end
+
+  after do
+    delete_namespace(namespace)
+  end
+
+  context "when modsec deployed" do  # this is the default behaviour
+    context "when the url is benign" do
+      let(:url) { good_url }
+
+      specify "request succeeds" do
+        expect(URI.open(url).status).to eq(["200", "OK"])
+      end
     end
 
-  context "when modsec deployed" do
-    it "URL benign and request successful" do
-      result = URI.open(url1)
-      expect(result.status).to eq(["200", "OK"])
-      delete_namespace(namespace)
-    end
+    context "when the url is malicious" do
+      let(:url) { bad_url }
 
-    it "URL malicious and request blocked" do
-      expect { URI.open(url2) }.to raise_error(OpenURI::HTTPError, "403 Forbidden")
-      delete_namespace(namespace)
+      specify "request is blocked" do
+        expect { URI.open(url) }.to raise_error(OpenURI::HTTPError, "403 Forbidden")
+      end
     end
   end
-  
+
   context "when modsec disabled" do
-    it "URL benign and request successful" do
+    before do
       set_modsec_ing_annotation_false(namespace, ingress_name)
       sleep 5
-      result = URI.open(url1)
-      expect(result.status).to eq(["200", "OK"])
-      delete_namespace(namespace)
     end
 
-    it "URL malicious and request successful" do
-      set_modsec_ing_annotation_false(namespace, ingress_name)
-      sleep 5
-      result = URI.open(url2)
-      expect(result.status).to eq(["200", "OK"])
-      delete_namespace(namespace)
+    context "when the url is benign" do
+      let(:url) { good_url }
+
+      specify "request succeeds" do
+        expect(URI.open(url).status).to eq(["200", "OK"])
+      end
+    end
+
+    context "when the url is malicious" do
+      let(:url) { bad_url }
+
+      specify "request succeeds" do
+        expect(URI.open(url).status).to eq(["200", "OK"])
       end
     end
   end

--- a/smoke-tests/spec/modsec_spec.rb
+++ b/smoke-tests/spec/modsec_spec.rb
@@ -1,9 +1,9 @@
 require "spec_helper"
 
 describe "Testing modsec" do
-  namespace = "smoketest-modsec-#{readable_timestamp}"
+  namespace = "integrationtest-modsec-#{readable_timestamp}"
   host = "#{namespace}.apps.#{current_cluster}"
-  ingress_name = "modsec-smoketest-app-ing"
+  ingress_name = "modsec-integrationtest-app-ing"
 
   let(:good_url) { "https://#{host}" }
   let(:bad_url) { "https://#{host}?exec=/bin/bash" }
@@ -13,7 +13,7 @@ describe "Testing modsec" do
 
     apply_template_file(
       namespace: namespace,
-      file: "spec/fixtures/modsec-smoketest.yaml.erb",
+      file: "spec/fixtures/modsec-integrationtest.yaml.erb",
       binding: binding,
     )
     wait_for(namespace, "ingress", ingress_name)
@@ -29,7 +29,6 @@ describe "Testing modsec" do
       let(:url) { good_url }
 
       specify "request succeeds" do
-        binding.pry
         expect(URI.open(url).status).to eq(["200", "OK"])
       end
     end


### PR DESCRIPTION
This integration test is for testing ModSecurity.

The test creates a namespace and a deployment with an ingress.
The ModSec annotations are added to the ingress (during deployment via yaml) so all traffic is inspected by Modsec before traffic can get to the application pod. 

The test tries to curl the URL with a 'exec=/bin/bash' which is classed as a level 5 malicious by ModSec.

The expected return from the test should be a '403 Forbidden'. 
