### PR TITLE
Add Integration test for CRDs and ServiceMonitors

### DIFF
--- a/smoke-tests/spec/crds_spec.rb
+++ b/smoke-tests/spec/crds_spec.rb
@@ -1,0 +1,22 @@
+require "spec_helper"
+
+describe "crds" do
+
+  specify "expected crds" do
+    names = get_crds.map { |set| set.dig("metadata", "name") }.sort
+
+    expected = [
+      "alertmanagers.monitoring.coreos.com",
+      "certificates.certmanager.k8s.io",
+      "challenges.certmanager.k8s.io",
+      "clusterissuers.certmanager.k8s.io",
+      "issuers.certmanager.k8s.io",
+      "orders.certmanager.k8s.io",
+      "prometheuses.monitoring.coreos.com",
+      "prometheusrules.monitoring.coreos.com",
+      "servicemonitors.monitoring.coreos.com",
+      "tzcronjobs.cronjobber.hidde.co",
+    ]
+    expect(names).to include(*expected)
+  end
+end

--- a/smoke-tests/spec/kubernetes_helper.rb
+++ b/smoke-tests/spec/kubernetes_helper.rb
@@ -171,6 +171,14 @@ def get_daemonsets
   JSON.parse(`kubectl get daemonsets --all-namespaces -o json`).fetch("items")
 end
 
+def get_crds
+  JSON.parse(`kubectl get crds --all-namespaces -o json`).fetch("items")
+end
+
+def get_servicemonitors(namespace)
+  JSON.parse(`kubectl get servicemonitors -n #{namespace} -o json`).fetch("items")
+end
+
 #Set the enable-modsecurity flag to false on the ingress annotation
 def set_modsec_ing_annotation_false(namespace, ingress_name)
   `kubectl -n #{namespace} annotate --overwrite ingresses/#{ingress_name} nginx.ingress.kubernetes.io/enable-modsecurity='false'`.chomp

--- a/smoke-tests/spec/servicemonitors_spec.rb
+++ b/smoke-tests/spec/servicemonitors_spec.rb
@@ -19,43 +19,25 @@ describe "servicemonitors" do
       "prometheus-operator-operator",
       "prometheus-operator-prometheus",
     ]
+    expect(names).to include(*expected)
+  end
+
+  specify "expected nginx-ingress servicemonitors" do
+    names = get_servicemonitors("ingress-controllers").map { |set| set.dig("metadata", "name") }.sort
+
+    expected = [
+      "nginx-ingress",
+    ]
     expect(names).to eq(expected)
   end
 
-  # specify "expected nginx-ingress servicemonitors" do
-  #   names = get_servicemonitors.map { |set| set.dig("metadata", "name") }.sort
+  specify "expected concourse servicemonitors", cluster: "live-1" do
+    names = get_servicemonitors("concourse").map { |set| set.dig("metadata", "name") }.sort
 
-  #   expected = [
-  #     "alertmanagers.monitoring.coreos.com",
-  #     "certificates.certmanager.k8s.io",
-  #     "challenges.certmanager.k8s.io",
-  #     "clusterissuers.certmanager.k8s.io",
-  #     "issuers.certmanager.k8s.io",
-  #     "orders.certmanager.k8s.io",
-  #     "prometheuses.monitoring.coreos.com",
-  #     "prometheusrules.monitoring.coreos.com",
-  #     "servicemonitors.monitoring.coreos.com",
-  #     "tzcronjobs.cronjobber.hidde.co",
-  #   ]
-  #   expect(names).to eq(expected)
-  # end
-
-  # specify "expected concourse servicemonitors" do
-  #   names = get_servicemonitors.map { |set| set.dig("metadata", "name") }.sort
-
-  #   expected = [
-  #     "alertmanagers.monitoring.coreos.com",
-  #     "certificates.certmanager.k8s.io",
-  #     "challenges.certmanager.k8s.io",
-  #     "clusterissuers.certmanager.k8s.io",
-  #     "issuers.certmanager.k8s.io",
-  #     "orders.certmanager.k8s.io",
-  #     "prometheuses.monitoring.coreos.com",
-  #     "prometheusrules.monitoring.coreos.com",
-  #     "servicemonitors.monitoring.coreos.com",
-  #     "tzcronjobs.cronjobber.hidde.co",
-  #   ]
-  #   expect(names).to eq(expected)
-  # end
+    expected = [
+      "concourse",
+    ]
+    expect(names).to eq(expected)
+  end
 
 end

