### PR TITLE
Add live-1 tag to the external-dns test

### DIFF
--- a/smoke-tests/spec/external_dns_spec.rb
+++ b/smoke-tests/spec/external_dns_spec.rb
@@ -1,6 +1,7 @@
 require "spec_helper"
 
-describe "external DNS" do
+# This test can only be ran against live-1. Test clusters do not have enough privileges.
+describe "external DNS", cluster: "live-1" do
   namespace = "integrationtest-dns-#{readable_timestamp}"
   zone = nil
   parent_zone = nil

--- a/terraform/cloud-platform-components/resources/prometheusrule-alerts/Custom-Alerts.md
+++ b/terraform/cloud-platform-components/resources/prometheusrule-alerts/Custom-Alerts.md
@@ -428,3 +428,45 @@ $ kubectl logs <cronjob-name> -n logging
 ```
 
 The following links have more information on [Kubernetes Cronjobs](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/) and [Kubernetes Jobs](https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/)
+
+## Nginx Config Reload Failure
+
+```
+NginxConfigReloadFailure
+Severity: Critical
+```
+
+This alert is triggered when the nginx config fails to reload on an ingress-controller pod.
+
+Expression:
+```
+nginx_ingress_controller_config_last_reload_successful == 0
+```
+
+### Action
+
+Check why nginx config is not able to reload using the below:
+
+The following two [`stern`](https://github.com/wercker/stern) commands can be run to confirm config is not reloading and for any errors marked as `[emerg]` which means the system is in an unusable state and requires immediate attention.
+
+```
+stern --namespace ingress-controllers nginx-ingress-acme-controller | grep "Unexpected failure reloading the backend"
+stern --namespace ingress-controllers nginx-ingress-acme-controller | grep emerg
+```
+
+You can also run the following query on Kibana to check for the error:
+
+`kubernetes.namespace_name:event-router emerg`
+
+#### Nginx Error Log Severity Levels
+
+The are a number of severity levels that can be defined in the error_log. The following is a list of all severity levels: 
+
++ debug - Useful debugging information to help determine where the problem lies.
++ info - Informational messages that aren’t necessary to read but may be good to know.
++ notice - Something normal happened that is worth noting.
++ warn - Something unexpected happened, however is not a cause for concern.
++ error - Something was unsuccessful.
++ crit - There are problems that need to be critically addressed.
++ alert - Prompt action is required.
++ emerg - The system is in an unusable state and requires immediate attention.

--- a/terraform/cloud-platform-components/resources/prometheusrule-alerts/application-alerts.yaml
+++ b/terraform/cloud-platform-components/resources/prometheusrule-alerts/application-alerts.yaml
@@ -239,7 +239,7 @@ spec:
         severity: warning
     - alert: KubePersistentVolumeFullInFourDays-Low
       annotations:
-        message: Based on recent sampling, the PersistentVolume claimed by {{`{{ $labels.persistentvolumeclaim }}`}} in Namespace {{`{{ $labels.namespace }}`}} is expected to fill up within four days. Currently {{`{{ printf "%0.2f" $value }}`}}% is available.
+        message: Based on recent sampling, the PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} is expected to fill up within four days. Currently {{ printf "%0.2f" $value }} is available.
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumefullinfourdays
       expr: |-
         100 * (
@@ -252,3 +252,11 @@ spec:
       for: 5m
       labels:
         severity: warning
+    - alert: NginxConfigReloadFailure
+      annotations:
+        message: The Nginx Config has failed to reload for pod {{ $labels.pod }}
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumefullinfourdays
+      expr: nginx_ingress_controller_config_last_reload_successful == 0
+      for: 30s
+      labels:
+        severity: critical

--- a/terraform/cloud-platform-components/resources/prometheusrule-alerts/application-alerts.yaml
+++ b/terraform/cloud-platform-components/resources/prometheusrule-alerts/application-alerts.yaml
@@ -252,11 +252,4 @@ spec:
       for: 5m
       labels:
         severity: warning
-    - alert: NginxConfigReloadFailure
-      annotations:
-        message: The Nginx Config has failed to reload for pod {{ $labels.pod }}
-        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumefullinfourdays
-      expr: nginx_ingress_controller_config_last_reload_successful == 0
-      for: 30s
-      labels:
-        severity: critical
+        

--- a/terraform/cloud-platform-components/resources/prometheusrule-alerts/node-alerts.yaml
+++ b/terraform/cloud-platform-components/resources/prometheusrule-alerts/node-alerts.yaml
@@ -114,3 +114,12 @@ spec:
       annotations:
         message: HTTPCode_Target_5XX_Count high for `{{$labels.service}}. HTTPCode_Target_5XX_Count high'
         runbook_url: https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/cloud-platform-components/resources/prometheusrule-alerts/Custom-Alerts.md
+    - alert: NginxConfigReloadFailure
+      annotations:
+        message: The Nginx Config has failed to reload for pod {{ $labels.pod }}
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/cloud-platform-components/resources/prometheusrule-alerts/Custom-Alerts.md#nginx-config-reload-failure
+      expr: nginx_ingress_controller_config_last_reload_successful == 0
+      for: 30s
+      labels:
+        severity: critical
+        


### PR DESCRIPTION
- added `cluster: "live-1"` to `smoke-tests/spec/external_dns_spec.rb`
that tag prevents the test to run outside of live-1 (on a test cluster)