### PR TITLE
Tf12 upgrade cloud platform components

### DIFF
--- a/terraform/cloud-platform-components/cert-manager.tf
+++ b/terraform/cloud-platform-components/cert-manager.tf
@@ -6,7 +6,7 @@ resource "kubernetes_namespace" "cert_manager" {
   metadata {
     name = "cert-manager"
 
-    labels {
+    labels = {
       "name"                                           = "cert-manager"
       "component"                                      = "cert-manager"
       "cloud-platform.justice.gov.uk/environment-name" = "production"
@@ -14,13 +14,13 @@ resource "kubernetes_namespace" "cert_manager" {
       "certmanager.k8s.io/disable-validation"          = "true"
     }
 
-    annotations {
+    annotations = {
       "cloud-platform.justice.gov.uk/application"                   = "cert-manager"
       "cloud-platform.justice.gov.uk/business-unit"                 = "cloud-platform"
       "cloud-platform.justice.gov.uk/owner"                         = "Cloud Platform: platforms@digital.justice.gov.uk"
       "cloud-platform.justice.gov.uk/source-code"                   = "https://github.com/ministryofjustice/cloud-platform-infrastructure"
       "cloud-platform.justice.gov.uk/can-use-loadbalancer-services" = "true"
-      "iam.amazonaws.com/permitted"                                 = "${aws_iam_role.cert_manager.name}"
+      "iam.amazonaws.com/permitted"                                 = aws_iam_role.cert_manager.name
     }
   }
 }
@@ -31,21 +31,32 @@ data "aws_iam_policy_document" "cert_manager_assume" {
 
     principals {
       type        = "AWS"
-      identifiers = ["${data.aws_iam_role.nodes.arn}"]
+      identifiers = [data.aws_iam_role.nodes.arn]
     }
   }
 }
 
 resource "aws_iam_role" "cert_manager" {
-  name               = "cert-manager.${data.terraform_remote_state.cluster.cluster_domain_name}"
-  assume_role_policy = "${data.aws_iam_policy_document.cert_manager_assume.json}"
+  name               = "cert-manager.${data.terraform_remote_state.cluster.outputs.cluster_domain_name}"
+  assume_role_policy = data.aws_iam_policy_document.cert_manager_assume.json
 }
 
 data "aws_iam_policy_document" "cert_manager" {
   statement {
     actions = ["route53:ChangeResourceRecordSets"]
 
-    resources = ["${format("arn:aws:route53:::hostedzone/%s", terraform.workspace == local.live_workspace ? "*" : data.terraform_remote_state.cluster.hosted_zone_id)}"]
+    # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+    # force an interpolation expression to be interpreted as a list by wrapping it
+    # in an extra set of list brackets. That form was supported for compatibility in
+    # v0.11, but is no longer supported in Terraform v0.12.
+    #
+    # If the expression in the following list itself returns a list, remove the
+    # brackets to avoid interpretation as a list of lists. If the expression
+    # returns a single list item then leave it as-is and remove this TODO comment.
+    resources = [format(
+      "arn:aws:route53:::hostedzone/%s",
+      terraform.workspace == local.live_workspace ? "*" : data.terraform_remote_state.cluster.outputs.hosted_zone_id,
+    )]
   }
 
   statement {
@@ -61,8 +72,8 @@ data "aws_iam_policy_document" "cert_manager" {
 
 resource "aws_iam_role_policy" "cert_manager" {
   name   = "route53"
-  role   = "${aws_iam_role.cert_manager.id}"
-  policy = "${data.aws_iam_policy_document.cert_manager.json}"
+  role   = aws_iam_role.cert_manager.id
+  policy = data.aws_iam_policy_document.cert_manager.json
 }
 
 data "http" "cert-manager-crds" {
@@ -76,17 +87,18 @@ kubectl apply -n cert-manager -f - <<EOF
 ${data.http.cert-manager-crds.body}
 EOF
 EOS
+
   }
 
   provisioner "local-exec" {
-    when = "destroy"
+    when = destroy
 
     # destroying the CRDs also deletes all resources of type "certificate" (not the actual certs, those are in secrets of type "tls")
     command = "exit 0"
   }
 
-  triggers {
-    contents_crds = "${sha1("${data.http.cert-manager-crds.body}")}"
+  triggers = {
+    contents_crds = sha1(data.http.cert-manager-crds.body)
   }
 }
 
@@ -98,12 +110,13 @@ data "helm_repository" "jetstack" {
 resource "helm_release" "cert-manager" {
   name          = "cert-manager"
   chart         = "jetstack/cert-manager"
-  repository    = "${data.helm_repository.jetstack.metadata.0.name}"
+  repository    = data.helm_repository.jetstack.metadata[0].name
   namespace     = "cert-manager"
-  version       = "${local.cert-manager-version}"
+  version       = local.cert-manager-version
   recreate_pods = true
 
-  values = [<<EOF
+  values = [
+    <<EOF
 ingressShim:
   defaultIssuerName: letsencrypt-production
   defaultIssuerKind: ClusterIssuer
@@ -116,22 +129,23 @@ securityContext:
 podAnnotations:
   iam.amazonaws.com/role: "${aws_iam_role.cert_manager.name}"
 EOF
+    ,
   ]
 
   depends_on = [
-    "null_resource.deploy",
-    "null_resource.cert-manager-crds",
-    "kubernetes_namespace.cert_manager",
-    "helm_release.open-policy-agent",
+    null_resource.deploy,
+    null_resource.cert-manager-crds,
+    kubernetes_namespace.cert_manager,
+    helm_release.open-policy-agent,
   ]
 
   lifecycle {
-    ignore_changes = ["keyring"]
+    ignore_changes = [keyring]
   }
 }
 
 resource "null_resource" "cert_manager_issuers" {
-  depends_on = ["helm_release.cert-manager"]
+  depends_on = [helm_release.cert-manager]
 
   provisioner "local-exec" {
     command = "kubectl apply -n cert-manager -f ${path.module}/templates/cert-manager/letsencrypt-production.yaml"
@@ -142,35 +156,43 @@ resource "null_resource" "cert_manager_issuers" {
   }
 
   provisioner "local-exec" {
-    when    = "destroy"
+    when    = destroy
     command = "kubectl delete -n cert-manager -f ${path.module}/templates/cert-manager/letsencrypt-production.yaml"
   }
 
   provisioner "local-exec" {
-    when    = "destroy"
+    when    = destroy
     command = "kubectl delete -n cert-manager -f ${path.module}/templates/cert-manager/letsencrypt-staging.yaml"
   }
 
-  triggers {
-    contents_production = "${sha1(file("${path.module}/templates/cert-manager/letsencrypt-production.yaml"))}"
-    contents_staging    = "${sha1(file("${path.module}/templates/cert-manager/letsencrypt-staging.yaml"))}"
+  triggers = {
+    contents_production = filesha1(
+      "${path.module}/templates/cert-manager/letsencrypt-production.yaml",
+    )
+    contents_staging = filesha1(
+      "${path.module}/templates/cert-manager/letsencrypt-staging.yaml",
+    )
   }
 }
 
 resource "null_resource" "cert_manager_monitoring" {
-  depends_on = ["helm_release.prometheus_operator", "helm_release.cert-manager"]
+  depends_on = [
+    helm_release.prometheus_operator,
+    helm_release.cert-manager,
+  ]
 
   provisioner "local-exec" {
     command = "kubectl apply -n cert-manager -f ${path.module}/resources/cert-manager/"
   }
 
   provisioner "local-exec" {
-    when    = "destroy"
+    when    = destroy
     command = "kubectl delete -n cert-manager -f ${path.module}/resources/cert-manager/"
   }
 
-  triggers {
-    servicemonitor = "${sha1(file("${path.module}/resources/cert-manager/servicemonitor.yaml"))}"
-    alerts         = "${sha1(file("${path.module}/resources/cert-manager/alerts.yaml"))}"
+  triggers = {
+    servicemonitor = filesha1("${path.module}/resources/cert-manager/servicemonitor.yaml")
+    alerts         = filesha1("${path.module}/resources/cert-manager/alerts.yaml")
   }
 }
+

--- a/terraform/cloud-platform-components/eventrouter.tf
+++ b/terraform/cloud-platform-components/eventrouter.tf
@@ -8,5 +8,6 @@ resource "helm_release" "eventrouter" {
     value = "stdout"
   }
 
-  depends_on = ["helm_release.fluentd_es"]
+  depends_on = [helm_release.fluentd_es]
 }
+

--- a/terraform/cloud-platform-components/external-dns.tf
+++ b/terraform/cloud-platform-components/external-dns.tf
@@ -4,21 +4,32 @@ data "aws_iam_policy_document" "external_dns_assume" {
 
     principals {
       type        = "AWS"
-      identifiers = ["${data.aws_iam_role.nodes.arn}"]
+      identifiers = [data.aws_iam_role.nodes.arn]
     }
   }
 }
 
 resource "aws_iam_role" "external_dns" {
-  name               = "external-dns.${data.terraform_remote_state.cluster.cluster_domain_name}"
-  assume_role_policy = "${data.aws_iam_policy_document.external_dns_assume.json}"
+  name               = "external-dns.${data.terraform_remote_state.cluster.outputs.cluster_domain_name}"
+  assume_role_policy = data.aws_iam_policy_document.external_dns_assume.json
 }
 
 data "aws_iam_policy_document" "external_dns" {
   statement {
     actions = ["route53:ChangeResourceRecordSets"]
 
-    resources = ["${format("arn:aws:route53:::hostedzone/%s", terraform.workspace == local.live_workspace ? "*" : data.terraform_remote_state.cluster.hosted_zone_id)}"]
+    # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+    # force an interpolation expression to be interpreted as a list by wrapping it
+    # in an extra set of list brackets. That form was supported for compatibility in
+    # v0.11, but is no longer supported in Terraform v0.12.
+    #
+    # If the expression in the following list itself returns a list, remove the
+    # brackets to avoid interpretation as a list of lists. If the expression
+    # returns a single list item then leave it as-is and remove this TODO comment.
+    resources = [format(
+      "arn:aws:route53:::hostedzone/%s",
+      terraform.workspace == local.live_workspace ? "*" : data.terraform_remote_state.cluster.outputs.hosted_zone_id,
+    )]
   }
 
   statement {
@@ -33,8 +44,8 @@ data "aws_iam_policy_document" "external_dns" {
 
 resource "aws_iam_role_policy" "external_dns" {
   name   = "route53"
-  role   = "${aws_iam_role.external_dns.id}"
-  policy = "${data.aws_iam_policy_document.external_dns.json}"
+  role   = aws_iam_role.external_dns.id
+  policy = data.aws_iam_policy_document.external_dns.json
 }
 
 resource "helm_release" "external_dns" {
@@ -43,7 +54,8 @@ resource "helm_release" "external_dns" {
   namespace = "kube-system"
   version   = "2.6.4"
 
-  values = [<<EOF
+  values = [
+    <<EOF
 image:
   tag: 0.5.17-debian-9-r0
 sources:
@@ -54,7 +66,10 @@ aws:
   region: eu-west-2
   zoneType: public
 domainFilters:
-  ${terraform.workspace == local.live_workspace ? "" : format("- %s", data.terraform_remote_state.cluster.cluster_domain_name)}
+  ${terraform.workspace == local.live_workspace ? "" : format(
+    "- %s",
+    data.terraform_remote_state.cluster.outputs.cluster_domain_name,
+)}
 rbac:
   create: true
   apiVersion: v1
@@ -64,15 +79,17 @@ logLevel: info
 podAnnotations:
   iam.amazonaws.com/role: "${aws_iam_role.external_dns.name}"
 EOF
-  ]
+,
+]
 
-  depends_on = [
-    "null_resource.deploy",
-    "helm_release.kiam",
-    "helm_release.open-policy-agent",
-  ]
+depends_on = [
+  null_resource.deploy,
+  helm_release.kiam,
+  helm_release.open-policy-agent,
+]
 
-  lifecycle {
-    ignore_changes = ["keyring"]
-  }
+lifecycle {
+  ignore_changes = [keyring]
 }
+}
+

--- a/terraform/cloud-platform-components/fluentd.tf
+++ b/terraform/cloud-platform-components/fluentd.tf
@@ -2,11 +2,11 @@ resource "kubernetes_namespace" "logging" {
   metadata {
     name = "logging"
 
-    labels {
+    labels = {
       "component" = "logging"
     }
 
-    annotations {
+    annotations = {
       "cloud-platform.justice.gov.uk/application"                = "Logging"
       "cloud-platform.justice.gov.uk/business-unit"              = "cloud-platform"
       "cloud-platform.justice.gov.uk/owner"                      = "Cloud Platform: platforms@digital.justice.gov.uk"
@@ -24,8 +24,7 @@ resource "helm_release" "fluentd_es" {
 
   set {
     name  = "fluent_elasticsearch_host"
-    value = "${replace(terraform.workspace, "live", "") != terraform.workspace ? "search-cloud-platform-live-dibidbfud3uww3lpxnhj2jdws4.eu-west-2.es.amazonaws.com" : "placeholder-elasticsearch"}"
-
+    value = replace(terraform.workspace, "live", "") != terraform.workspace ? "search-cloud-platform-live-dibidbfud3uww3lpxnhj2jdws4.eu-west-2.es.amazonaws.com" : "placeholder-elasticsearch"
     # if you need to connect to the test elasticsearch cluster, replace "placeholder-elasticsearch" with "search-cloud-platform-test-zradqd7twglkaydvgwhpuypzy4.eu-west-2.es.amazonaws.com"
     # -> value = "${replace(terraform.workspace, "live", "") != terraform.workspace ? "search-cloud-platform-live-dibidbfud3uww3lpxnhj2jdws4.eu-west-2.es.amazonaws.com" : "search-cloud-platform-test-zradqd7twglkaydvgwhpuypzy4.eu-west-2.es.amazonaws.com"
     # Your cluster will need to be whitelisted.
@@ -33,12 +32,12 @@ resource "helm_release" "fluentd_es" {
 
   set {
     name  = "fluent_elasticsearch_audit_host"
-    value = "${replace(terraform.workspace, "live", "") != terraform.workspace ? "search-cloud-platform-audit-dq5bdnjokj4yt7qozshmifug6e.eu-west-2.es.amazonaws.com" : ""}"
+    value = replace(terraform.workspace, "live", "") != terraform.workspace ? "search-cloud-platform-audit-dq5bdnjokj4yt7qozshmifug6e.eu-west-2.es.amazonaws.com" : ""
   }
 
   set {
     name  = "fluent_kubernetes_cluster_name"
-    value = "${terraform.workspace}"
+    value = terraform.workspace
   }
 
   set {
@@ -47,12 +46,13 @@ resource "helm_release" "fluentd_es" {
   }
 
   depends_on = [
-    "kubernetes_namespace.logging",
-    "null_resource.deploy",
-    "null_resource.priority_classes",
+    kubernetes_namespace.logging,
+    null_resource.deploy,
+    null_resource.priority_classes,
   ]
 
   lifecycle {
-    ignore_changes = ["keyring"]
+    ignore_changes = [keyring]
   }
 }
+

--- a/terraform/cloud-platform-components/helm.tf
+++ b/terraform/cloud-platform-components/helm.tf
@@ -26,8 +26,8 @@ resource "kubernetes_cluster_role_binding" "tiller" {
 
 resource "null_resource" "deploy" {
   depends_on = [
-    "kubernetes_service_account.tiller",
-    "kubernetes_cluster_role_binding.tiller",
+    kubernetes_service_account.tiller,
+    kubernetes_cluster_role_binding.tiller,
   ]
 
   provisioner "local-exec" {
@@ -35,7 +35,8 @@ resource "null_resource" "deploy" {
   }
 
   provisioner "local-exec" {
-    when    = "destroy"
+    when    = destroy
     command = "kubectl -n kube-system delete deployment.apps/tiller-deploy service/tiller-deploy"
   }
 }
+

--- a/terraform/cloud-platform-components/kuberos.tf
+++ b/terraform/cloud-platform-components/kuberos.tf
@@ -5,38 +5,46 @@ resource "helm_release" "kuberos" {
   recreate_pods = true
 
   set {
-    name  = "ingress.host"
-    value = "${terraform.workspace == local.live_workspace ? format("%s.%s", "login", local.live_domain) : format("%s.%s", "login.apps", data.terraform_remote_state.cluster.cluster_domain_name)}"
+    name = "ingress.host"
+    value = terraform.workspace == local.live_workspace ? format("%s.%s", "login", local.live_domain) : format(
+      "%s.%s",
+      "login.apps",
+      data.terraform_remote_state.cluster.outputs.cluster_domain_name,
+    )
   }
 
   set {
-    name  = "ingress.tls.secretName.host"
-    value = "${terraform.workspace == local.live_workspace ? format("%s.%s", "login", local.live_domain) : format("%s.%s", "login.apps", data.terraform_remote_state.cluster.cluster_domain_name)}"
+    name = "ingress.tls.secretName.host"
+    value = terraform.workspace == local.live_workspace ? format("%s.%s", "login", local.live_domain) : format(
+      "%s.%s",
+      "login.apps",
+      data.terraform_remote_state.cluster.outputs.cluster_domain_name,
+    )
   }
 
   set {
     name  = "cluster.name"
-    value = "${data.terraform_remote_state.cluster.cluster_domain_name}"
+    value = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   }
 
   set {
     name  = "cluster.address"
-    value = "https://api.${data.terraform_remote_state.cluster.cluster_domain_name}"
+    value = "https://api.${data.terraform_remote_state.cluster.outputs.cluster_domain_name}"
   }
 
   set {
     name  = "oidc.issuerUrl"
-    value = "${data.terraform_remote_state.cluster.oidc_issuer_url}"
+    value = data.terraform_remote_state.cluster.outputs.oidc_issuer_url
   }
 
   set {
     name  = "oidc.clientId"
-    value = "${data.terraform_remote_state.cluster.oidc_kubernetes_client_id}"
+    value = data.terraform_remote_state.cluster.outputs.oidc_kubernetes_client_id
   }
 
   set {
     name  = "oidc.clientSecret"
-    value = "${data.terraform_remote_state.cluster.oidc_kubernetes_client_secret}"
+    value = data.terraform_remote_state.cluster.outputs.oidc_kubernetes_client_secret
   }
 
   set {
@@ -44,9 +52,10 @@ resource "helm_release" "kuberos" {
     value = "2"
   }
 
-  depends_on = ["null_resource.deploy"]
+  depends_on = [null_resource.deploy]
 
   lifecycle {
-    ignore_changes = ["keyring"]
+    ignore_changes = [keyring]
   }
 }
+

--- a/terraform/cloud-platform-components/main.tf
+++ b/terraform/cloud-platform-components/main.tf
@@ -13,16 +13,18 @@ provider "aws" {
   region  = "eu-west-2"
 }
 
-provider "kubernetes" {}
+provider "kubernetes" {
+}
 
 provider "helm" {
-  kubernetes {}
+  kubernetes {
+  }
 }
 
 data "terraform_remote_state" "cluster" {
   backend = "s3"
 
-  config {
+  config = {
     bucket  = "cloud-platform-terraform-state"
     region  = "eu-west-1"
     key     = "cloud-platform/${terraform.workspace}/terraform.tfstate"
@@ -33,7 +35,7 @@ data "terraform_remote_state" "cluster" {
 data "terraform_remote_state" "global" {
   backend = "s3"
 
-  config {
+  config = {
     bucket  = "cloud-platform-terraform-state"
     region  = "eu-west-1"
     key     = "global-resources/terraform.tfstate"
@@ -43,10 +45,11 @@ data "terraform_remote_state" "global" {
 
 // This is the kubernetes role that node hosts are assigned.
 data "aws_iam_role" "nodes" {
-  name = "nodes.${data.terraform_remote_state.cluster.cluster_domain_name}"
+  name = "nodes.${data.terraform_remote_state.cluster.outputs.cluster_domain_name}"
 }
 
-data "aws_caller_identity" "current" {}
+data "aws_caller_identity" "current" {
+}
 
 provider "aws" {
   alias   = "dsd"
@@ -58,3 +61,4 @@ locals {
   live_workspace = "live-1"
   live_domain    = "cloud-platform.service.justice.gov.uk"
 }
+

--- a/terraform/cloud-platform-components/metrics-server.tf
+++ b/terraform/cloud-platform-components/metrics-server.tf
@@ -14,9 +14,10 @@ resource "helm_release" "metrics_server" {
     value = "--logtostderr"
   }
 
-  depends_on = ["null_resource.deploy"]
+  depends_on = [null_resource.deploy]
 
   lifecycle {
-    ignore_changes = ["keyring"]
+    ignore_changes = [keyring]
   }
 }
+

--- a/terraform/cloud-platform-components/nginx-ingress-acme.tf
+++ b/terraform/cloud-platform-components/nginx-ingress-acme.tf
@@ -2,14 +2,14 @@ resource "kubernetes_namespace" "ingress_controllers" {
   metadata {
     name = "ingress-controllers"
 
-    labels {
+    labels = {
       "name"                                           = "ingress-controllers"
       "component"                                      = "ingress-controllers"
       "cloud-platform.justice.gov.uk/environment-name" = "production"
       "cloud-platform.justice.gov.uk/is-production"    = "true"
     }
 
-    annotations {
+    annotations = {
       "cloud-platform.justice.gov.uk/application"                   = "Kubernetes Ingress Controllers"
       "cloud-platform.justice.gov.uk/business-unit"                 = "cloud-platform"
       "cloud-platform.justice.gov.uk/owner"                         = "Cloud Platform: platforms@digital.justice.gov.uk"
@@ -25,7 +25,8 @@ resource "helm_release" "nginx_ingress_acme" {
   namespace = "ingress-controllers"
   version   = "v1.24.0"
 
-  values = [<<EOF
+  values = [
+    <<EOF
 controller:
   replicaCount: 6
 
@@ -100,7 +101,7 @@ controller:
 
   service:
     annotations:
-      external-dns.alpha.kubernetes.io/hostname: "*.apps.${data.terraform_remote_state.cluster.cluster_domain_name},apps.${data.terraform_remote_state.cluster.cluster_domain_name}${terraform.workspace == local.live_workspace ? format(",*.%s", local.live_domain) : ""}"
+      external-dns.alpha.kubernetes.io/hostname: "*.apps.${data.terraform_remote_state.cluster.outputs.cluster_domain_name},apps.${data.terraform_remote_state.cluster.outputs.cluster_domain_name}${terraform.workspace == local.live_workspace ? format(",*.%s", local.live_domain) : ""}"
       service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
 
     externalTrafficPolicy: "Local"
@@ -149,6 +150,7 @@ defaultBackend:
 rbac:
   create: true
 EOF
+    ,
   ]
 
   // Although it _does_ depend on cert-manager for getting the default
@@ -156,27 +158,29 @@ EOF
   // self-signed certificate until the proper one becomes available. This
   // dependency is not captured here.
   depends_on = [
-    "null_resource.deploy",
-    "kubernetes_namespace.ingress_controllers",
-    "helm_release.open-policy-agent",
+    null_resource.deploy,
+    kubernetes_namespace.ingress_controllers,
+    helm_release.open-policy-agent,
   ]
 
   lifecycle {
-    ignore_changes = ["keyring"]
+    ignore_changes = [keyring]
   }
 }
 
 data "template_file" "nginx_ingress_default_certificate" {
-  template = "${file("${path.module}/templates/nginx-ingress/default-certificate.yaml")}"
+  template = file(
+    "${path.module}/templates/nginx-ingress/default-certificate.yaml",
+  )
 
-  vars {
-    common_name = "*.apps.${data.terraform_remote_state.cluster.cluster_domain_name}"
-    alt_name    = "${terraform.workspace == local.live_workspace ? format("- '*.%s'", local.live_domain) : ""}"
+  vars = {
+    common_name = "*.apps.${data.terraform_remote_state.cluster.outputs.cluster_domain_name}"
+    alt_name    = terraform.workspace == local.live_workspace ? format("- '*.%s'", local.live_domain) : ""
   }
 }
 
 resource "null_resource" "nginx_ingress_default_certificate" {
-  depends_on = ["helm_release.cert-manager"]
+  depends_on = [helm_release.cert-manager]
 
   provisioner "local-exec" {
     command = <<EOS
@@ -184,36 +188,41 @@ kubectl apply -n ingress-controllers -f - <<EOF
 ${data.template_file.nginx_ingress_default_certificate.rendered}
 EOF
 EOS
+
   }
 
   provisioner "local-exec" {
-    when = "destroy"
+    when = destroy
 
     command = <<EOS
 kubectl delete -n ingress-controllers -f - <<EOF
 ${data.template_file.nginx_ingress_default_certificate.rendered}
 EOF
 EOS
+
   }
 
-  triggers {
-    contents = "${sha1("${data.template_file.nginx_ingress_default_certificate.rendered}")}"
+  triggers = {
+    contents = sha1(
+      data.template_file.nginx_ingress_default_certificate.rendered,
+    )
   }
 }
 
 resource "null_resource" "nginx_ingress_servicemonitor" {
-  depends_on = ["helm_release.prometheus_operator"]
+  depends_on = [helm_release.prometheus_operator]
 
   provisioner "local-exec" {
     command = "kubectl apply -n ingress-controllers -f ${path.module}/resources/nginx-ingress/servicemonitor.yaml"
   }
 
   provisioner "local-exec" {
-    when    = "destroy"
+    when    = destroy
     command = "kubectl delete -n ingress-controllers -f ${path.module}/resources/nginx-ingress/servicemonitor.yaml"
   }
 
-  triggers {
-    contents = "${sha1(file("${path.module}/resources/nginx-ingress/servicemonitor.yaml"))}"
+  triggers = {
+    contents = filesha1("${path.module}/resources/nginx-ingress/servicemonitor.yaml")
   }
 }
+

--- a/terraform/cloud-platform-components/opa.tf
+++ b/terraform/cloud-platform-components/opa.tf
@@ -2,12 +2,12 @@ resource "kubernetes_namespace" "opa" {
   metadata {
     name = "opa"
 
-    labels {
+    labels = {
       "name"                        = "opa"
       "openpolicyagent.org/webhook" = "ignore"
     }
 
-    annotations {
+    annotations = {
       "cloud-platform.justice.gov.uk/application"   = "OPA"
       "cloud-platform.justice.gov.uk/business-unit" = "cloud-platform"
       "cloud-platform.justice.gov.uk/owner"         = "Cloud Platform: platforms@digital.justice.gov.uk"
@@ -17,7 +17,7 @@ resource "kubernetes_namespace" "opa" {
 }
 
 data "template_file" "values" {
-  template = "${file("${path.module}/templates/opa/values.yaml.tpl")}"
+  template = file("${path.module}/templates/opa/values.yaml.tpl")
 }
 
 resource "helm_release" "open-policy-agent" {
@@ -28,17 +28,17 @@ resource "helm_release" "open-policy-agent" {
   version    = "1.8.0"
 
   depends_on = [
-    "null_resource.kube_system_ns_label",
-    "kubernetes_namespace.opa",
-    "null_resource.deploy",
+    null_resource.kube_system_ns_label,
+    kubernetes_namespace.opa,
+    null_resource.deploy,
   ]
 
   values = [
-    "${data.template_file.values.rendered}",
+    data.template_file.values.rendered,
   ]
 
   lifecycle {
-    ignore_changes = ["keyring"]
+    ignore_changes = [keyring]
   }
 }
 
@@ -52,15 +52,15 @@ resource "null_resource" "kube_system_ns_label" {
 resource "kubernetes_config_map" "policy_default" {
   metadata {
     name      = "policy-default"
-    namespace = "${helm_release.open-policy-agent.namespace}"
+    namespace = helm_release.open-policy-agent.namespace
 
-    labels {
+    labels = {
       "openpolicyagent.org/policy" = "rego"
     }
   }
 
-  data {
-    main.rego = "${file("${path.module}/resources/opa/policies/main.rego")}"
+  data = {
+    main.rego = file("${path.module}/resources/opa/policies/main.rego")
   }
 
   lifecycle {
@@ -71,15 +71,17 @@ resource "kubernetes_config_map" "policy_default" {
 resource "kubernetes_config_map" "policy_cloud_platform_admission" {
   metadata {
     name      = "policy-cloud-platform-admission"
-    namespace = "${helm_release.open-policy-agent.namespace}"
+    namespace = helm_release.open-policy-agent.namespace
 
-    labels {
+    labels = {
       "openpolicyagent.org/policy" = "rego"
     }
   }
 
-  data {
-    main.rego = "${file("${path.module}/resources/opa/policies/cloud_platform_admission.rego")}"
+  data = {
+    main.rego = file(
+      "${path.module}/resources/opa/policies/cloud_platform_admission.rego",
+    )
   }
 
   lifecycle {
@@ -90,15 +92,15 @@ resource "kubernetes_config_map" "policy_cloud_platform_admission" {
 resource "kubernetes_config_map" "policy_ingress_clash" {
   metadata {
     name      = "policy-ingress-clash"
-    namespace = "${helm_release.open-policy-agent.namespace}"
+    namespace = helm_release.open-policy-agent.namespace
 
-    labels {
+    labels = {
       "openpolicyagent.org/policy" = "rego"
     }
   }
 
-  data {
-    main.rego = "${file("${path.module}/resources/opa/policies/ingress_clash.rego")}"
+  data = {
+    main.rego = file("${path.module}/resources/opa/policies/ingress_clash.rego")
   }
 
   lifecycle {
@@ -109,15 +111,15 @@ resource "kubernetes_config_map" "policy_ingress_clash" {
 resource "kubernetes_config_map" "policy_service_type" {
   metadata {
     name      = "policy-service-type"
-    namespace = "${helm_release.open-policy-agent.namespace}"
+    namespace = helm_release.open-policy-agent.namespace
 
-    labels {
+    labels = {
       "openpolicyagent.org/policy" = "rego"
     }
   }
 
-  data {
-    main.rego = "${file("${path.module}/resources/opa/policies/service_type.rego")}"
+  data = {
+    main.rego = file("${path.module}/resources/opa/policies/service_type.rego")
   }
 
   lifecycle {
@@ -128,15 +130,17 @@ resource "kubernetes_config_map" "policy_service_type" {
 resource "kubernetes_config_map" "policy_pod_toleration_withkey" {
   metadata {
     name      = "policy-pod-toleration-withkey"
-    namespace = "${helm_release.open-policy-agent.namespace}"
+    namespace = helm_release.open-policy-agent.namespace
 
-    labels {
+    labels = {
       "openpolicyagent.org/policy" = "rego"
     }
   }
 
-  data {
-    main.rego = "${file("${path.module}/resources/opa/policies/pod_toleration_withkey.rego")}"
+  data = {
+    main.rego = file(
+      "${path.module}/resources/opa/policies/pod_toleration_withkey.rego",
+    )
   }
 
   lifecycle {
@@ -147,18 +151,21 @@ resource "kubernetes_config_map" "policy_pod_toleration_withkey" {
 resource "kubernetes_config_map" "policy_pod_toleration_withnullkey" {
   metadata {
     name      = "policy-pod-toleration-withnullkey"
-    namespace = "${helm_release.open-policy-agent.namespace}"
+    namespace = helm_release.open-policy-agent.namespace
 
-    labels {
+    labels = {
       "openpolicyagent.org/policy" = "rego"
     }
   }
 
-  data {
-    main.rego = "${file("${path.module}/resources/opa/policies/pod_toleration_withnullkey.rego")}"
+  data = {
+    main.rego = file(
+      "${path.module}/resources/opa/policies/pod_toleration_withnullkey.rego",
+    )
   }
 
   lifecycle {
     ignore_changes = ["metadata.0.annotations"]
   }
 }
+

--- a/terraform/cloud-platform-components/opa.tf
+++ b/terraform/cloud-platform-components/opa.tf
@@ -60,7 +60,7 @@ resource "kubernetes_config_map" "policy_default" {
   }
 
   data = {
-    main.rego = file("${path.module}/resources/opa/policies/main.rego")
+    main = file("${path.module}/resources/opa/policies/main.rego")
   }
 
   lifecycle {
@@ -79,7 +79,7 @@ resource "kubernetes_config_map" "policy_cloud_platform_admission" {
   }
 
   data = {
-    main.rego = file(
+    main = file(
       "${path.module}/resources/opa/policies/cloud_platform_admission.rego",
     )
   }
@@ -100,7 +100,7 @@ resource "kubernetes_config_map" "policy_ingress_clash" {
   }
 
   data = {
-    main.rego = file("${path.module}/resources/opa/policies/ingress_clash.rego")
+    main = file("${path.module}/resources/opa/policies/ingress_clash.rego")
   }
 
   lifecycle {
@@ -119,7 +119,7 @@ resource "kubernetes_config_map" "policy_service_type" {
   }
 
   data = {
-    main.rego = file("${path.module}/resources/opa/policies/service_type.rego")
+    main = file("${path.module}/resources/opa/policies/service_type.rego")
   }
 
   lifecycle {
@@ -138,7 +138,7 @@ resource "kubernetes_config_map" "policy_pod_toleration_withkey" {
   }
 
   data = {
-    main.rego = file(
+    main = file(
       "${path.module}/resources/opa/policies/pod_toleration_withkey.rego",
     )
   }
@@ -159,7 +159,7 @@ resource "kubernetes_config_map" "policy_pod_toleration_withnullkey" {
   }
 
   data = {
-    main.rego = file(
+    main = file(
       "${path.module}/resources/opa/policies/pod_toleration_withnullkey.rego",
     )
   }

--- a/terraform/cloud-platform-components/opa.tf
+++ b/terraform/cloud-platform-components/opa.tf
@@ -64,7 +64,7 @@ resource "kubernetes_config_map" "policy_default" {
   }
 
   lifecycle {
-    ignore_changes = ["metadata.0.annotations"]
+    ignore_changes = [metadata.0.annotations]
   }
 }
 
@@ -85,7 +85,7 @@ resource "kubernetes_config_map" "policy_cloud_platform_admission" {
   }
 
   lifecycle {
-    ignore_changes = ["metadata.0.annotations"]
+    ignore_changes = [metadata.0.annotations]
   }
 }
 
@@ -104,7 +104,7 @@ resource "kubernetes_config_map" "policy_ingress_clash" {
   }
 
   lifecycle {
-    ignore_changes = ["metadata.0.annotations"]
+    ignore_changes = [metadata.0.annotations]
   }
 }
 
@@ -123,7 +123,7 @@ resource "kubernetes_config_map" "policy_service_type" {
   }
 
   lifecycle {
-    ignore_changes = ["metadata.0.annotations"]
+    ignore_changes = [metadata.0.annotations]
   }
 }
 
@@ -144,7 +144,7 @@ resource "kubernetes_config_map" "policy_pod_toleration_withkey" {
   }
 
   lifecycle {
-    ignore_changes = ["metadata.0.annotations"]
+    ignore_changes = [metadata.0.annotations]
   }
 }
 
@@ -165,7 +165,7 @@ resource "kubernetes_config_map" "policy_pod_toleration_withnullkey" {
   }
 
   lifecycle {
-    ignore_changes = ["metadata.0.annotations"]
+    ignore_changes = [metadata.0.annotations]
   }
 }
 

--- a/terraform/cloud-platform-components/priorityclasses.tf
+++ b/terraform/cloud-platform-components/priorityclasses.tf
@@ -4,11 +4,12 @@ resource "null_resource" "priority_classes" {
   }
 
   provisioner "local-exec" {
-    when    = "destroy"
+    when    = destroy
     command = "kubectl delete -f ${path.module}/resources/priorityclasses.yaml"
   }
 
-  triggers {
-    contents = "${sha1(file("${path.module}/resources/priorityclasses.yaml"))}"
+  triggers = {
+    contents = filesha1("${path.module}/resources/priorityclasses.yaml")
   }
 }
+

--- a/terraform/cloud-platform-components/prometheus.tf
+++ b/terraform/cloud-platform-components/prometheus.tf
@@ -5,11 +5,11 @@ resource "kubernetes_namespace" "monitoring" {
   metadata {
     name = "monitoring"
 
-    labels {
+    labels = {
       "component" = "monitoring"
     }
 
-    annotations {
+    annotations = {
       "cloud-platform.justice.gov.uk/application"                = "Monitoring"
       "cloud-platform.justice.gov.uk/business-unit"              = "cloud-platform"
       "cloud-platform.justice.gov.uk/owner"                      = "Cloud Platform: platforms@digital.justice.gov.uk"
@@ -20,24 +20,24 @@ resource "kubernetes_namespace" "monitoring" {
   }
 
   lifecycle {
-    ignore_changes = ["metadata"]
+    ignore_changes = [metadata]
   }
 }
 
 resource "kubernetes_secret" "grafana_secret" {
-  depends_on = ["kubernetes_namespace.monitoring"]
+  depends_on = [kubernetes_namespace.monitoring]
 
   metadata {
     name      = "grafana-env"
     namespace = "monitoring"
   }
 
-  data {
-    GF_AUTH_GENERIC_OAUTH_CLIENT_ID     = "${data.terraform_remote_state.cluster.oidc_components_client_id}"
-    GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET = "${data.terraform_remote_state.cluster.oidc_components_client_secret}"
-    GF_AUTH_GENERIC_OAUTH_AUTH_URL      = "${data.terraform_remote_state.cluster.oidc_issuer_url}authorize"
-    GF_AUTH_GENERIC_OAUTH_TOKEN_URL     = "${data.terraform_remote_state.cluster.oidc_issuer_url}oauth/token"
-    GF_AUTH_GENERIC_OAUTH_API_URL       = "${data.terraform_remote_state.cluster.oidc_issuer_url}userinfo"
+  data = {
+    GF_AUTH_GENERIC_OAUTH_CLIENT_ID     = data.terraform_remote_state.cluster.outputs.oidc_components_client_id
+    GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET = data.terraform_remote_state.cluster.outputs.oidc_components_client_secret
+    GF_AUTH_GENERIC_OAUTH_AUTH_URL      = "${data.terraform_remote_state.cluster.outputs.oidc_issuer_url}authorize"
+    GF_AUTH_GENERIC_OAUTH_TOKEN_URL     = "${data.terraform_remote_state.cluster.outputs.oidc_issuer_url}oauth/token"
+    GF_AUTH_GENERIC_OAUTH_API_URL       = "${data.terraform_remote_state.cluster.outputs.oidc_issuer_url}userinfo"
   }
 
   type = "Opaque"
@@ -52,7 +52,7 @@ resource "random_id" "password" {
 }
 
 data "template_file" "alertmanager_routes" {
-  count = "${length(var.alertmanager_slack_receivers)}"
+  count = length(var.alertmanager_slack_receivers)
 
   template = <<EOS
 - match:
@@ -60,11 +60,12 @@ data "template_file" "alertmanager_routes" {
   receiver: slack-$${severity}
 EOS
 
-  vars = "${var.alertmanager_slack_receivers[count.index]}"
+
+  vars = var.alertmanager_slack_receivers[count.index]
 }
 
 data "template_file" "alertmanager_receivers" {
-  count = "${length(var.alertmanager_slack_receivers)}"
+  count = length(var.alertmanager_slack_receivers)
 
   template = <<EOS
 - name: 'slack-$${severity}'
@@ -87,29 +88,46 @@ data "template_file" "alertmanager_receivers" {
       url: '{{ template "__alert_silence_link" . }}'
 EOS
 
-  vars = "${var.alertmanager_slack_receivers[count.index]}"
+
+  vars = var.alertmanager_slack_receivers[count.index]
 }
 
 locals {
-  alertmanager_ingress = "${terraform.workspace == local.live_workspace ? format("%s.%s", "https://alertmanager", local.live_domain) : format("%s.%s", "https://alertmanager.apps", data.terraform_remote_state.cluster.cluster_domain_name)}"
-  grafana_ingress      = "${terraform.workspace == local.live_workspace ? format("%s.%s", "grafana", local.live_domain) : format("%s.%s", "grafana.apps", data.terraform_remote_state.cluster.cluster_domain_name)}"
-  grafana_root         = "${terraform.workspace == local.live_workspace ? format("%s.%s", "https://grafana", local.live_domain) : format("%s.%s", "https://grafana.apps", data.terraform_remote_state.cluster.cluster_domain_name)}"
-  prometheus_ingress   = "${terraform.workspace == local.live_workspace ? format("%s.%s", "https://prometheus", local.live_domain) : format("%s.%s", "https://prometheus.apps", data.terraform_remote_state.cluster.cluster_domain_name)}"
+  alertmanager_ingress = terraform.workspace == local.live_workspace ? format("%s.%s", "https://alertmanager", local.live_domain) : format(
+    "%s.%s",
+    "https://alertmanager.apps",
+    data.terraform_remote_state.cluster.outputs.cluster_domain_name,
+  )
+  grafana_ingress = terraform.workspace == local.live_workspace ? format("%s.%s", "grafana", local.live_domain) : format(
+    "%s.%s",
+    "grafana.apps",
+    data.terraform_remote_state.cluster.outputs.cluster_domain_name,
+  )
+  grafana_root = terraform.workspace == local.live_workspace ? format("%s.%s", "https://grafana", local.live_domain) : format(
+    "%s.%s",
+    "https://grafana.apps",
+    data.terraform_remote_state.cluster.outputs.cluster_domain_name,
+  )
+  prometheus_ingress = terraform.workspace == local.live_workspace ? format("%s.%s", "https://prometheus", local.live_domain) : format(
+    "%s.%s",
+    "https://prometheus.apps",
+    data.terraform_remote_state.cluster.outputs.cluster_domain_name,
+  )
 }
 
 data "template_file" "prometheus_operator" {
-  template = "${file("${ path.module }/templates/prometheus-operator.yaml.tpl")}"
+  template = file("${path.module}/templates/prometheus-operator.yaml.tpl")
 
-  vars {
-    alertmanager_ingress   = "${local.alertmanager_ingress}"
-    grafana_ingress        = "${local.grafana_ingress}"
-    grafana_root           = "${local.grafana_root}"
-    pagerduty_config       = "${ var.pagerduty_config }"
-    alertmanager_routes    = "${join("", data.template_file.alertmanager_routes.*.rendered)}"
-    alertmanager_receivers = "${join("", data.template_file.alertmanager_receivers.*.rendered)}"
-    prometheus_ingress     = "${local.prometheus_ingress}"
-    random_username        = "${ random_id.username.hex }"
-    random_password        = "${ random_id.password.hex }"
+  vars = {
+    alertmanager_ingress   = local.alertmanager_ingress
+    grafana_ingress        = local.grafana_ingress
+    grafana_root           = local.grafana_root
+    pagerduty_config       = var.pagerduty_config
+    alertmanager_routes    = join("", data.template_file.alertmanager_routes.*.rendered)
+    alertmanager_receivers = join("", data.template_file.alertmanager_receivers.*.rendered)
+    prometheus_ingress     = local.prometheus_ingress
+    random_username        = random_id.username.hex
+    random_password        = random_id.password.hex
   }
 }
 
@@ -120,15 +138,15 @@ resource "helm_release" "prometheus_operator" {
   version   = "3.0.0"
 
   values = [
-    "${ data.template_file.prometheus_operator.rendered }",
+    data.template_file.prometheus_operator.rendered,
   ]
 
   # Depends on Helm being installed
   depends_on = [
-    "null_resource.deploy",
-    "kubernetes_secret.grafana_secret",
-    "helm_release.open-policy-agent",
-    "helm_release.nginx_ingress_acme",
+    null_resource.deploy,
+    kubernetes_secret.grafana_secret,
+    helm_release.open-policy-agent,
+    helm_release.nginx_ingress_acme,
   ]
 
   provisioner "local-exec" {
@@ -137,13 +155,15 @@ resource "helm_release" "prometheus_operator" {
 
   # Delete Prometheus leftovers
   # Ref: https://github.com/coreos/prometheus-operator#removal
+  # Delete Prometheus leftovers
+  # Ref: https://github.com/coreos/prometheus-operator#removal
   provisioner "local-exec" {
-    when    = "destroy"
+    when    = destroy
     command = "kubectl delete svc -l k8s-app=kubelet -n kube-system"
   }
 
   lifecycle {
-    ignore_changes = ["keyring"]
+    ignore_changes = [keyring]
   }
 }
 
@@ -154,16 +174,20 @@ resource "random_id" "session_secret" {
 }
 
 data "template_file" "prometheus_proxy" {
-  template = "${file("${path.module}/templates/oauth2-proxy.yaml.tpl")}"
+  template = file("${path.module}/templates/oauth2-proxy.yaml.tpl")
 
-  vars {
-    upstream      = "http://prometheus-operator-prometheus:9090"
-    hostname      = "${terraform.workspace == local.live_workspace ? format("%s.%s", "prometheus", local.live_domain) : format("%s.%s", "prometheus.apps", data.terraform_remote_state.cluster.cluster_domain_name)}"
+  vars = {
+    upstream = "http://prometheus-operator-prometheus:9090"
+    hostname = terraform.workspace == local.live_workspace ? format("%s.%s", "prometheus", local.live_domain) : format(
+      "%s.%s",
+      "prometheus.apps",
+      data.terraform_remote_state.cluster.outputs.cluster_domain_name,
+    )
     exclude_paths = "^/-/healthy$"
-    issuer_url    = "${data.terraform_remote_state.cluster.oidc_issuer_url}"
-    client_id     = "${data.terraform_remote_state.cluster.oidc_components_client_id}"
-    client_secret = "${data.terraform_remote_state.cluster.oidc_components_client_secret}"
-    cookie_secret = "${random_id.session_secret.b64_std}"
+    issuer_url    = data.terraform_remote_state.cluster.outputs.oidc_issuer_url
+    client_id     = data.terraform_remote_state.cluster.outputs.oidc_components_client_id
+    client_secret = data.terraform_remote_state.cluster.outputs.oidc_components_client_secret
+    cookie_secret = random_id.session_secret.b64_std
   }
 }
 
@@ -174,31 +198,35 @@ resource "helm_release" "prometheus_proxy" {
   version   = "0.9.1"
 
   values = [
-    "${data.template_file.prometheus_proxy.rendered}",
+    data.template_file.prometheus_proxy.rendered,
   ]
 
   depends_on = [
-    "null_resource.deploy",
-    "random_id.session_secret",
-    "helm_release.open-policy-agent",
+    null_resource.deploy,
+    random_id.session_secret,
+    helm_release.open-policy-agent,
   ]
 
   lifecycle {
-    ignore_changes = ["keyring"]
+    ignore_changes = [keyring]
   }
 }
 
 data "template_file" "alertmanager_proxy" {
-  template = "${file("${path.module}/templates/oauth2-proxy.yaml.tpl")}"
+  template = file("${path.module}/templates/oauth2-proxy.yaml.tpl")
 
-  vars {
-    upstream      = "http://prometheus-operator-alertmanager:9093"
-    hostname      = "${terraform.workspace == local.live_workspace ? format("%s.%s", "alertmanager", local.live_domain) : format("%s.%s", "alertmanager.apps", data.terraform_remote_state.cluster.cluster_domain_name)}"
+  vars = {
+    upstream = "http://prometheus-operator-alertmanager:9093"
+    hostname = terraform.workspace == local.live_workspace ? format("%s.%s", "alertmanager", local.live_domain) : format(
+      "%s.%s",
+      "alertmanager.apps",
+      data.terraform_remote_state.cluster.outputs.cluster_domain_name,
+    )
     exclude_paths = "^/-/healthy$"
-    issuer_url    = "${data.terraform_remote_state.cluster.oidc_issuer_url}"
-    client_id     = "${data.terraform_remote_state.cluster.oidc_components_client_id}"
-    client_secret = "${data.terraform_remote_state.cluster.oidc_components_client_secret}"
-    cookie_secret = "${random_id.session_secret.b64_std}"
+    issuer_url    = data.terraform_remote_state.cluster.outputs.oidc_issuer_url
+    client_id     = data.terraform_remote_state.cluster.outputs.oidc_components_client_id
+    client_secret = data.terraform_remote_state.cluster.outputs.oidc_components_client_secret
+    cookie_secret = random_id.session_secret.b64_std
   }
 }
 
@@ -209,16 +237,17 @@ resource "helm_release" "alertmanager_proxy" {
   version   = "0.9.1"
 
   values = [
-    "${data.template_file.alertmanager_proxy.rendered}",
+    data.template_file.alertmanager_proxy.rendered,
   ]
 
   depends_on = [
-    "null_resource.deploy",
-    "random_id.session_secret",
-    "helm_release.open-policy-agent",
+    null_resource.deploy,
+    random_id.session_secret,
+    helm_release.open-policy-agent,
   ]
 
   lifecycle {
-    ignore_changes = ["keyring"]
+    ignore_changes = [keyring]
   }
 }
+

--- a/terraform/cloud-platform-components/psp.tf
+++ b/terraform/cloud-platform-components/psp.tf
@@ -4,11 +4,12 @@ resource "null_resource" "pod_security_policy" {
   }
 
   provisioner "local-exec" {
-    when    = "destroy"
+    when    = destroy
     command = "kubectl delete --ignore-not-found -f ${path.module}/resources/psp/pod-security-policy.yaml"
   }
 
-  triggers {
-    content = "${sha1(file("${path.module}/resources/psp/pod-security-policy.yaml"))}"
+  triggers = {
+    content = filesha1("${path.module}/resources/psp/pod-security-policy.yaml")
   }
 }
+

--- a/terraform/cloud-platform-components/rbac.tf
+++ b/terraform/cloud-platform-components/rbac.tf
@@ -15,3 +15,4 @@ resource "kubernetes_cluster_role_binding" "webops" {
     api_group = "rbac.authorization.k8s.io"
   }
 }
+

--- a/terraform/cloud-platform-components/storageclass.tf
+++ b/terraform/cloud-platform-components/storageclass.tf
@@ -4,7 +4,8 @@ resource "null_resource" "storageclass" {
   }
 
   provisioner "local-exec" {
-    when    = "destroy"
+    when    = destroy
     command = "kubectl delete -f ${path.module}/resources/storageclass.yaml"
   }
 }
+

--- a/terraform/cloud-platform-components/tzcronjobber.tf
+++ b/terraform/cloud-platform-components/tzcronjobber.tf
@@ -4,7 +4,8 @@ resource "null_resource" "tzcronjobber" {
   }
 
   provisioner "local-exec" {
-    when    = "destroy"
+    when    = destroy
     command = "kubectl delete -n kube-system --ignore-not-found -f ${path.module}/resources/tzcronjobber/"
   }
 }
+

--- a/terraform/cloud-platform-components/variables.tf
+++ b/terraform/cloud-platform-components/variables.tf
@@ -14,3 +14,11 @@ variable "cloud_platform_slack_webhook" {
   description = "Slack webhook to pass it to  script to send alerts"
 }
 
+variable "github_client_id" {
+}
+
+variable "github_client_secret" {
+}
+
+variable "github_secret_key" {
+}

--- a/terraform/cloud-platform-components/variables.tf
+++ b/terraform/cloud-platform-components/variables.tf
@@ -4,11 +4,13 @@ variable "pagerduty_config" {
 
 variable "alertmanager_slack_receivers" {
   description = "A list of configuration values for Slack receivers"
-  type        = "list"
+  type        = list(string)
 }
 
-variable "aws_master_account_id" {}
+variable "aws_master_account_id" {
+}
 
 variable "cloud_platform_slack_webhook" {
   description = "Slack webhook to pass it to  script to send alerts"
 }
+

--- a/terraform/cloud-platform-components/variables.tf
+++ b/terraform/cloud-platform-components/variables.tf
@@ -4,7 +4,7 @@ variable "pagerduty_config" {
 
 variable "alertmanager_slack_receivers" {
   description = "A list of configuration values for Slack receivers"
-  type        = list(string)
+  type        = "list"
 }
 
 variable "aws_master_account_id" {

--- a/terraform/cloud-platform-components/versions.tf
+++ b/terraform/cloud-platform-components/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/cloud-platform/bastion.tf
+++ b/terraform/cloud-platform/bastion.tf
@@ -190,7 +190,7 @@ resource "aws_autoscaling_group" "bastion" {
   # If the expression in the following list itself returns a list, remove the
   # brackets to avoid interpretation as a list of lists. If the expression
   # returns a single list item then leave it as-is and remove this TODO comment.
-  vpc_zone_identifier = [module.cluster_vpc.public_subnets]
+  vpc_zone_identifier = module.cluster_vpc.public_subnets
   default_cooldown    = 60
 
   tags = [

--- a/terraform/cloud-platform/kops.tf
+++ b/terraform/cloud-platform/kops.tf
@@ -1,5 +1,5 @@
 resource "local_file" "kops" {
-  content  = "${data.template_file.kops.rendered}"
+  content  = data.template_file.kops.rendered
   filename = "../../kops/${terraform.workspace}.yaml"
 }
 
@@ -8,25 +8,26 @@ resource "aws_kms_key" "kms" {
 }
 
 data "template_file" "kops" {
-  template = "${file("./templates/kops.yaml.tpl")}"
+  template = file("./templates/kops.yaml.tpl")
 
-  vars {
-    cluster_domain_name                  = "${local.cluster_base_domain_name}"
-    cluster_node_count                   = "${local.is_live_cluster ? var.cluster_node_count : 3}"
-    kops_state_store                     = "${data.terraform_remote_state.global.cloud_platform_kops_state}"
-    oidc_issuer_url                      = "${local.oidc_issuer_url}"
-    oidc_client_id                       = "${auth0_client.kubernetes.client_id}"
-    network_cidr_block                   = "${module.cluster_vpc.vpc_cidr_block}"
-    network_id                           = "${module.cluster_vpc.vpc_id}"
-    internal_subnets_id_a                = "${module.cluster_vpc.private_subnets[0]}"
-    internal_subnets_id_b                = "${module.cluster_vpc.private_subnets[1]}"
-    internal_subnets_id_c                = "${module.cluster_vpc.private_subnets[2]}"
-    external_subnets_id_a                = "${module.cluster_vpc.public_subnets[0]}"
-    external_subnets_id_b                = "${module.cluster_vpc.public_subnets[1]}"
-    external_subnets_id_c                = "${module.cluster_vpc.public_subnets[2]}"
-    authorized_keys_manager_systemd_unit = "${indent(6, data.template_file.authorized_keys_manager.rendered)}"
-    kms_key                              = "${aws_kms_key.kms.arn}"
-    worker_node_machine_type             = "${var.worker_node_machine_type}"
-    master_node_machine_type             = "${var.master_node_machine_type}"
+  vars = {
+    cluster_domain_name                  = local.cluster_base_domain_name
+    cluster_node_count                   = local.is_live_cluster ? var.cluster_node_count : 3
+    kops_state_store                     = data.terraform_remote_state.global.outputs.cloud_platform_kops_state
+    oidc_issuer_url                      = local.oidc_issuer_url
+    oidc_client_id                       = auth0_client.kubernetes.client_id
+    network_cidr_block                   = module.cluster_vpc.vpc_cidr_block
+    network_id                           = module.cluster_vpc.vpc_id
+    internal_subnets_id_a                = module.cluster_vpc.private_subnets[0]
+    internal_subnets_id_b                = module.cluster_vpc.private_subnets[1]
+    internal_subnets_id_c                = module.cluster_vpc.private_subnets[2]
+    external_subnets_id_a                = module.cluster_vpc.public_subnets[0]
+    external_subnets_id_b                = module.cluster_vpc.public_subnets[1]
+    external_subnets_id_c                = module.cluster_vpc.public_subnets[2]
+    authorized_keys_manager_systemd_unit = indent(6, data.template_file.authorized_keys_manager.rendered)
+    kms_key                              = aws_kms_key.kms.arn
+    worker_node_machine_type             = var.worker_node_machine_type
+    master_node_machine_type             = var.master_node_machine_type
   }
 }
+

--- a/terraform/cloud-platform/main.tf
+++ b/terraform/cloud-platform/main.tf
@@ -62,7 +62,7 @@ module "cluster_ssl" {
 }
 
 module "cluster_vpc" {
-  version              = "1.66.0"
+  version              = "2.18.0"
   source               = "terraform-aws-modules/vpc/aws"
   name                 = local.cluster_name
   cidr                 = var.vpc_cidr

--- a/terraform/cloud-platform/main.tf
+++ b/terraform/cloud-platform/main.tf
@@ -23,7 +23,7 @@ provider "aws" {
 # the AWS providr credentials are handled.
 #
 provider "auth0" {
-  version = ">= 0.1.18"
+  version = ">= 0.2.1"
   domain  = local.auth0_tenant_domain
 }
 

--- a/terraform/cloud-platform/main.tf
+++ b/terraform/cloud-platform/main.tf
@@ -24,13 +24,13 @@ provider "aws" {
 #
 provider "auth0" {
   version = ">= 0.1.18"
-  domain  = "${local.auth0_tenant_domain}"
+  domain  = local.auth0_tenant_domain
 }
 
 data "terraform_remote_state" "global" {
   backend = "s3"
 
-  config {
+  config = {
     bucket  = "cloud-platform-terraform-state"
     region  = "eu-west-1"
     key     = "global-resources/terraform.tfstate"
@@ -39,36 +39,36 @@ data "terraform_remote_state" "global" {
 }
 
 locals {
-  cluster_name             = "${terraform.workspace}"
+  cluster_name             = terraform.workspace
   cluster_base_domain_name = "${local.cluster_name}.cloud-platform.service.justice.gov.uk"
   auth0_tenant_domain      = "justice-cloud-platform.eu.auth0.com"
   oidc_issuer_url          = "https://${local.auth0_tenant_domain}/"
 
-  is_live_cluster      = "${terraform.workspace == "live-1"}"
-  services_base_domain = "${local.is_live_cluster ? "cloud-platform.service.justice.gov.uk" : "apps.${local.cluster_base_domain_name}"}"
+  is_live_cluster      = terraform.workspace == "live-1"
+  services_base_domain = local.is_live_cluster ? "cloud-platform.service.justice.gov.uk" : "apps.${local.cluster_base_domain_name}"
 }
 
 # Modules
 module "cluster_dns" {
   source                   = "../modules/cluster_dns"
-  cluster_base_domain_name = "${local.cluster_base_domain_name}"
-  parent_zone_id           = "${data.terraform_remote_state.global.cp_zone_id}"
+  cluster_base_domain_name = local.cluster_base_domain_name
+  parent_zone_id           = data.terraform_remote_state.global.outputs.cp_zone_id
 }
 
 module "cluster_ssl" {
   source                   = "../modules/cluster_ssl"
-  cluster_base_domain_name = "${local.cluster_base_domain_name}"
-  dns_zone_id              = "${module.cluster_dns.cluster_dns_zone_id}"
+  cluster_base_domain_name = local.cluster_base_domain_name
+  dns_zone_id              = module.cluster_dns.cluster_dns_zone_id
 }
 
 module "cluster_vpc" {
   version              = "1.66.0"
   source               = "terraform-aws-modules/vpc/aws"
-  name                 = "${local.cluster_name}"
-  cidr                 = "${var.vpc_cidr}"
-  azs                  = "${var.availability_zones}"
-  private_subnets      = "${var.internal_subnets}"
-  public_subnets       = "${var.external_subnets}"
+  name                 = local.cluster_name
+  cidr                 = var.vpc_cidr
+  azs                  = var.availability_zones
+  private_subnets      = var.internal_subnets
+  public_subnets       = var.external_subnets
   enable_nat_gateway   = true
   enable_vpn_gateway   = false
   enable_dns_hostnames = true
@@ -87,8 +87,8 @@ module "cluster_vpc" {
 
   tags = {
     Terraform = "true"
-    Cluster   = "${local.cluster_name}"
-    Domain    = "${local.cluster_base_domain_name}"
+    Cluster   = local.cluster_name
+    Domain    = local.cluster_base_domain_name
   }
 }
 
@@ -98,8 +98,8 @@ resource "tls_private_key" "cluster" {
 }
 
 resource "aws_key_pair" "cluster" {
-  key_name   = "${local.cluster_base_domain_name}"
-  public_key = "${tls_private_key.cluster.public_key_openssh}"
+  key_name   = local.cluster_base_domain_name
+  public_key = tls_private_key.cluster.public_key_openssh
 }
 
 resource "auth0_client" "kubernetes" {
@@ -107,14 +107,22 @@ resource "auth0_client" "kubernetes" {
   description = "Cloud Platform kubernetes"
   app_type    = "regular_web"
 
-  callbacks = ["${format("https://login.%s/ui", local.services_base_domain)}"]
+  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+  # force an interpolation expression to be interpreted as a list by wrapping it
+  # in an extra set of list brackets. That form was supported for compatibility in
+  # v0.11, but is no longer supported in Terraform v0.12.
+  #
+  # If the expression in the following list itself returns a list, remove the
+  # brackets to avoid interpretation as a list of lists. If the expression
+  # returns a single list item then leave it as-is and remove this TODO comment.
+  callbacks = [format("https://login.%s/ui", local.services_base_domain)]
 
   custom_login_page_on = true
   is_first_party       = true
   oidc_conformant      = true
   sso                  = true
 
-  jwt_configuration = {
+  jwt_configuration {
     alg                 = "RS256"
     lifetime_in_seconds = "2592000"
   }
@@ -126,13 +134,34 @@ resource "auth0_client" "components" {
   app_type    = "regular_web"
 
   callbacks = [
-    "${format("https://prometheus.%s/oauth2/callback", local.services_base_domain)}",
-    "${format("https://alertmanager.%s/oauth2/callback", local.services_base_domain)}",
-    "${format("https://concourse.%s/sky/issuer/callback", local.services_base_domain)}",
-    "${format("https://kibana.%s/oauth2/callback", local.services_base_domain)}",
-    "${format("https://kibana-audit.%s/oauth2/callback", local.services_base_domain)}",
-    "${format("https://grafana.%s/login/generic_oauth", local.services_base_domain)}",
-    "${format("https://kube-ops.%s/login/authorized", local.services_base_domain)}",
+    format(
+      "https://prometheus.%s/oauth2/callback",
+      local.services_base_domain,
+    ),
+    format(
+      "https://alertmanager.%s/oauth2/callback",
+      local.services_base_domain,
+    ),
+    format(
+      "https://concourse.%s/sky/issuer/callback",
+      local.services_base_domain,
+    ),
+    format(
+      "https://kibana.%s/oauth2/callback",
+      local.services_base_domain,
+    ),
+    format(
+      "https://kibana-audit.%s/oauth2/callback",
+      local.services_base_domain,
+    ),
+    format(
+      "https://grafana.%s/login/generic_oauth",
+      local.services_base_domain,
+    ),
+    format(
+      "https://kube-ops.%s/login/authorized",
+      local.services_base_domain,
+    ),
   ]
 
   custom_login_page_on = true
@@ -140,8 +169,9 @@ resource "auth0_client" "components" {
   oidc_conformant      = true
   sso                  = true
 
-  jwt_configuration = {
+  jwt_configuration {
     alg                 = "RS256"
     lifetime_in_seconds = "36000"
   }
 }
+

--- a/terraform/cloud-platform/outputs.tf
+++ b/terraform/cloud-platform/outputs.tf
@@ -1,75 +1,76 @@
 output "cluster_name" {
-  value = "${local.cluster_name}"
+  value = local.cluster_name
 }
 
 output "cluster_domain_name" {
-  value = "${local.cluster_base_domain_name}"
+  value = local.cluster_base_domain_name
 }
 
 output "network_id" {
-  value = "${module.cluster_vpc.vpc_id}"
+  value = module.cluster_vpc.vpc_id
 }
 
 output "network_cidr_block" {
-  value = "${module.cluster_vpc.vpc_cidr_block}"
+  value = module.cluster_vpc.vpc_cidr_block
 }
 
 output "kops_state_store" {
-  value = "${data.terraform_remote_state.global.cloud_platform_kops_state}"
+  value = data.terraform_remote_state.global.outputs.cloud_platform_kops_state
 }
 
 output "availability_zones" {
-  value = "${var.availability_zones}"
+  value = var.availability_zones
 }
 
 output "vpc_id" {
-  value = "${module.cluster_vpc.vpc_id}"
+  value = module.cluster_vpc.vpc_id
 }
 
 output "internal_subnets" {
-  value = "${var.internal_subnets}"
+  value = var.internal_subnets
 }
 
 output "internal_subnets_ids" {
-  value = "${module.cluster_vpc.private_subnets}"
+  value = module.cluster_vpc.private_subnets
 }
 
 output "external_subnets" {
-  value = "${var.external_subnets}"
+  value = var.external_subnets
 }
 
 output "external_subnets_ids" {
-  value = "${module.cluster_vpc.public_subnets}"
+  value = module.cluster_vpc.public_subnets
 }
 
 output "hosted_zone_id" {
-  value = "${module.cluster_dns.cluster_dns_zone_id}"
+  value = module.cluster_dns.cluster_dns_zone_id
 }
 
 output "instance_key_name" {
-  value = "${aws_key_pair.cluster.key_name}"
+  value = aws_key_pair.cluster.key_name
 }
 
 output "oidc_issuer_url" {
-  value = "${local.oidc_issuer_url}"
+  value = local.oidc_issuer_url
 }
 
 output "oidc_kubernetes_client_id" {
-  value = "${auth0_client.kubernetes.client_id}"
+  value = auth0_client.kubernetes.client_id
 }
 
 output "oidc_kubernetes_client_secret" {
-  value = "${auth0_client.kubernetes.client_secret}"
+  value = auth0_client.kubernetes.client_secret
 }
 
 output "oidc_components_client_id" {
-  value = "${auth0_client.components.client_id}"
+  value = auth0_client.components.client_id
 }
 
 output "oidc_components_client_secret" {
-  value = "${auth0_client.components.client_secret}"
+  value = auth0_client.components.client_secret
 }
 
 output "certificate_arn" {
-  value = "${module.cluster_ssl.apps_acm_arn}"
+  value = module.cluster_ssl.apps_acm_arn
 }
+

--- a/terraform/cloud-platform/variables.tf
+++ b/terraform/cloud-platform/variables.tf
@@ -4,19 +4,19 @@ variable "vpc_cidr" {
 }
 
 variable "internal_subnets" {
-  type        = "list"
+  type        = list(string)
   description = "list of subnet CIDR blocks that are not publicly acceessibly"
   default     = ["172.20.32.0/19", "172.20.64.0/19", "172.20.96.0/19"]
 }
 
 variable "external_subnets" {
-  type        = "list"
+  type        = list(string)
   description = "list of subnet CIDR blocks that are publicly acceessibly"
   default     = ["172.20.0.0/22", "172.20.4.0/22", "172.20.8.0/22"]
 }
 
 variable "availability_zones" {
-  type        = "list"
+  type        = list(string)
   description = "a list of EC2 availability zones"
   default     = ["eu-west-2a", "eu-west-2b", "eu-west-2c"]
 }
@@ -35,3 +35,4 @@ variable "worker_node_machine_type" {
   description = "The AWS EC2 instance types to use for worker nodes"
   default     = "r5.2xlarge"
 }
+

--- a/terraform/cloud-platform/versions.tf
+++ b/terraform/cloud-platform/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/aws_federation/iam_federation.tf
+++ b/terraform/modules/aws_federation/iam_federation.tf
@@ -1,15 +1,16 @@
 data "template_file" "saml_metadata" {
-  template = "${file("${path.module}/saml/auth0-saml-metadata.xml")}"
+  template = file("${path.module}/saml/auth0-saml-metadata.xml")
 
-  vars {
-    saml_x509_cert  = "${var.saml_x509_cert}"
-    saml_idp_domain = "${var.saml_idp_domain}"
-    saml_login_url  = "${var.saml_login_url}"
-    saml_logout_url = "${var.saml_logout_url}"
+  vars = {
+    saml_x509_cert  = var.saml_x509_cert
+    saml_idp_domain = var.saml_idp_domain
+    saml_login_url  = var.saml_login_url
+    saml_logout_url = var.saml_logout_url
   }
 }
 
 resource "aws_iam_saml_provider" "auth0" {
   name                   = "${var.env}-auth0"
-  saml_metadata_document = "${data.template_file.saml_metadata.rendered}"
+  saml_metadata_document = data.template_file.saml_metadata.rendered
 }
+

--- a/terraform/modules/aws_federation/iam_roles.tf
+++ b/terraform/modules/aws_federation/iam_roles.tf
@@ -4,7 +4,7 @@ data "aws_iam_policy_document" "federated_role_trust_policy" {
 
     principals {
       type        = "Federated"
-      identifiers = ["${aws_iam_saml_provider.auth0.arn}"]
+      identifiers = [aws_iam_saml_provider.auth0.arn]
     }
 
     actions = ["sts:AssumeRoleWithSAML"]
@@ -22,10 +22,11 @@ data "aws_iam_policy_document" "federated_role_trust_policy" {
 resource "aws_iam_role" "test_github_webops" {
   name = "test-github-webops"
 
-  assume_role_policy = "${data.aws_iam_policy_document.federated_role_trust_policy.json}"
+  assume_role_policy = data.aws_iam_policy_document.federated_role_trust_policy.json
 }
 
 resource "aws_iam_role_policy_attachment" "test_github_webops_admin" {
-  role       = "${aws_iam_role.test_github_webops.name}"
+  role       = aws_iam_role.test_github_webops.name
   policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
 }
+

--- a/terraform/modules/aws_federation/outputs.tf
+++ b/terraform/modules/aws_federation/outputs.tf
@@ -1,3 +1,4 @@
 output "saml_provider_arn" {
-  value = "${aws_iam_saml_provider.auth0.arn}"
+  value = aws_iam_saml_provider.auth0.arn
 }
+

--- a/terraform/modules/aws_federation/variables.tf
+++ b/terraform/modules/aws_federation/variables.tf
@@ -1,5 +1,15 @@
-variable "env" {}
-variable "saml_idp_domain" {}
-variable "saml_x509_cert" {}
-variable "saml_login_url" {}
-variable "saml_logout_url" {}
+variable "env" {
+}
+
+variable "saml_idp_domain" {
+}
+
+variable "saml_x509_cert" {
+}
+
+variable "saml_login_url" {
+}
+
+variable "saml_logout_url" {
+}
+

--- a/terraform/modules/aws_federation/versions.tf
+++ b/terraform/modules/aws_federation/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/cluster_dns/dns.tf
+++ b/terraform/modules/cluster_dns/dns.tf
@@ -4,12 +4,11 @@ resource "aws_route53_zone" "cluster" {
 }
 
 resource "aws_route53_record" "parent_zone_cluster_ns" {
-  zone_id = "${var.parent_zone_id}"
-  name    = "${aws_route53_zone.cluster.name}"
+  zone_id = var.parent_zone_id
+  name    = aws_route53_zone.cluster.name
   type    = "NS"
   ttl     = "30"
 
-  records = [
-    "${aws_route53_zone.cluster.name_servers}",
-  ]
+  records = aws_route53_zone.cluster.name_servers
 }
+

--- a/terraform/modules/cluster_dns/outputs.tf
+++ b/terraform/modules/cluster_dns/outputs.tf
@@ -1,7 +1,8 @@
 output "cluster_dns_zone_name" {
-  value = "${aws_route53_zone.cluster.name}"
+  value = aws_route53_zone.cluster.name
 }
 
 output "cluster_dns_zone_id" {
-  value = "${aws_route53_zone.cluster.zone_id}"
+  value = aws_route53_zone.cluster.zone_id
 }
+

--- a/terraform/modules/cluster_dns/variables.tf
+++ b/terraform/modules/cluster_dns/variables.tf
@@ -1,2 +1,6 @@
-variable "cluster_base_domain_name" {}
-variable "parent_zone_id" {}
+variable "cluster_base_domain_name" {
+}
+
+variable "parent_zone_id" {
+}
+

--- a/terraform/modules/cluster_dns/versions.tf
+++ b/terraform/modules/cluster_dns/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/cluster_ssl/acm.tf
+++ b/terraform/modules/cluster_ssl/acm.tf
@@ -4,14 +4,15 @@ resource "aws_acm_certificate" "apps" {
 }
 
 resource "aws_route53_record" "apps_cert_validation" {
-  name    = "${aws_acm_certificate.apps.domain_validation_options.0.resource_record_name}"
-  type    = "${aws_acm_certificate.apps.domain_validation_options.0.resource_record_type}"
-  zone_id = "${var.dns_zone_id}"
-  records = ["${aws_acm_certificate.apps.domain_validation_options.0.resource_record_value}"]
+  name    = aws_acm_certificate.apps.domain_validation_options[0].resource_record_name
+  type    = aws_acm_certificate.apps.domain_validation_options[0].resource_record_type
+  zone_id = var.dns_zone_id
+  records = [aws_acm_certificate.apps.domain_validation_options[0].resource_record_value]
   ttl     = 60
 }
 
 resource "aws_acm_certificate_validation" "apps" {
-  certificate_arn         = "${aws_acm_certificate.apps.arn}"
-  validation_record_fqdns = ["${aws_route53_record.apps_cert_validation.fqdn}"]
+  certificate_arn         = aws_acm_certificate.apps.arn
+  validation_record_fqdns = [aws_route53_record.apps_cert_validation.fqdn]
 }
+

--- a/terraform/modules/cluster_ssl/outputs.tf
+++ b/terraform/modules/cluster_ssl/outputs.tf
@@ -1,3 +1,4 @@
 output "apps_acm_arn" {
-  value = "${aws_acm_certificate.apps.arn}"
+  value = aws_acm_certificate.apps.arn
 }
+

--- a/terraform/modules/cluster_ssl/variables.tf
+++ b/terraform/modules/cluster_ssl/variables.tf
@@ -1,2 +1,6 @@
-variable "cluster_base_domain_name" {}
-variable "dns_zone_id" {}
+variable "cluster_base_domain_name" {
+}
+
+variable "dns_zone_id" {
+}
+

--- a/terraform/modules/cluster_ssl/versions.tf
+++ b/terraform/modules/cluster_ssl/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
This is related to https://github.com/ministryofjustice/cloud-platform/issues/1369

Upgraded tf version 0.12.13 for cloud-platform-components in cloud-platform-infrastructure.

->Performed tf 0.12upgrade for cloud-platform-components
->Fix Error: Attribute name required in opa.tf by removing "" for metadata.0.annotations
->Fix type for var "alertmanager_slack_receivers"
->Fix Error "A managed resource "main" "rego" has not been declared in the root module."
Changed to data = { main = file() }
form example:
https://www.openpolicyagent.org/docs/v0.12.2/kubernetes-admission-control/#3-deploy-opa-on-top-of-kubernetes
->Fix "Warning: Value for undeclared variable"
by adding github_client_id, github_client_secret and github_secret_key in variables.tf