--- a/smoke-tests/spec/servicemonitors_spec.rb
+++ b/smoke-tests/spec/servicemonitors_spec.rb
@@ -1,0 +1,61 @@
+require "spec_helper"
+
+describe "servicemonitors" do
+
+  specify "expected prometheus servicemonitors" do
+    names = get_servicemonitors("monitoring").map { |set| set.dig("metadata", "name") }.sort
+
+    expected = [
+      "prometheus-operator-alertmanager",
+      "prometheus-operator-apiserver",
+      "prometheus-operator-grafana",
+      "prometheus-operator-kube-controller-manager",
+      "prometheus-operator-kube-dns",
+      "prometheus-operator-kube-etcd",
+      "prometheus-operator-kube-scheduler",
+      "prometheus-operator-kube-state-metrics",
+      "prometheus-operator-kubelet",
+      "prometheus-operator-node-exporter",
+      "prometheus-operator-operator",
+      "prometheus-operator-prometheus",
+    ]
+    expect(names).to eq(expected)
+  end
+
+  # specify "expected nginx-ingress servicemonitors" do
+  #   names = get_servicemonitors.map { |set| set.dig("metadata", "name") }.sort
+
+  #   expected = [
+  #     "alertmanagers.monitoring.coreos.com",
+  #     "certificates.certmanager.k8s.io",
+  #     "challenges.certmanager.k8s.io",
+  #     "clusterissuers.certmanager.k8s.io",
+  #     "issuers.certmanager.k8s.io",
+  #     "orders.certmanager.k8s.io",
+  #     "prometheuses.monitoring.coreos.com",
+  #     "prometheusrules.monitoring.coreos.com",
+  #     "servicemonitors.monitoring.coreos.com",
+  #     "tzcronjobs.cronjobber.hidde.co",
+  #   ]
+  #   expect(names).to eq(expected)
+  # end
+
+  # specify "expected concourse servicemonitors" do
+  #   names = get_servicemonitors.map { |set| set.dig("metadata", "name") }.sort
+
+  #   expected = [
+  #     "alertmanagers.monitoring.coreos.com",
+  #     "certificates.certmanager.k8s.io",
+  #     "challenges.certmanager.k8s.io",
+  #     "clusterissuers.certmanager.k8s.io",
+  #     "issuers.certmanager.k8s.io",
+  #     "orders.certmanager.k8s.io",
+  #     "prometheuses.monitoring.coreos.com",
+  #     "prometheusrules.monitoring.coreos.com",
+  #     "servicemonitors.monitoring.coreos.com",
+  #     "tzcronjobs.cronjobber.hidde.co",
+  #   ]
+  #   expect(names).to eq(expected)
+  # end
+
+end


### PR DESCRIPTION
Related to: https://github.com/ministryofjustice/cloud-platform/issues/1299

Smoke tests to check expected Custom Resource Definitions(CRDs) and ServiceMonitors are available.

This test expects below CRDs,
    ` "alertmanagers.monitoring.coreos.com",
      "certificates.certmanager.k8s.io",
      "challenges.certmanager.k8s.io",
      "clusterissuers.certmanager.k8s.io",
      "issuers.certmanager.k8s.io",
      "orders.certmanager.k8s.io",
      "prometheuses.monitoring.coreos.com",
      "prometheusrules.monitoring.coreos.com",
      "servicemonitors.monitoring.coreos.com",
      "tzcronjobs.cronjobber.hidde.co",`

And below ServiceMonitors
      `"prometheus-operator-alertmanager",
      "prometheus-operator-apiserver",
      "prometheus-operator-grafana",
      "prometheus-operator-kube-controller-manager",
      "prometheus-operator-kube-dns",
      "prometheus-operator-kube-etcd",
      "prometheus-operator-kube-scheduler",
      "prometheus-operator-kube-state-metrics",
      "prometheus-operator-kubelet",
      "prometheus-operator-node-exporter",
      "prometheus-operator-operator",
      "prometheus-operator-prometheus",
      "nginx-ingress",
      "concourse"`