### PR TITLE
Add a script to cleanly destroy a (test) cluster

### DIFF
--- a/destroy-cluster.sh
+++ b/destroy-cluster.sh
@@ -1,0 +1,52 @@
+#!/bin/bash -x
+
+set -euo pipefail
+
+# Edit this to specify the cluster to destroy
+CLUSTER=mourad-rds
+
+main() {
+  terraform_components
+  kops_cluster
+  terraform_base
+  terraform_workspaces
+}
+
+terraform_components() {
+  kops export kubecfg ${CLUSTER}.cloud-platform.service.justice.gov.uk
+  (
+    cd terraform/cloud-platform-components
+    terraform init
+    terraform workspace select ${CLUSTER}
+    # prometheus_operator often fails to delete cleanly if anything has
+    # happened to the open policy agent beforehand. Delete it first to
+    # avoid any issues
+    terraform destroy -target helm_release.prometheus_operator -auto-approve
+    terraform destroy -auto-approve
+  )
+}
+
+kops_cluster() {
+  kops delete cluster --name ${CLUSTER}.cloud-platform.service.justice.gov.uk --yes
+}
+
+terraform_base() {
+  (
+    cd terraform/cloud-platform
+    terraform init
+    terraform workspace select ${CLUSTER}
+    terraform destroy -auto-approve
+  )
+}
+
+terraform_workspaces() {
+  for dir in terraform/cloud-platform terraform/cloud-platform-components; do
+    (
+      cd ${dir}
+      terraform workspace select default
+      terraform workspace delete ${CLUSTER}
+    )
+  done
+}
+
+main


### PR DESCRIPTION
This script destroys a test cluster by reversing the steps used to
create it.

It also deletes the prometheus_operator helm release first, because
it's common to have problems with this if it happens concurrently
with deleting the rest of the components.
Finally, the script clears up terraform workspaces.

This script is deliberately NOT written to take a cluster name
as a command-line parameter, as an extra safety measure.