### PR TITLE
do not delete CRDS

### DIFF
--- a/terraform/cloud-platform-components/cert-manager.tf
+++ b/terraform/cloud-platform-components/cert-manager.tf
@@ -81,11 +81,8 @@ EOS
   provisioner "local-exec" {
     when = "destroy"
 
-    command = <<EOS
-kubectl delete -n cert-manager -f - <<EOF
-${data.http.cert-manager-crds.body}
-EOF
-EOS
+    # destroying the CRDs also deletes all resources of type "certificate" (not the actual certs, those are in secrets of type "tls")
+    command = "exit 0"
   }
 
   triggers {


### PR DESCRIPTION
**Why**
when running `terraform apply` on a null_resource, it will do a destroy/create; we need a smarted upgrade method