### PR TITLE
upgrade externals-dns to v0.5.17

### DIFF
--- a/terraform/cloud-platform-components/external-dns.tf
+++ b/terraform/cloud-platform-components/external-dns.tf
@@ -41,7 +41,7 @@ resource "helm_release" "external_dns" {
   name      = "external-dns"
   chart     = "stable/external-dns"
   namespace = "kube-system"
-  version   = "2.6.4"
+  version   = "12.6.4"
 
   values = [<<EOF
 image:
@@ -64,6 +64,12 @@ logLevel: info
 podAnnotations:
   iam.amazonaws.com/role: "${aws_iam_role.external_dns.name}"
 EOF
+  ]
+
+  depends_on = [
+    "null_resource.deploy",
+    "helm_release.kiam",
+    "helm_release.open-policy-agent",
   ]
 
   lifecycle {

--- a/terraform/cloud-platform-components/external-dns.tf
+++ b/terraform/cloud-platform-components/external-dns.tf
@@ -41,11 +41,11 @@ resource "helm_release" "external_dns" {
   name      = "external-dns"
   chart     = "stable/external-dns"
   namespace = "kube-system"
-  version   = "1.7.0"
+  version   = "2.6.4"
 
   values = [<<EOF
 image:
-  tag: v0.5.11
+  tag: 0.5.17-debian-9-r0
 sources:
   - service
   - ingress
@@ -64,12 +64,6 @@ logLevel: info
 podAnnotations:
   iam.amazonaws.com/role: "${aws_iam_role.external_dns.name}"
 EOF
-  ]
-
-  depends_on = [
-    "null_resource.deploy",
-    "helm_release.kiam",
-    "helm_release.open-policy-agent",
   ]
 
   lifecycle {


### PR DESCRIPTION
upgrade both chart and app version for external-dns

~ helm_release.external_dns
    values.0:   image:
                -  tag: v0.5.11
                +  tag: 0.5.17-debian-9-r0
                 sources:
                   - service
                   - ingress
                 provider: aws
                 aws:
    version:    "1.7.0" => "2.6.4"

This update required a taint and apply due to a known issue:

https://github.com/operator-framework/operator-lifecycle-manager/issues/952