### PR TITLE
remove compression rate from log

### DIFF
--- a/terraform/cloud-platform-components/nginx-ingress-acme.tf
+++ b/terraform/cloud-platform-components/nginx-ingress-acme.tf
@@ -53,7 +53,6 @@ controller:
       "time": "$time_iso8601",
       "body_bytes_sent": $body_bytes_sent,
       "bytes_sent": $bytes_sent,
-      "gzip_ratio": $gzip_ratio,
       "http_host": "$host",
       "http_referer": "$http_referer",
       "http_user_agent": "$http_user_agent",


### PR DESCRIPTION
**Why**
Whenever the filed is not a numeric value, nginx does not put in 0/1 but leaves an unfinished `:` that breaks the json parser