### PR TITLE
Upgrade ingress-controller to latest version

### DIFF
--- a/terraform/cloud-platform-components/nginx-ingress-acme.tf
+++ b/terraform/cloud-platform-components/nginx-ingress-acme.tf
@@ -23,7 +23,7 @@ resource "helm_release" "nginx_ingress_acme" {
   name      = "nginx-ingress-acme"
   chart     = "stable/nginx-ingress"
   namespace = "ingress-controllers"
-  version   = "v1.3.1"
+  version   = "v1.24.0"
 
   values = [<<EOF
 controller:
@@ -66,7 +66,6 @@ controller:
       "kubernetes_service_port": "$service_port",
       "proxy_upstream_name": "$proxy_upstream_name",
       "proxy_protocol_addr": "$proxy_protocol_addr",
-      "real_ip": "$the_real_ip",
       "remote_addr": "$remote_addr",
       "remote_user": "$remote_user",
       "request_id": "$req_id",


### PR DESCRIPTION
This is related to https://github.com/ministryofjustice/cloud-platform/issues/1290

Upgrade ingress-controller to latest version

    Chart version: 1.24.0
    appVersion: 0.26.1

    Removed $the_real_ip variable  as it was removed from template and default log_format from v0.26.0