### PR TITLE
Remove file ModSecurity.conf file load

### DIFF
--- a/smoke-tests/spec/fixtures/modsec-integrationtest.yaml.erb
+++ b/smoke-tests/spec/fixtures/modsec-integrationtest.yaml.erb
@@ -37,7 +37,6 @@ metadata:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
-      Include /etc/nginx/modsecurity/modsecurity.conf
       Include /etc/nginx/owasp-modsecurity-crs/nginx-modsecurity.conf
       SecRuleEngine On
 spec:


### PR DESCRIPTION
The current set up causes the following error:
Error: exit status 1
2019/10/09 09:28:16 [emerg] 113#113: "modsecurity_rules" directive Rule id: 200000 is duplicated
 in /tmp/nginx-cfg152497997:41944
The change below loads the modsecurity.conf file when the true flag is set to enable modsecurity and there is no need to reference is separately.
https://github.com/kubernetes/ingress-nginx/pull/4080/files.

The current setup also breaks ingress-controllers and they can not be recycled. 