### PR TITLE
Add dependency on ingress-controllers

### DIFF
--- a/terraform/cloud-platform-components/prometheus.tf
+++ b/terraform/cloud-platform-components/prometheus.tf
@@ -128,6 +128,7 @@ resource "helm_release" "prometheus_operator" {
     "null_resource.deploy",
     "kubernetes_secret.grafana_secret",
     "helm_release.open-policy-agent",
+    "helm_release.nginx_ingress_acme",
   ]
 
   provisioner "local-exec" {


### PR DESCRIPTION
The installation of prometheus operator fails the first time, when
we build a test cluster.

    Error: Error applying plan:

    1 error occurred:
            * helm_release.prometheus_operator: 1 error occurred:
            * helm_release.prometheus_operator: rpc error: code = Unknown
    desc = release prometheus-operator failed: Internal error occurred:
    failed calling webhook "validate.nginx.ingress.kubernetes.io": Post
    https://nginx-ingress-acme-controller-admission.ingress-controllers.svc:443/extensions/v1beta1/ingresses?timeout=30s:
    dial tcp 100.71.204.116:443: connect: connection refused

I think this is because the admission webhook is not ready when
the installation happens.

This change adds a dependency, so that terraform doesn't try to
install prometheus operator before the webhook is in place.

I've run the cluster build process twice, with this change, and
it seems to fix the problem (the previous two runs both failed
with the error above).