### PR TITLE
Add code-formatter and malformed-yaml rejecter

### DIFF
--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -1,0 +1,12 @@
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+jobs:
+  format-code:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: ministryofjustice/github-actions/code-formatter@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/malformed-yaml.yml
+++ b/.github/workflows/malformed-yaml.yml
@@ -1,0 +1,12 @@
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+jobs:
+  reject-malformed-yaml:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: ministryofjustice/github-actions/malformed-yaml@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This commit adds two github actions to this repo:

* Code-formatter will automatically format any ruby & terraform
source code files included in a PR

* Malformed-yaml will reject any PRs which include YAML files
that fail to parse