### PR TITLE
Make audit-1 cluster source code represent actual deployment

### DIFF
--- a/terraform/global-resources/elasticsearch.tf
+++ b/terraform/global-resources/elasticsearch.tf
@@ -292,7 +292,7 @@ resource "aws_elasticsearch_domain" "audit_1" {
 
   cluster_config {
     instance_type          = "m4.xlarge.elasticsearch"
-    instance_count         = "3"
+    instance_count         = "4"
     zone_awareness_enabled = true
   }
 


### PR DESCRIPTION
When applying audit-1 terraform I noticed that the current deployed status was 4 nodes. 