### PR TITLE
Increase wait time to 1 minute for nginx reload alert

### DIFF
--- a/terraform/cloud-platform-components/resources/prometheusrule-alerts/node-alerts.yaml
+++ b/terraform/cloud-platform-components/resources/prometheusrule-alerts/node-alerts.yaml
@@ -119,7 +119,7 @@ spec:
         message: The Nginx Config has failed to reload for pod {{ $labels.pod }}
         runbook_url: https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/cloud-platform-components/resources/prometheusrule-alerts/Custom-Alerts.md#nginx-config-reload-failure
       expr: nginx_ingress_controller_config_last_reload_successful == 0
-      for: 30s
+      for: 1m
       labels:
         severity: critical
         


### PR DESCRIPTION
Nginx config can fail to reload under certain circumstances, however it is able to resolve itself within a few seconds also. This increase is so that we do not get out of ours alerts if the alert is able to resolve itself. The wait time is now 1 minute instead of 30 seconds.