### PR TITLE
Reduce fluentd pods memory requests to 200Mi

### DIFF
--- a/helm-charts/fluentd-es/templates/daemonset.yaml
+++ b/helm-charts/fluentd-es/templates/daemonset.yaml
@@ -58,7 +58,7 @@ spec:
             memory: 1000Mi
           requests:
             cpu: 10m
-            memory: 400Mi
+            memory: 200Mi
         volumeMounts:
         - name: varlog
           mountPath: /var/log


### PR DESCRIPTION
The change to 400Mi means that the total memory requested by the
logging namespace exceeds the 12G allowed, meaning some fluentd
pods are not running . We're not using that memory anyway, so
this is not helpful.

This commit puts the memory request per container back to the
previous value of 200Mi