### PR TITLE
Add disable alerts

### DIFF
--- a/create-cluster.rb
+++ b/create-cluster.rb
@@ -77,11 +77,9 @@ def install_components(cluster_name)
 end
 
 def disable_alerts
-  # This will disable high-priority pagerduty alarms for your cluster by replacing the token XXXXX with a dummy value 
-  # in line pagerduty_config = "XXXXX" in your working terraform.tfvars file.
+  # This will disable high-priority pagerduty alarms for your cluster by replacing the pagerduty_config token XXXXX with a dummy value
   `sed -i 's/pagerduty_config = ".*"/pagerduty_config = "dummydummy"/g' terraform/cloud-platform-components/terraform.tfvars`
-  # This will disable lower priority alerts for your cluster by replacing the alertmanager slack webhook url XXXXX with a dummy value 
-  # in line cloud_platform_slack_webhook = "XXXXX" in your working terraform.tfvars file.
+  # This will disable lower priority alerts for your cluster by replacing the alertmanager slack webhook url XXXXX with a dummy value
   `sed -i 's/cloud_platform_slack_webhook = ".*"/cloud_platform_slack_webhook = "dummydummy"/g' terraform/cloud-platform-components/terraform.tfvars`
 end
 

--- a/create-cluster.rb
+++ b/create-cluster.rb
@@ -59,6 +59,8 @@ def install_components(cluster_name)
   execute "cd #{dir}; rm -rf .terraform"
   switch_terraform_workspace(dir, cluster_name)
 
+  disable_alerts()
+
   # Ensure we have the latest helm charts for all the required components
   execute "helm init --client-only; helm repo update"
   # Without this step, you may get errors like this:
@@ -73,6 +75,11 @@ def install_components(cluster_name)
     log "Cluster components failed to install. Aborting."
     exit 1
   end
+end
+
+def disable_alerts
+  `sed -i 's/pagerduty_config = ".*"/pagerduty_config = "dummydummy"/g' terraform/cloud-platform-components/terraform.tfvars`
+  `sed -i 's/cloud_platform_slack_webhook = ".*"/cloud_platform_slack_webhook = "dummydummy"/g' terraform/cloud-platform-components/terraform.tfvars`
 end
 
 def wait_for_kops_validate

--- a/create-cluster.rb
+++ b/create-cluster.rb
@@ -80,7 +80,7 @@ def disable_alerts
   # This will disable high-priority pagerduty alarms for your cluster by replacing the token XXXXX with a dummy value 
   # in line pagerduty_config = "XXXXX" in your working terraform.tfvars file.
   `sed -i 's/pagerduty_config = ".*"/pagerduty_config = "dummydummy"/g' terraform/cloud-platform-components/terraform.tfvars`
-  # This will disavle lower priority alerts for your cluster by replacing the webhook url XXXXX with a dummy value 
+  # This will disable lower priority alerts for your cluster by replacing the alertmanager slack webhook url XXXXX with a dummy value 
   # in line cloud_platform_slack_webhook = "XXXXX" in your working terraform.tfvars file.
   `sed -i 's/cloud_platform_slack_webhook = ".*"/cloud_platform_slack_webhook = "dummydummy"/g' terraform/cloud-platform-components/terraform.tfvars`
 end

--- a/create-cluster.rb
+++ b/create-cluster.rb
@@ -77,9 +77,9 @@ def install_components(cluster_name)
 end
 
 def disable_alerts
-  # This will disable high-priority pagerduty alarms for your cluster by replacing the pagerduty_config token XXXXX with a dummy value
+  # This will disable high-priority pagerduty alarms for your cluster by replacing the pagerduty_config token with a dummy value
   `sed -i 's/pagerduty_config = ".*"/pagerduty_config = "dummydummy"/g' terraform/cloud-platform-components/terraform.tfvars`
-  # This will disable lower priority alerts for your cluster by replacing the alertmanager slack webhook url XXXXX with a dummy value
+  # This will disable lower priority alerts for your cluster by replacing the alertmanager slack webhook url with a dummy value
   `sed -i 's/cloud_platform_slack_webhook = ".*"/cloud_platform_slack_webhook = "dummydummy"/g' terraform/cloud-platform-components/terraform.tfvars`
 end
 

--- a/create-cluster.rb
+++ b/create-cluster.rb
@@ -58,7 +58,8 @@ def install_components(cluster_name)
   dir = "terraform/cloud-platform-components"
   execute "cd #{dir}; rm -rf .terraform"
   switch_terraform_workspace(dir, cluster_name)
-
+  
+  # Comment disable_alerts() to enable high priority - Pagerduty alarms and lower prority Slack alerts for your cluster
   disable_alerts()
 
   # Ensure we have the latest helm charts for all the required components

--- a/create-cluster.rb
+++ b/create-cluster.rb
@@ -77,11 +77,11 @@ def install_components(cluster_name)
 end
 
 def disable_alerts
-  # This will replace the value of pagerduty_config to a dummy value in your working terraform.tfvars file.
-  # Comment below command to enable high priority - Pagerduty alarms for your cluster
+  # This will disable high-priority pagerduty alarms for your cluster by replacing the token XXXXX with a dummy value 
+  # in line pagerduty_config = "XXXXX" in your working terraform.tfvars file.
   `sed -i 's/pagerduty_config = ".*"/pagerduty_config = "dummydummy"/g' terraform/cloud-platform-components/terraform.tfvars`
-  # This will change the slack webhook of alertmanager.  
-  # Comment below command to enable lower prority Slack alerts for your cluster
+  # This will disavle lower priority alerts for your cluster by replacing the webhook url XXXXX with a dummy value 
+  # in line cloud_platform_slack_webhook = "XXXXX" in your working terraform.tfvars file.
   `sed -i 's/cloud_platform_slack_webhook = ".*"/cloud_platform_slack_webhook = "dummydummy"/g' terraform/cloud-platform-components/terraform.tfvars`
 end
 

--- a/create-cluster.rb
+++ b/create-cluster.rb
@@ -58,8 +58,6 @@ def install_components(cluster_name)
   dir = "terraform/cloud-platform-components"
   execute "cd #{dir}; rm -rf .terraform"
   switch_terraform_workspace(dir, cluster_name)
-  
-  # Comment disable_alerts() to enable high priority - Pagerduty alarms and lower prority Slack alerts for your cluster
   disable_alerts()
 
   # Ensure we have the latest helm charts for all the required components
@@ -79,7 +77,11 @@ def install_components(cluster_name)
 end
 
 def disable_alerts
+  # This will replace the value of pagerduty_config to a dummy value in your working terraform.tfvars file.
+  # Comment below command to enable high priority - Pagerduty alarms for your cluster
   `sed -i 's/pagerduty_config = ".*"/pagerduty_config = "dummydummy"/g' terraform/cloud-platform-components/terraform.tfvars`
+  # This will change the slack webhook of alertmanager.  
+  # Comment below command to enable lower prority Slack alerts for your cluster
   `sed -i 's/cloud_platform_slack_webhook = ".*"/cloud_platform_slack_webhook = "dummydummy"/g' terraform/cloud-platform-components/terraform.tfvars`
 end
 


### PR DESCRIPTION
What:
Added script to find pagerduty_config and slack_webhook and replace with dummy values

Why:
To disable alerts when building test clusters by default. 