### PR TITLE
Remove cluster nodes from role policy, after tests

### DIFF
--- a/smoke-tests/spec/constants.rb
+++ b/smoke-tests/spec/constants.rb
@@ -3,3 +3,5 @@ AWS = {
   account_id: "754256621582",
   region: "eu-west-2",
 }
+
+LIVE1 = "live-1.cloud-platform.service.justice.gov.uk"

--- a/smoke-tests/spec/kiam_spec.rb
+++ b/smoke-tests/spec/kiam_spec.rb
@@ -44,6 +44,10 @@ describe "kiam" do
     delete_namespace(namespace)
   end
 
+  after(:all) do
+    remove_cluster_nodes_from_trust_relationship(role_args, role)
+  end
+
   context "namespace has annotations" do
     let(:namespace_annotations) { {annotations: "iam.amazonaws.com/permitted=.*"} }
 


### PR DESCRIPTION
After the kiam tests have finished, remove the cluster's nodes from the
role policy trust relationships.

This avoids a problem where, after a cluster is deleted, its ARN in the
trust relationships list is replaced with a malformed value (AWS does this
by itself).

Pre-emptively removing the cluster from the trust  policy means this won't
happen.

The exception is live-1. We never remove live-1 nodes from the list, which
means we don't have to worry about the list size dropping to zero,  which
would complicate things.