### PR TITLE
add live-1 tag to extdns integration test

### DIFF
--- a/smoke-tests/spec/external_dns_spec.rb
+++ b/smoke-tests/spec/external_dns_spec.rb
@@ -1,6 +1,7 @@
 require "spec_helper"
 
-describe "external DNS" do
+# This test can only be ran against live-1. Test clusters do not have enough privileges.
+describe "external DNS", cluster: "live-1" do
   namespace = "integrationtest-dns-#{readable_timestamp}"
   zone = nil
   parent_zone = nil


### PR DESCRIPTION
add tag to the extdns test to ensure it doesn't run outside of live-1. Test clusters do not have the required access - the test would fail.