### PR TITLE
Add the jetstack helm repository, for cert-manager

### DIFF
--- a/terraform/cloud-platform-components/cert-manager.tf
+++ b/terraform/cloud-platform-components/cert-manager.tf
@@ -90,7 +90,7 @@ EOS
   }
 }
 
-resource "helm_repository" "jetstack" {
+data "helm_repository" "jetstack" {
   name = "jetstack"
   url  = "https://charts.jetstack.io"
 }

--- a/terraform/cloud-platform-components/cert-manager.tf
+++ b/terraform/cloud-platform-components/cert-manager.tf
@@ -90,9 +90,15 @@ EOS
   }
 }
 
+resource "helm_repository" "jetstack" {
+  name = "jetstack"
+  url  = "https://charts.jetstack.io"
+}
+
 resource "helm_release" "cert-manager" {
   name          = "cert-manager"
   chart         = "jetstack/cert-manager"
+  repository    = "${data.helm_repository.jetstack.metadata.0.name}"
   namespace     = "cert-manager"
   version       = "${local.cert-manager-version}"
   recreate_pods = true


### PR DESCRIPTION
We get cert-manager from the jetstack repository now (see commit
6681b514633c91703cabb51031cd4679aa7cb88c)

This means we need the jetstack helm repository, or we get failures like
this during the components install phase of creating a test cluster;

```

Error: Error applying plan:

1 error occurred:
       * helm_release.cert-manager: 1 error occurred:
       * helm_release.cert-manager: repo jetstack not found

```

This commit adds the helm repository, and uses it when installing
cert-manager.

Provider documentation is here:
https://www.terraform.io/docs/providers/helm/repository.html

fixes https://github.com/ministryofjustice/cloud-platform/issues/1267