### PR TITLE
Remove exlusion of cert-manager test

### DIFF
--- a/smoke-tests/spec/cert_manager_spec.rb
+++ b/smoke-tests/spec/cert_manager_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-xdescribe "cert-manager" do
+describe "cert-manager" do
   let(:namespace) { "cert-manager-test-#{random_string}" }
 
   before do


### PR DESCRIPTION
We were able to ascertain that the cert manager fails were a global issue in the cluster and not caused by a faulty test.