### PR TITLE
Adding admission control for pods

### DIFF
--- a/terraform/cloud-platform-components/templates/opa/values.yaml.tpl
+++ b/terraform/cloud-platform-components/templates/opa/values.yaml.tpl
@@ -34,6 +34,10 @@ admissionControllerRules:
     apiGroups: [""]
     apiVersions: ["v1"]
     resources: ["services"]
+  - operations: ["CREATE", "UPDATE"]
+    apiGroups: [""]
+    apiVersions: ["v1"]
+    resources: ["pods"]
 
 # Controls a PodDisruptionBudget for the OPA pod. Suggested use if having opa
 # always running for admission control is important


### PR DESCRIPTION
What and Why:
Adding admission control restrictions to pod resource to restrict the kinds of operations and resources that are subject to OPA.

Next steps to:
https://github.com/ministryofjustice/cloud-platform-infrastructure/pull/396

Related to: https://github.com/ministryofjustice/cloud-platform/issues/1028