### PR TITLE
Tf12 upgrade cloud platform

### DIFF
--- a/terraform/cloud-platform/bastion.tf
+++ b/terraform/cloud-platform/bastion.tf
@@ -190,7 +190,7 @@ resource "aws_autoscaling_group" "bastion" {
   # If the expression in the following list itself returns a list, remove the
   # brackets to avoid interpretation as a list of lists. If the expression
   # returns a single list item then leave it as-is and remove this TODO comment.
-  vpc_zone_identifier = [module.cluster_vpc.public_subnets]
+  vpc_zone_identifier = module.cluster_vpc.public_subnets
   default_cooldown    = 60
 
   tags = [

--- a/terraform/cloud-platform/kops.tf
+++ b/terraform/cloud-platform/kops.tf
@@ -1,5 +1,5 @@
 resource "local_file" "kops" {
-  content  = "${data.template_file.kops.rendered}"
+  content  = data.template_file.kops.rendered
   filename = "../../kops/${terraform.workspace}.yaml"
 }
 
@@ -8,25 +8,26 @@ resource "aws_kms_key" "kms" {
 }
 
 data "template_file" "kops" {
-  template = "${file("./templates/kops.yaml.tpl")}"
+  template = file("./templates/kops.yaml.tpl")
 
-  vars {
-    cluster_domain_name                  = "${local.cluster_base_domain_name}"
-    cluster_node_count                   = "${local.is_live_cluster ? var.cluster_node_count : 3}"
-    kops_state_store                     = "${data.terraform_remote_state.global.cloud_platform_kops_state}"
-    oidc_issuer_url                      = "${local.oidc_issuer_url}"
-    oidc_client_id                       = "${auth0_client.kubernetes.client_id}"
-    network_cidr_block                   = "${module.cluster_vpc.vpc_cidr_block}"
-    network_id                           = "${module.cluster_vpc.vpc_id}"
-    internal_subnets_id_a                = "${module.cluster_vpc.private_subnets[0]}"
-    internal_subnets_id_b                = "${module.cluster_vpc.private_subnets[1]}"
-    internal_subnets_id_c                = "${module.cluster_vpc.private_subnets[2]}"
-    external_subnets_id_a                = "${module.cluster_vpc.public_subnets[0]}"
-    external_subnets_id_b                = "${module.cluster_vpc.public_subnets[1]}"
-    external_subnets_id_c                = "${module.cluster_vpc.public_subnets[2]}"
-    authorized_keys_manager_systemd_unit = "${indent(6, data.template_file.authorized_keys_manager.rendered)}"
-    kms_key                              = "${aws_kms_key.kms.arn}"
-    worker_node_machine_type             = "${var.worker_node_machine_type}"
-    master_node_machine_type             = "${var.master_node_machine_type}"
+  vars = {
+    cluster_domain_name                  = local.cluster_base_domain_name
+    cluster_node_count                   = local.is_live_cluster ? var.cluster_node_count : 3
+    kops_state_store                     = data.terraform_remote_state.global.outputs.cloud_platform_kops_state
+    oidc_issuer_url                      = local.oidc_issuer_url
+    oidc_client_id                       = auth0_client.kubernetes.client_id
+    network_cidr_block                   = module.cluster_vpc.vpc_cidr_block
+    network_id                           = module.cluster_vpc.vpc_id
+    internal_subnets_id_a                = module.cluster_vpc.private_subnets[0]
+    internal_subnets_id_b                = module.cluster_vpc.private_subnets[1]
+    internal_subnets_id_c                = module.cluster_vpc.private_subnets[2]
+    external_subnets_id_a                = module.cluster_vpc.public_subnets[0]
+    external_subnets_id_b                = module.cluster_vpc.public_subnets[1]
+    external_subnets_id_c                = module.cluster_vpc.public_subnets[2]
+    authorized_keys_manager_systemd_unit = indent(6, data.template_file.authorized_keys_manager.rendered)
+    kms_key                              = aws_kms_key.kms.arn
+    worker_node_machine_type             = var.worker_node_machine_type
+    master_node_machine_type             = var.master_node_machine_type
   }
 }
+

--- a/terraform/cloud-platform/main.tf
+++ b/terraform/cloud-platform/main.tf
@@ -62,7 +62,7 @@ module "cluster_ssl" {
 }
 
 module "cluster_vpc" {
-  version              = "1.66.0"
+  version              = "2.18.0"
   source               = "terraform-aws-modules/vpc/aws"
   name                 = local.cluster_name
   cidr                 = var.vpc_cidr

--- a/terraform/cloud-platform/main.tf
+++ b/terraform/cloud-platform/main.tf
@@ -23,7 +23,7 @@ provider "aws" {
 # the AWS providr credentials are handled.
 #
 provider "auth0" {
-  version = ">= 0.1.18"
+  version = ">= 0.2.1"
   domain  = local.auth0_tenant_domain
 }
 

--- a/terraform/cloud-platform/main.tf
+++ b/terraform/cloud-platform/main.tf
@@ -24,13 +24,13 @@ provider "aws" {
 #
 provider "auth0" {
   version = ">= 0.1.18"
-  domain  = "${local.auth0_tenant_domain}"
+  domain  = local.auth0_tenant_domain
 }
 
 data "terraform_remote_state" "global" {
   backend = "s3"
 
-  config {
+  config = {
     bucket  = "cloud-platform-terraform-state"
     region  = "eu-west-1"
     key     = "global-resources/terraform.tfstate"
@@ -39,36 +39,36 @@ data "terraform_remote_state" "global" {
 }
 
 locals {
-  cluster_name             = "${terraform.workspace}"
+  cluster_name             = terraform.workspace
   cluster_base_domain_name = "${local.cluster_name}.cloud-platform.service.justice.gov.uk"
   auth0_tenant_domain      = "justice-cloud-platform.eu.auth0.com"
   oidc_issuer_url          = "https://${local.auth0_tenant_domain}/"
 
-  is_live_cluster      = "${terraform.workspace == "live-1"}"
-  services_base_domain = "${local.is_live_cluster ? "cloud-platform.service.justice.gov.uk" : "apps.${local.cluster_base_domain_name}"}"
+  is_live_cluster      = terraform.workspace == "live-1"
+  services_base_domain = local.is_live_cluster ? "cloud-platform.service.justice.gov.uk" : "apps.${local.cluster_base_domain_name}"
 }
 
 # Modules
 module "cluster_dns" {
   source                   = "../modules/cluster_dns"
-  cluster_base_domain_name = "${local.cluster_base_domain_name}"
-  parent_zone_id           = "${data.terraform_remote_state.global.cp_zone_id}"
+  cluster_base_domain_name = local.cluster_base_domain_name
+  parent_zone_id           = data.terraform_remote_state.global.outputs.cp_zone_id
 }
 
 module "cluster_ssl" {
   source                   = "../modules/cluster_ssl"
-  cluster_base_domain_name = "${local.cluster_base_domain_name}"
-  dns_zone_id              = "${module.cluster_dns.cluster_dns_zone_id}"
+  cluster_base_domain_name = local.cluster_base_domain_name
+  dns_zone_id              = module.cluster_dns.cluster_dns_zone_id
 }
 
 module "cluster_vpc" {
   version              = "1.66.0"
   source               = "terraform-aws-modules/vpc/aws"
-  name                 = "${local.cluster_name}"
-  cidr                 = "${var.vpc_cidr}"
-  azs                  = "${var.availability_zones}"
-  private_subnets      = "${var.internal_subnets}"
-  public_subnets       = "${var.external_subnets}"
+  name                 = local.cluster_name
+  cidr                 = var.vpc_cidr
+  azs                  = var.availability_zones
+  private_subnets      = var.internal_subnets
+  public_subnets       = var.external_subnets
   enable_nat_gateway   = true
   enable_vpn_gateway   = false
   enable_dns_hostnames = true
@@ -87,8 +87,8 @@ module "cluster_vpc" {
 
   tags = {
     Terraform = "true"
-    Cluster   = "${local.cluster_name}"
-    Domain    = "${local.cluster_base_domain_name}"
+    Cluster   = local.cluster_name
+    Domain    = local.cluster_base_domain_name
   }
 }
 
@@ -98,8 +98,8 @@ resource "tls_private_key" "cluster" {
 }
 
 resource "aws_key_pair" "cluster" {
-  key_name   = "${local.cluster_base_domain_name}"
-  public_key = "${tls_private_key.cluster.public_key_openssh}"
+  key_name   = local.cluster_base_domain_name
+  public_key = tls_private_key.cluster.public_key_openssh
 }
 
 resource "auth0_client" "kubernetes" {
@@ -107,14 +107,22 @@ resource "auth0_client" "kubernetes" {
   description = "Cloud Platform kubernetes"
   app_type    = "regular_web"
 
-  callbacks = ["${format("https://login.%s/ui", local.services_base_domain)}"]
+  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+  # force an interpolation expression to be interpreted as a list by wrapping it
+  # in an extra set of list brackets. That form was supported for compatibility in
+  # v0.11, but is no longer supported in Terraform v0.12.
+  #
+  # If the expression in the following list itself returns a list, remove the
+  # brackets to avoid interpretation as a list of lists. If the expression
+  # returns a single list item then leave it as-is and remove this TODO comment.
+  callbacks = [format("https://login.%s/ui", local.services_base_domain)]
 
   custom_login_page_on = true
   is_first_party       = true
   oidc_conformant      = true
   sso                  = true
 
-  jwt_configuration = {
+  jwt_configuration {
     alg                 = "RS256"
     lifetime_in_seconds = "2592000"
   }
@@ -126,13 +134,34 @@ resource "auth0_client" "components" {
   app_type    = "regular_web"
 
   callbacks = [
-    "${format("https://prometheus.%s/oauth2/callback", local.services_base_domain)}",
-    "${format("https://alertmanager.%s/oauth2/callback", local.services_base_domain)}",
-    "${format("https://concourse.%s/sky/issuer/callback", local.services_base_domain)}",
-    "${format("https://kibana.%s/oauth2/callback", local.services_base_domain)}",
-    "${format("https://kibana-audit.%s/oauth2/callback", local.services_base_domain)}",
-    "${format("https://grafana.%s/login/generic_oauth", local.services_base_domain)}",
-    "${format("https://kube-ops.%s/login/authorized", local.services_base_domain)}",
+    format(
+      "https://prometheus.%s/oauth2/callback",
+      local.services_base_domain,
+    ),
+    format(
+      "https://alertmanager.%s/oauth2/callback",
+      local.services_base_domain,
+    ),
+    format(
+      "https://concourse.%s/sky/issuer/callback",
+      local.services_base_domain,
+    ),
+    format(
+      "https://kibana.%s/oauth2/callback",
+      local.services_base_domain,
+    ),
+    format(
+      "https://kibana-audit.%s/oauth2/callback",
+      local.services_base_domain,
+    ),
+    format(
+      "https://grafana.%s/login/generic_oauth",
+      local.services_base_domain,
+    ),
+    format(
+      "https://kube-ops.%s/login/authorized",
+      local.services_base_domain,
+    ),
   ]
 
   custom_login_page_on = true
@@ -140,8 +169,9 @@ resource "auth0_client" "components" {
   oidc_conformant      = true
   sso                  = true
 
-  jwt_configuration = {
+  jwt_configuration {
     alg                 = "RS256"
     lifetime_in_seconds = "36000"
   }
 }
+

--- a/terraform/cloud-platform/outputs.tf
+++ b/terraform/cloud-platform/outputs.tf
@@ -1,75 +1,76 @@
 output "cluster_name" {
-  value = "${local.cluster_name}"
+  value = local.cluster_name
 }
 
 output "cluster_domain_name" {
-  value = "${local.cluster_base_domain_name}"
+  value = local.cluster_base_domain_name
 }
 
 output "network_id" {
-  value = "${module.cluster_vpc.vpc_id}"
+  value = module.cluster_vpc.vpc_id
 }
 
 output "network_cidr_block" {
-  value = "${module.cluster_vpc.vpc_cidr_block}"
+  value = module.cluster_vpc.vpc_cidr_block
 }
 
 output "kops_state_store" {
-  value = "${data.terraform_remote_state.global.cloud_platform_kops_state}"
+  value = data.terraform_remote_state.global.outputs.cloud_platform_kops_state
 }
 
 output "availability_zones" {
-  value = "${var.availability_zones}"
+  value = var.availability_zones
 }
 
 output "vpc_id" {
-  value = "${module.cluster_vpc.vpc_id}"
+  value = module.cluster_vpc.vpc_id
 }
 
 output "internal_subnets" {
-  value = "${var.internal_subnets}"
+  value = var.internal_subnets
 }
 
 output "internal_subnets_ids" {
-  value = "${module.cluster_vpc.private_subnets}"
+  value = module.cluster_vpc.private_subnets
 }
 
 output "external_subnets" {
-  value = "${var.external_subnets}"
+  value = var.external_subnets
 }
 
 output "external_subnets_ids" {
-  value = "${module.cluster_vpc.public_subnets}"
+  value = module.cluster_vpc.public_subnets
 }
 
 output "hosted_zone_id" {
-  value = "${module.cluster_dns.cluster_dns_zone_id}"
+  value = module.cluster_dns.cluster_dns_zone_id
 }
 
 output "instance_key_name" {
-  value = "${aws_key_pair.cluster.key_name}"
+  value = aws_key_pair.cluster.key_name
 }
 
 output "oidc_issuer_url" {
-  value = "${local.oidc_issuer_url}"
+  value = local.oidc_issuer_url
 }
 
 output "oidc_kubernetes_client_id" {
-  value = "${auth0_client.kubernetes.client_id}"
+  value = auth0_client.kubernetes.client_id
 }
 
 output "oidc_kubernetes_client_secret" {
-  value = "${auth0_client.kubernetes.client_secret}"
+  value = auth0_client.kubernetes.client_secret
 }
 
 output "oidc_components_client_id" {
-  value = "${auth0_client.components.client_id}"
+  value = auth0_client.components.client_id
 }
 
 output "oidc_components_client_secret" {
-  value = "${auth0_client.components.client_secret}"
+  value = auth0_client.components.client_secret
 }
 
 output "certificate_arn" {
-  value = "${module.cluster_ssl.apps_acm_arn}"
+  value = module.cluster_ssl.apps_acm_arn
 }
+

--- a/terraform/cloud-platform/variables.tf
+++ b/terraform/cloud-platform/variables.tf
@@ -4,19 +4,19 @@ variable "vpc_cidr" {
 }
 
 variable "internal_subnets" {
-  type        = "list"
+  type        = list(string)
   description = "list of subnet CIDR blocks that are not publicly acceessibly"
   default     = ["172.20.32.0/19", "172.20.64.0/19", "172.20.96.0/19"]
 }
 
 variable "external_subnets" {
-  type        = "list"
+  type        = list(string)
   description = "list of subnet CIDR blocks that are publicly acceessibly"
   default     = ["172.20.0.0/22", "172.20.4.0/22", "172.20.8.0/22"]
 }
 
 variable "availability_zones" {
-  type        = "list"
+  type        = list(string)
   description = "a list of EC2 availability zones"
   default     = ["eu-west-2a", "eu-west-2b", "eu-west-2c"]
 }
@@ -35,3 +35,4 @@ variable "worker_node_machine_type" {
   description = "The AWS EC2 instance types to use for worker nodes"
   default     = "r5.2xlarge"
 }
+

--- a/terraform/cloud-platform/versions.tf
+++ b/terraform/cloud-platform/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/aws_federation/iam_federation.tf
+++ b/terraform/modules/aws_federation/iam_federation.tf
@@ -1,15 +1,16 @@
 data "template_file" "saml_metadata" {
-  template = "${file("${path.module}/saml/auth0-saml-metadata.xml")}"
+  template = file("${path.module}/saml/auth0-saml-metadata.xml")
 
-  vars {
-    saml_x509_cert  = "${var.saml_x509_cert}"
-    saml_idp_domain = "${var.saml_idp_domain}"
-    saml_login_url  = "${var.saml_login_url}"
-    saml_logout_url = "${var.saml_logout_url}"
+  vars = {
+    saml_x509_cert  = var.saml_x509_cert
+    saml_idp_domain = var.saml_idp_domain
+    saml_login_url  = var.saml_login_url
+    saml_logout_url = var.saml_logout_url
   }
 }
 
 resource "aws_iam_saml_provider" "auth0" {
   name                   = "${var.env}-auth0"
-  saml_metadata_document = "${data.template_file.saml_metadata.rendered}"
+  saml_metadata_document = data.template_file.saml_metadata.rendered
 }
+

--- a/terraform/modules/aws_federation/iam_roles.tf
+++ b/terraform/modules/aws_federation/iam_roles.tf
@@ -4,7 +4,7 @@ data "aws_iam_policy_document" "federated_role_trust_policy" {
 
     principals {
       type        = "Federated"
-      identifiers = ["${aws_iam_saml_provider.auth0.arn}"]
+      identifiers = [aws_iam_saml_provider.auth0.arn]
     }
 
     actions = ["sts:AssumeRoleWithSAML"]
@@ -22,10 +22,11 @@ data "aws_iam_policy_document" "federated_role_trust_policy" {
 resource "aws_iam_role" "test_github_webops" {
   name = "test-github-webops"
 
-  assume_role_policy = "${data.aws_iam_policy_document.federated_role_trust_policy.json}"
+  assume_role_policy = data.aws_iam_policy_document.federated_role_trust_policy.json
 }
 
 resource "aws_iam_role_policy_attachment" "test_github_webops_admin" {
-  role       = "${aws_iam_role.test_github_webops.name}"
+  role       = aws_iam_role.test_github_webops.name
   policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
 }
+

--- a/terraform/modules/aws_federation/outputs.tf
+++ b/terraform/modules/aws_federation/outputs.tf
@@ -1,3 +1,4 @@
 output "saml_provider_arn" {
-  value = "${aws_iam_saml_provider.auth0.arn}"
+  value = aws_iam_saml_provider.auth0.arn
 }
+

--- a/terraform/modules/aws_federation/variables.tf
+++ b/terraform/modules/aws_federation/variables.tf
@@ -1,5 +1,15 @@
-variable "env" {}
-variable "saml_idp_domain" {}
-variable "saml_x509_cert" {}
-variable "saml_login_url" {}
-variable "saml_logout_url" {}
+variable "env" {
+}
+
+variable "saml_idp_domain" {
+}
+
+variable "saml_x509_cert" {
+}
+
+variable "saml_login_url" {
+}
+
+variable "saml_logout_url" {
+}
+

--- a/terraform/modules/aws_federation/versions.tf
+++ b/terraform/modules/aws_federation/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/cluster_dns/dns.tf
+++ b/terraform/modules/cluster_dns/dns.tf
@@ -4,12 +4,11 @@ resource "aws_route53_zone" "cluster" {
 }
 
 resource "aws_route53_record" "parent_zone_cluster_ns" {
-  zone_id = "${var.parent_zone_id}"
-  name    = "${aws_route53_zone.cluster.name}"
+  zone_id = var.parent_zone_id
+  name    = aws_route53_zone.cluster.name
   type    = "NS"
   ttl     = "30"
 
-  records = [
-    "${aws_route53_zone.cluster.name_servers}",
-  ]
+  records = aws_route53_zone.cluster.name_servers
 }
+

--- a/terraform/modules/cluster_dns/outputs.tf
+++ b/terraform/modules/cluster_dns/outputs.tf
@@ -1,7 +1,8 @@
 output "cluster_dns_zone_name" {
-  value = "${aws_route53_zone.cluster.name}"
+  value = aws_route53_zone.cluster.name
 }
 
 output "cluster_dns_zone_id" {
-  value = "${aws_route53_zone.cluster.zone_id}"
+  value = aws_route53_zone.cluster.zone_id
 }
+

--- a/terraform/modules/cluster_dns/variables.tf
+++ b/terraform/modules/cluster_dns/variables.tf
@@ -1,2 +1,6 @@
-variable "cluster_base_domain_name" {}
-variable "parent_zone_id" {}
+variable "cluster_base_domain_name" {
+}
+
+variable "parent_zone_id" {
+}
+

--- a/terraform/modules/cluster_dns/versions.tf
+++ b/terraform/modules/cluster_dns/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/cluster_ssl/acm.tf
+++ b/terraform/modules/cluster_ssl/acm.tf
@@ -4,14 +4,15 @@ resource "aws_acm_certificate" "apps" {
 }
 
 resource "aws_route53_record" "apps_cert_validation" {
-  name    = "${aws_acm_certificate.apps.domain_validation_options.0.resource_record_name}"
-  type    = "${aws_acm_certificate.apps.domain_validation_options.0.resource_record_type}"
-  zone_id = "${var.dns_zone_id}"
-  records = ["${aws_acm_certificate.apps.domain_validation_options.0.resource_record_value}"]
+  name    = aws_acm_certificate.apps.domain_validation_options[0].resource_record_name
+  type    = aws_acm_certificate.apps.domain_validation_options[0].resource_record_type
+  zone_id = var.dns_zone_id
+  records = [aws_acm_certificate.apps.domain_validation_options[0].resource_record_value]
   ttl     = 60
 }
 
 resource "aws_acm_certificate_validation" "apps" {
-  certificate_arn         = "${aws_acm_certificate.apps.arn}"
-  validation_record_fqdns = ["${aws_route53_record.apps_cert_validation.fqdn}"]
+  certificate_arn         = aws_acm_certificate.apps.arn
+  validation_record_fqdns = [aws_route53_record.apps_cert_validation.fqdn]
 }
+

--- a/terraform/modules/cluster_ssl/outputs.tf
+++ b/terraform/modules/cluster_ssl/outputs.tf
@@ -1,3 +1,4 @@
 output "apps_acm_arn" {
-  value = "${aws_acm_certificate.apps.arn}"
+  value = aws_acm_certificate.apps.arn
 }
+

--- a/terraform/modules/cluster_ssl/variables.tf
+++ b/terraform/modules/cluster_ssl/variables.tf
@@ -1,2 +1,6 @@
-variable "cluster_base_domain_name" {}
-variable "dns_zone_id" {}
+variable "cluster_base_domain_name" {
+}
+
+variable "dns_zone_id" {
+}
+

--- a/terraform/modules/cluster_ssl/versions.tf
+++ b/terraform/modules/cluster_ssl/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
This is related to https://github.com/ministryofjustice/cloud-platform/issues/1368

Upgraded cloud-platform in cloud-platform-infrastructure to tfv0.12.13.

Performed tf 0.12upgrade on below:
terraform/cloud-platform
module aws_federation
module cluster_dns
module cluster_ssl

Upgraded auth0 version to 0.2.1
Updated cluster_vpc module version to 2.18.0