### PR TITLE
null_resource to add labels to kube-system

### DIFF
--- a/terraform/cloud-platform-components/opa.tf
+++ b/terraform/cloud-platform-components/opa.tf
@@ -42,7 +42,7 @@ resource "helm_release" "open-policy-agent" {
   }
 }
 
-# This label will prevent OPA to ignore kube-system from making policy decisions. 
+# By adding this label OPA will ignore kube-system for all policy decisions. 
 resource "null_resource" "kube_system_ns_label" {
   provisioner "local-exec" {
     command = "kubectl label ns kube-system 'openpolicyagent.org/webhook=ignore'"

--- a/terraform/cloud-platform-components/opa.tf
+++ b/terraform/cloud-platform-components/opa.tf
@@ -42,7 +42,7 @@ resource "helm_release" "open-policy-agent" {
   }
 }
 
-# This label will prevent OPA to ignore kube-system  This adds label to kube-system namespace.
+# This label will prevent OPA to ignore kube-system from making policy decisions. 
 resource "null_resource" "kube_system_ns_label" {
   provisioner "local-exec" {
     command = "kubectl label ns kube-system 'openpolicyagent.org/webhook=ignore'"

--- a/terraform/cloud-platform-components/opa.tf
+++ b/terraform/cloud-platform-components/opa.tf
@@ -28,6 +28,7 @@ resource "helm_release" "open-policy-agent" {
   version    = "1.8.0"
 
   depends_on = [
+    "null_resource.kube_system_ns_label",
     "kubernetes_namespace.opa",
     "null_resource.deploy",
   ]
@@ -38,6 +39,13 @@ resource "helm_release" "open-policy-agent" {
 
   lifecycle {
     ignore_changes = ["keyring"]
+  }
+}
+
+# This label will prevent OPA to ignore kube-system  This adds label to kube-system namespace.
+resource "null_resource" "kube_system_ns_label" {
+  provisioner "local-exec" {
+    command = "kubectl label ns kube-system 'openpolicyagent.org/webhook=ignore'"
   }
 }
 


### PR DESCRIPTION
What and why:
Adding labels to kube-system so OPA ignore kube-system namespace from policy decisions.

