### PR TITLE
Move node machineType to terraform variables

### DIFF
--- a/terraform/cloud-platform/kops.tf
+++ b/terraform/cloud-platform/kops.tf
@@ -26,5 +26,7 @@ data "template_file" "kops" {
     external_subnets_id_c                = "${module.cluster_vpc.public_subnets[2]}"
     authorized_keys_manager_systemd_unit = "${indent(6, data.template_file.authorized_keys_manager.rendered)}"
     kms_key                              = "${aws_kms_key.kms.arn}"
+    worker_node_machine_type             = "${var.worker_node_machine_type}"
+    master_node_machine_type             = "${var.master_node_machine_type}"
   }
 }

--- a/terraform/cloud-platform/templates/kops.yaml.tpl
+++ b/terraform/cloud-platform/templates/kops.yaml.tpl
@@ -306,7 +306,7 @@ metadata:
   name: master-eu-west-2a
 spec:
   image: kope.io/k8s-1.13-debian-stretch-amd64-hvm-ebs-2019-08-16
-  machineType: c4.4xlarge
+  machineType: ${master_node_machine_type}
   maxSize: 1
   minSize: 1
   nodeLabels:
@@ -333,7 +333,7 @@ metadata:
   name: master-eu-west-2b
 spec:
   image: kope.io/k8s-1.13-debian-stretch-amd64-hvm-ebs-2019-08-16
-  machineType: c4.4xlarge
+  machineType: ${master_node_machine_type}
   maxSize: 1
   minSize: 1
   nodeLabels:
@@ -360,7 +360,7 @@ metadata:
   name: master-eu-west-2c
 spec:
   image: kope.io/k8s-1.13-debian-stretch-amd64-hvm-ebs-2019-08-16
-  machineType: c4.4xlarge
+  machineType: ${master_node_machine_type}
   maxSize: 1
   minSize: 1
   nodeLabels:
@@ -387,7 +387,7 @@ metadata:
   name: nodes
 spec:
   image: kope.io/k8s-1.13-debian-stretch-amd64-hvm-ebs-2019-08-16
-  machineType: r5.2xlarge
+  machineType: ${worker_node_machine_type}
   maxSize: ${cluster_node_count}
   minSize: ${cluster_node_count}
   rootVolumeSize: 256

--- a/terraform/cloud-platform/variables.tf
+++ b/terraform/cloud-platform/variables.tf
@@ -25,3 +25,13 @@ variable "cluster_node_count" {
   description = "The number of worker node in the cluster"
   default     = "21"
 }
+
+variable "master_node_machine_type" {
+  description = "The AWS EC2 instance types to use for master nodes"
+  default     = "c4.4xlarge"
+}
+
+variable "worker_node_machine_type" {
+  description = "The AWS EC2 instance types to use for worker nodes"
+  default     = "r5.2xlarge"
+}


### PR DESCRIPTION
Instead of hard-coding EC2 instance types into
the kops config template, this change moves them 
to terraform variables.

This change by itself will not alter anything, but
it's a pre-requisite for the next change to the 
ruby script which builds test clusters. That 
change will alter the invocation of the terraform
apply step, to supply different machine type
values, so that we can build different sizes of
test cluster.