### PR TITLE
Update makefile to pull specific tools image tag

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-TOOLS_IMAGE := ministryofjustice/cloud-platform-tools
+TOOLS_IMAGE := ministryofjustice/cloud-platform-tools:1.1
 
 tools-shell:
 	docker pull $(TOOLS_IMAGE)


### PR DESCRIPTION
The tools image has been updated so that it can be
used to run the cluster integration tests:

https://github.com/ministryofjustice/cloud-platform-tools-image/pull/35
https://github.com/ministryofjustice/cloud-platform-tools-image/pull/36

This change uses the correct version of the tools
image in the `make tools-shell` target, so that
the build script will automatically run the
integration tests on new test clusters