### PR TITLE
Change fluentd containers resource requests

### DIFF
--- a/helm-charts/fluentd-es/templates/daemonset.yaml
+++ b/helm-charts/fluentd-es/templates/daemonset.yaml
@@ -57,8 +57,8 @@ spec:
             cpu: 250m
             memory: 1000Mi
           requests:
-            cpu: 100m
-            memory: 200Mi
+            cpu: 10m
+            memory: 300Mi
         volumeMounts:
         - name: varlog
           mountPath: /var/log


### PR DESCRIPTION
* reduce CPU request from 100m to 10m
* increase memory request from 200Mi to 300Mi

This is closer to the resources the pods use on live-1, and will
enable us to reduce the resourcequota CPU request limit for the
namespace.