### PR TITLE
Skip all mod_security tests

### DIFF
--- a/smoke-tests/README.md
+++ b/smoke-tests/README.md
@@ -12,6 +12,9 @@ The smoke tests will run inside a docker container against your current Kubernet
 - `docker`
 - `cluster-admin` access to a Cloud Platform cluster
 - `aws-credentials` your aws credentials must be located in the default location `${HOME}/.aws`
+- The following environment variables must be set:
+      AWS_PROFILE=moj-cp
+      AWS_REGION=eu-west-2
 
 ### Build or pull the image
 You'll need to have pulled the image locally, you can do this with the following:

--- a/smoke-tests/spec/modsec_spec.rb
+++ b/smoke-tests/spec/modsec_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe "Testing modsec" do
+xdescribe "Testing modsec" do
   namespace = "integrationtest-modsec-#{readable_timestamp}"
   host = "#{namespace}.apps.#{current_cluster}"
   ingress_name = "modsec-integrationtest-app-ing"


### PR DESCRIPTION
There is a problem in the interaction between the latest version of
ingress-controller and mod_security. So, these tests need to be disabled
until this is resolved.