### PR TITLE
Re-enable ModSec integration test

### DIFF
--- a/smoke-tests/spec/modsec_spec.rb
+++ b/smoke-tests/spec/modsec_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-xdescribe "Testing modsec" do
+describe "Testing modsec" do
   namespace = "integrationtest-modsec-#{readable_timestamp}"
   host = "#{namespace}.apps.#{current_cluster}"
   ingress_name = "modsec-integrationtest-app-ing"

--- a/smoke-tests/spec/modsec_spec.rb
+++ b/smoke-tests/spec/modsec_spec.rb
@@ -24,7 +24,7 @@ describe "Testing modsec" do
     delete_namespace(namespace)
   end
 
-  context "when modsec deployed" do  # this is the default behaviour
+  context "when modsec deployed" do # this is the default behaviour
     context "when the url is benign" do
       let(:url) { good_url }
 


### PR DESCRIPTION
WHAT
Re-enable the modsec integration test 

WHY
This test was disabled after an ingress-controller upfate, the test required changes to how modsecurity worked. The changes were made previously (https://github.com/ministryofjustice/cloud-platform-infrastructure/commit/3a6935aed4ba1fbfdb7f4b63ccb80f81dd0b76e5), but more testing was required before adding back in. 