### PR TITLE
Make 'KubePersistentVolumeFullInFourDays' rule warning not critical

### DIFF
--- a/terraform/cloud-platform-components/resources/prometheusrule-alerts/application-alerts.yaml
+++ b/terraform/cloud-platform-components/resources/prometheusrule-alerts/application-alerts.yaml
@@ -237,3 +237,18 @@ spec:
       for: 10m
       labels:
         severity: warning
+    - alert: KubePersistentVolumeFullInFourDays
+      annotations:
+        message: Based on recent sampling, the PersistentVolume claimed by {{`{{ $labels.persistentvolumeclaim }}`}} in Namespace {{`{{ $labels.namespace }}`}} is expected to fill up within four days. Currently {{`{{ printf "%0.2f" $value }}`}}% is available.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumefullinfourdays
+      expr: |-
+        100 * (
+          kubelet_volume_stats_available_bytes{job="kubelet"}
+            /
+          kubelet_volume_stats_capacity_bytes{job="kubelet"}
+        ) < 15
+        and
+        predict_linear(kubelet_volume_stats_available_bytes{job="kubelet"}[6h], 4 * 24 * 3600) < 0
+      for: 5m
+      labels:
+        severity: warning

--- a/terraform/cloud-platform-components/templates/prometheus-operator.yaml.tpl
+++ b/terraform/cloud-platform-components/templates/prometheus-operator.yaml.tpl
@@ -110,6 +110,10 @@ alertmanager:
           alertname: PodIsRestartingFrequently
         receiver: 'null'
       - match:
+          alertname: KubePersistentVolumeFullInFourDay
+        receiver: 'null'
+      
+      - match:
           severity: critical
         receiver: pager-duty-high-priority
       ${indent(6, alertmanager_routes)}


### PR DESCRIPTION
The KubePersistentVolumeFullInFourDays rule is currently set to `critical`, meaning it will alarm out of hours. This change sends the default alert to null and adds the same rule to our own application alerts manifest sending all alerts to slack as a `warning`. 