### PR TITLE
Tf12 upgrade global resources

### DIFF
--- a/terraform/global-resources/auth0.tf
+++ b/terraform/global-resources/auth0.tf
@@ -1,27 +1,33 @@
 resource "auth0_rule" "whitelist-github-orgs" {
-  name    = "whitelist-github-orgs"
-  script  = "${file("${path.module}/resources/auth0-rules/whitelist-github-orgs.js")}"
+  name = "whitelist-github-orgs"
+  script = file(
+    "${path.module}/resources/auth0-rules/whitelist-github-orgs.js",
+  )
   order   = 10
   enabled = true
 }
 
 resource "auth0_rule" "add-github-teams-to-oidc-group-claim" {
-  name    = "add-github-teams-to-oidc-group-claim"
-  script  = "${file("${path.module}/resources/auth0-rules/add-github-teams-to-oidc-group-claim.js")}"
+  name = "add-github-teams-to-oidc-group-claim"
+  script = file(
+    "${path.module}/resources/auth0-rules/add-github-teams-to-oidc-group-claim.js",
+  )
   order   = 30
   enabled = true
 }
 
 resource "auth0_rule" "add-github-teams-to-saml-mappings" {
-  name    = "add-github-teams-to-saml-mappings"
-  script  = "${file("${path.module}/resources/auth0-rules/add-github-teams-to-saml-mappings.js")}"
+  name = "add-github-teams-to-saml-mappings"
+  script = file(
+    "${path.module}/resources/auth0-rules/add-github-teams-to-saml-mappings.js",
+  )
   order   = 40
   enabled = true
 }
 
 resource "auth0_rule_config" "aws-account-id" {
   key   = "AWS_ACCOUNT_ID"
-  value = "${data.aws_caller_identity.cloud-platform.account_id}"
+  value = data.aws_caller_identity.cloud-platform.account_id
 }
 
 resource "auth0_rule_config" "k8s-oidc-group-claim-domain" {
@@ -31,10 +37,11 @@ resource "auth0_rule_config" "k8s-oidc-group-claim-domain" {
 
 resource "auth0_rule_config" "aws-saml-provider-name" {
   key   = "AWS_SAML_PROVIDER_NAME"
-  value = "${aws_iam_saml_provider.auth0.name}"
+  value = aws_iam_saml_provider.auth0.name
 }
 
 resource "auth0_rule_config" "aws-saml-role-prefix" {
   key   = "AWS_SAML_ROLE_PREFIX"
   value = "saml-github."
 }
+

--- a/terraform/global-resources/dns.tf
+++ b/terraform/global-resources/dns.tf
@@ -9,35 +9,32 @@ resource "aws_route53_zone" "k8s_integration_dsd_io" {
 }
 
 resource "aws_route53_record" "k8s_integration_dsd_io_NS" {
-  zone_id = "${data.aws_route53_zone.integration_dsd_io.zone_id}"
-  name    = "${aws_route53_zone.k8s_integration_dsd_io.name}"
+  zone_id = data.aws_route53_zone.integration_dsd_io.zone_id
+  name    = aws_route53_zone.k8s_integration_dsd_io.name
   type    = "NS"
   ttl     = "300"
 
-  records = [
-    "${aws_route53_zone.k8s_integration_dsd_io.name_servers}",
-  ]
+  records = aws_route53_zone.k8s_integration_dsd_io.name_servers
 }
 
 data "aws_route53_zone" "justice_gov_uk" {
-  provider = "aws.dsd"
+  provider = aws.dsd
   name     = "service.justice.gov.uk."
 }
 
 # new parent DNS zone for clusters
 resource "aws_route53_zone" "cloud-platform_justice_gov_uk" {
-  provider = "aws.cloud-platform"
+  provider = aws.cloud-platform
   name     = "cloud-platform.service.justice.gov.uk."
 }
 
 resource "aws_route53_record" "cloud-platform_justice_gov_uk_NS" {
-  provider = "aws.dsd"
-  zone_id  = "${data.aws_route53_zone.justice_gov_uk.zone_id}"
-  name     = "${aws_route53_zone.cloud-platform_justice_gov_uk.name}"
+  provider = aws.dsd
+  zone_id  = data.aws_route53_zone.justice_gov_uk.zone_id
+  name     = aws_route53_zone.cloud-platform_justice_gov_uk.name
   type     = "NS"
   ttl      = "300"
 
-  records = [
-    "${aws_route53_zone.cloud-platform_justice_gov_uk.name_servers}",
-  ]
+  records = aws_route53_zone.cloud-platform_justice_gov_uk.name_servers
 }
+

--- a/terraform/global-resources/elasticsearch.tf
+++ b/terraform/global-resources/elasticsearch.tf
@@ -15,9 +15,9 @@ locals {
 
   audit_domain = "cloud-platform-audit"
 
-  allowed_audit_ips = "${local.allowed_live_ips}"
+  allowed_audit_ips = local.allowed_live_ips
 
-  allowed_audit_1_ips = "${local.allowed_live_1_ips}"
+  allowed_audit_1_ips = local.allowed_live_1_ips
 
   test_domain = "cloud-platform-test"
 
@@ -38,15 +38,18 @@ locals {
   }
 }
 
-data "aws_region" "moj-dsd" {}
-data "aws_caller_identity" "moj-dsd" {}
+data "aws_region" "moj-dsd" {
+}
+
+data "aws_caller_identity" "moj-dsd" {
+}
 
 data "aws_region" "moj-cp" {
-  provider = "aws.cloud-platform"
+  provider = aws.cloud-platform
 }
 
 data "aws_caller_identity" "moj-cp" {
-  provider = "aws.cloud-platform"
+  provider = aws.cloud-platform
 }
 
 data "aws_iam_policy_document" "live" {
@@ -68,8 +71,16 @@ data "aws_iam_policy_document" "live" {
       test     = "IpAddress"
       variable = "aws:SourceIp"
 
+      # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+      # force an interpolation expression to be interpreted as a list by wrapping it
+      # in an extra set of list brackets. That form was supported for compatibility in
+      # v0.11, but is no longer supported in Terraform v0.12.
+      #
+      # If the expression in the following list itself returns a list, remove the
+      # brackets to avoid interpretation as a list of lists. If the expression
+      # returns a single list item then leave it as-is and remove this TODO comment.
       values = [
-        "${keys(local.allowed_live_ips)}",
+        keys(local.allowed_live_ips),
       ]
     }
   }
@@ -94,15 +105,23 @@ data "aws_iam_policy_document" "live_1" {
       test     = "IpAddress"
       variable = "aws:SourceIp"
 
+      # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+      # force an interpolation expression to be interpreted as a list by wrapping it
+      # in an extra set of list brackets. That form was supported for compatibility in
+      # v0.11, but is no longer supported in Terraform v0.12.
+      #
+      # If the expression in the following list itself returns a list, remove the
+      # brackets to avoid interpretation as a list of lists. If the expression
+      # returns a single list item then leave it as-is and remove this TODO comment.
       values = [
-        "${keys(local.allowed_live_1_ips)}",
+        keys(local.allowed_live_1_ips),
       ]
     }
   }
 }
 
 resource "aws_elasticsearch_domain" "live" {
-  domain_name           = "${local.live_domain}"
+  domain_name           = local.live_domain
   elasticsearch_version = "6.4"
 
   cluster_config {
@@ -119,24 +138,24 @@ resource "aws_elasticsearch_domain" "live" {
     volume_size = "1024"
   }
 
-  advanced_options {
+  advanced_options = {
     "rest.action.multi.allow_explicit_index" = "true"
   }
 
-  access_policies = "${data.aws_iam_policy_document.live.json}"
+  access_policies = data.aws_iam_policy_document.live.json
 
   snapshot_options {
     automated_snapshot_start_hour = 23
   }
 
-  tags {
-    Domain = "${local.live_domain}"
+  tags = {
+    Domain = local.live_domain
   }
 }
 
 resource "aws_elasticsearch_domain" "live_1" {
-  domain_name           = "${local.live_domain}"
-  provider              = "aws.cloud-platform"
+  domain_name           = local.live_domain
+  provider              = aws.cloud-platform
   elasticsearch_version = "6.4"
 
   cluster_config {
@@ -158,18 +177,18 @@ resource "aws_elasticsearch_domain" "live_1" {
     volume_size = "1024"
   }
 
-  advanced_options {
+  advanced_options = {
     "rest.action.multi.allow_explicit_index" = "true"
   }
 
-  access_policies = "${data.aws_iam_policy_document.live_1.json}"
+  access_policies = data.aws_iam_policy_document.live_1.json
 
   snapshot_options {
     automated_snapshot_start_hour = 23
   }
 
-  tags {
-    Domain = "${local.live_domain}"
+  tags = {
+    Domain = local.live_domain
   }
 }
 
@@ -204,8 +223,16 @@ data "aws_iam_policy_document" "audit" {
       test     = "IpAddress"
       variable = "aws:SourceIp"
 
+      # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+      # force an interpolation expression to be interpreted as a list by wrapping it
+      # in an extra set of list brackets. That form was supported for compatibility in
+      # v0.11, but is no longer supported in Terraform v0.12.
+      #
+      # If the expression in the following list itself returns a list, remove the
+      # brackets to avoid interpretation as a list of lists. If the expression
+      # returns a single list item then leave it as-is and remove this TODO comment.
       values = [
-        "${keys(local.allowed_audit_ips)}",
+        keys(local.allowed_audit_ips),
       ]
     }
   }
@@ -242,15 +269,23 @@ data "aws_iam_policy_document" "audit_1" {
       test     = "IpAddress"
       variable = "aws:SourceIp"
 
+      # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+      # force an interpolation expression to be interpreted as a list by wrapping it
+      # in an extra set of list brackets. That form was supported for compatibility in
+      # v0.11, but is no longer supported in Terraform v0.12.
+      #
+      # If the expression in the following list itself returns a list, remove the
+      # brackets to avoid interpretation as a list of lists. If the expression
+      # returns a single list item then leave it as-is and remove this TODO comment.
       values = [
-        "${keys(local.allowed_audit_1_ips)}",
+        keys(local.allowed_audit_1_ips),
       ]
     }
   }
 }
 
 resource "aws_elasticsearch_domain" "audit" {
-  domain_name           = "${local.audit_domain}"
+  domain_name           = local.audit_domain
   elasticsearch_version = "6.4"
 
   cluster_config {
@@ -264,18 +299,18 @@ resource "aws_elasticsearch_domain" "audit" {
     volume_size = "1024"
   }
 
-  advanced_options {
+  advanced_options = {
     "rest.action.multi.allow_explicit_index" = "true"
   }
 
-  access_policies = "${data.aws_iam_policy_document.audit.json}"
+  access_policies = data.aws_iam_policy_document.audit.json
 
   snapshot_options {
     automated_snapshot_start_hour = 23
   }
 
-  tags {
-    Domain = "${local.audit_domain}"
+  tags = {
+    Domain = local.audit_domain
   }
 
   log_publishing_options {
@@ -293,8 +328,8 @@ resource "aws_elasticsearch_domain" "audit" {
 
 # audit cluster for live-1
 resource "aws_elasticsearch_domain" "audit_1" {
-  domain_name           = "${local.audit_domain}"
-  provider              = "aws.cloud-platform"
+  domain_name           = local.audit_domain
+  provider              = aws.cloud-platform
   elasticsearch_version = "6.5"
 
   cluster_config {
@@ -309,18 +344,18 @@ resource "aws_elasticsearch_domain" "audit_1" {
     volume_size = "1024"
   }
 
-  advanced_options {
+  advanced_options = {
     "rest.action.multi.allow_explicit_index" = "true"
   }
 
-  access_policies = "${data.aws_iam_policy_document.audit_1.json}"
+  access_policies = data.aws_iam_policy_document.audit_1.json
 
   snapshot_options {
     automated_snapshot_start_hour = 23
   }
 
-  tags {
-    Domain = "${local.audit_domain}"
+  tags = {
+    Domain = local.audit_domain
   }
 }
 
@@ -343,8 +378,16 @@ data "aws_iam_policy_document" "test" {
       test     = "IpAddress"
       variable = "aws:SourceIp"
 
+      # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+      # force an interpolation expression to be interpreted as a list by wrapping it
+      # in an extra set of list brackets. That form was supported for compatibility in
+      # v0.11, but is no longer supported in Terraform v0.12.
+      #
+      # If the expression in the following list itself returns a list, remove the
+      # brackets to avoid interpretation as a list of lists. If the expression
+      # returns a single list item then leave it as-is and remove this TODO comment.
       values = [
-        "${keys(merge(local.allowed_live_1_ips, local.allowed_test_ips))}",
+        keys(merge(local.allowed_live_1_ips, local.allowed_test_ips)),
       ]
     }
   }
@@ -352,7 +395,7 @@ data "aws_iam_policy_document" "test" {
 
 resource "aws_elasticsearch_domain" "test" {
   domain_name           = "cloud-platform-test"
-  provider              = "aws.cloud-platform"
+  provider              = aws.cloud-platform
   elasticsearch_version = "7.1"
 
   cluster_config {
@@ -366,7 +409,7 @@ resource "aws_elasticsearch_domain" "test" {
     volume_size = "500"
   }
 
-  access_policies = "${data.aws_iam_policy_document.test.json}"
+  access_policies = data.aws_iam_policy_document.test.json
 
   log_publishing_options {
     cloudwatch_log_group_arn = ""
@@ -374,3 +417,4 @@ resource "aws_elasticsearch_domain" "test" {
     log_type                 = "ES_APPLICATION_LOGS"
   }
 }
+

--- a/terraform/global-resources/elasticsearch.tf
+++ b/terraform/global-resources/elasticsearch.tf
@@ -79,9 +79,7 @@ data "aws_iam_policy_document" "live" {
       # If the expression in the following list itself returns a list, remove the
       # brackets to avoid interpretation as a list of lists. If the expression
       # returns a single list item then leave it as-is and remove this TODO comment.
-      values = [
-        keys(local.allowed_live_ips),
-      ]
+      values = keys(local.allowed_live_ips)
     }
   }
 }
@@ -113,9 +111,7 @@ data "aws_iam_policy_document" "live_1" {
       # If the expression in the following list itself returns a list, remove the
       # brackets to avoid interpretation as a list of lists. If the expression
       # returns a single list item then leave it as-is and remove this TODO comment.
-      values = [
-        keys(local.allowed_live_1_ips),
-      ]
+      values = keys(local.allowed_live_1_ips)
     }
   }
 }
@@ -231,9 +227,7 @@ data "aws_iam_policy_document" "audit" {
       # If the expression in the following list itself returns a list, remove the
       # brackets to avoid interpretation as a list of lists. If the expression
       # returns a single list item then leave it as-is and remove this TODO comment.
-      values = [
-        keys(local.allowed_audit_ips),
-      ]
+      values = keys(local.allowed_audit_ips)
     }
   }
 }
@@ -277,9 +271,7 @@ data "aws_iam_policy_document" "audit_1" {
       # If the expression in the following list itself returns a list, remove the
       # brackets to avoid interpretation as a list of lists. If the expression
       # returns a single list item then leave it as-is and remove this TODO comment.
-      values = [
-        keys(local.allowed_audit_1_ips),
-      ]
+      values = keys(local.allowed_audit_1_ips)
     }
   }
 }
@@ -386,9 +378,7 @@ data "aws_iam_policy_document" "test" {
       # If the expression in the following list itself returns a list, remove the
       # brackets to avoid interpretation as a list of lists. If the expression
       # returns a single list item then leave it as-is and remove this TODO comment.
-      values = [
-        keys(merge(local.allowed_live_1_ips, local.allowed_test_ips)),
-      ]
+      values = keys(merge(local.allowed_live_1_ips, local.allowed_test_ips))
     }
   }
 }

--- a/terraform/global-resources/guardduty.tf
+++ b/terraform/global-resources/guardduty.tf
@@ -192,8 +192,9 @@ resource "aws_sns_topic_subscription" "GuardDuty-notifications_sns_subscription"
 # membership account provider
 # -----------------------------------------------------------
 
-provider "aws.member" {
+provider "aws" {
   region  = "${var.aws_region}"
+  alias   = "member"
   profile = "${var.aws_member_profile}"
 }
 
@@ -225,8 +226,9 @@ resource "aws_guardduty_member" "member" {
 # membership1 account provider
 # -----------------------------------------------------------
 
-provider "aws.member1" {
+provider "aws" {
   region  = "${var.aws_region}"
+  alias   = "member1"
   profile = "${var.aws_member1_profile}"
 }
 
@@ -258,8 +260,9 @@ resource "aws_guardduty_member" "member1" {
 # membership2 account provider
 # -----------------------------------------------------------
 
-provider "aws.member2" {
+provider "aws" {
   region  = "${var.aws_region}"
+  alias   = "member2"
   profile = "${var.aws_member2_profile}"
 }
 
@@ -291,8 +294,9 @@ resource "aws_guardduty_member" "member2" {
 # membership3 account provider
 # -----------------------------------------------------------
 
-provider "aws.member3" {
+provider "aws" {
   region  = "${var.aws_region}"
+  alias   = "member3"
   profile = "${var.aws_member3_profile}"
 }
 
@@ -324,8 +328,9 @@ resource "aws_guardduty_member" "member3" {
 # membership4 account provider
 # -----------------------------------------------------------
 
-provider "aws.member4" {
+provider "aws" {
   region  = "${var.aws_region}"
+  alias   = "member4"
   profile = "${var.aws_member4_profile}"
 }
 
@@ -357,8 +362,9 @@ resource "aws_guardduty_member" "member4" {
 # membership5 account provider
 # -----------------------------------------------------------
 
-provider "aws.member5" {
+provider "aws" {
   region  = "${var.aws_region}"
+  alias   = "member5"
   profile = "${var.aws_member5_profile}"
 }
 
@@ -390,8 +396,9 @@ resource "aws_guardduty_member" "member5" {
 # membership6 account provider
 # -----------------------------------------------------------
 
-provider "aws.member6" {
+provider "aws" {
   region  = "${var.aws_region}"
+  alias   = "member6"
   profile = "${var.aws_member6_profile}"
 }
 
@@ -423,8 +430,9 @@ resource "aws_guardduty_member" "member6" {
 # membership7 account provider
 # -----------------------------------------------------------
 
-provider "aws.member7" {
+provider "aws" {
   region  = "${var.aws_region}"
+  alias   = "member7"
   profile = "${var.aws_member7_profile}"
 }
 

--- a/terraform/global-resources/main.tf
+++ b/terraform/global-resources/main.tf
@@ -12,7 +12,7 @@ locals {
 }
 
 provider "auth0" {
-  domain = "${local.auth0_tenant_domain}"
+  domain = local.auth0_tenant_domain
 }
 
 # default provider
@@ -36,7 +36,7 @@ provider "aws" {
 }
 
 data "aws_caller_identity" "cloud-platform" {
-  provider = "aws.cloud-platform"
+  provider = aws.cloud-platform
 }
 
 # https://mojdsd.signin.aws.amazon.com/console
@@ -46,4 +46,6 @@ provider "aws" {
   profile = "moj-dsd"
 }
 
-provider "external" {}
+provider "external" {
+}
+

--- a/terraform/global-resources/main.tf
+++ b/terraform/global-resources/main.tf
@@ -12,6 +12,7 @@ locals {
 }
 
 provider "auth0" {
+  version = ">= 0.2.1"
   domain = local.auth0_tenant_domain
 }
 

--- a/terraform/global-resources/outputs.tf
+++ b/terraform/global-resources/outputs.tf
@@ -1,31 +1,32 @@
 output "k8s_zone_id" {
-  value = "${aws_route53_zone.k8s_integration_dsd_io.zone_id}"
+  value = aws_route53_zone.k8s_integration_dsd_io.zone_id
 }
 
 output "k8s_domain_name" {
-  value = "${aws_route53_zone.k8s_integration_dsd_io.name}"
+  value = aws_route53_zone.k8s_integration_dsd_io.name
 }
 
 output "cp_zone_id" {
-  value = "${aws_route53_zone.cloud-platform_justice_gov_uk.zone_id}"
+  value = aws_route53_zone.cloud-platform_justice_gov_uk.zone_id
 }
 
 output "cp_domain_name" {
-  value = "${aws_route53_zone.cloud-platform_justice_gov_uk.name}"
+  value = aws_route53_zone.cloud-platform_justice_gov_uk.name
 }
 
 output "kops_state_store" {
-  value = "${aws_s3_bucket.kops_state_store.bucket}"
+  value = aws_s3_bucket.kops_state_store.bucket
 }
 
 output "cloud_platform_kops_state" {
-  value = "${aws_s3_bucket.cloud_platform_kops_state.bucket}"
+  value = aws_s3_bucket.cloud_platform_kops_state.bucket
 }
 
 output "k8s_oidc_group_claim_domain" {
-  value = "${auth0_rule_config.k8s-oidc-group-claim-domain.value}"
+  value = auth0_rule_config.k8s-oidc-group-claim-domain.value
 }
 
 output "saml_login_page" {
   value = "https://${local.auth0_tenant_domain}/samlp/${auth0_client.saml.client_id}"
 }
+

--- a/terraform/global-resources/s3.tf
+++ b/terraform/global-resources/s3.tf
@@ -38,7 +38,7 @@ resource "aws_s3_bucket" "kops_state_store" {
 
 resource "aws_s3_bucket" "cloud_platform_kops_state" {
   bucket   = "cloud-platform-kops-state"
-  provider = "aws.cloud-platform-ireland"
+  provider = aws.cloud-platform-ireland
   acl      = "private"
 
   versioning {
@@ -104,3 +104,4 @@ resource "aws_s3_bucket" "cluster_components" {
     }
   }
 }
+

--- a/terraform/global-resources/variables.tf
+++ b/terraform/global-resources/variables.tf
@@ -1,48 +1,100 @@
 # AWS GuardDuty variables:
 
-variable "aws_region" {}
-variable "integration_key" {}
-variable "endpoint" {}
-variable "topic_arn" {}
-variable "sns_arn" {}
+variable "aws_region" {
+}
 
-variable "aws_master_account_id" {}
-variable "aws_master_profile" {}
+variable "integration_key" {
+}
 
-variable "aws_member_account_id" {}
-variable "aws_member_profile" {}
-variable "member_email" {}
+variable "endpoint" {
+}
 
-variable "aws_member1_account_id" {}
-variable "aws_member1_profile" {}
-variable "member1_email" {}
+variable "topic_arn" {
+}
 
-variable "aws_member2_account_id" {}
-variable "aws_member2_profile" {}
-variable "member2_email" {}
+variable "sns_arn" {
+}
 
-variable "aws_member3_account_id" {}
-variable "aws_member3_profile" {}
-variable "member3_email" {}
+variable "aws_master_account_id" {
+}
 
-variable "aws_member4_account_id" {}
-variable "aws_member4_profile" {}
-variable "member4_email" {}
+variable "aws_master_profile" {
+}
 
-variable "aws_member5_account_id" {}
-variable "aws_member5_profile" {}
-variable "member5_email" {}
+variable "aws_member_account_id" {
+}
 
-variable "aws_member6_account_id" {}
-variable "aws_member6_profile" {}
-variable "member6_email" {}
+variable "aws_member_profile" {
+}
 
-variable "aws_member7_account_id" {}
-variable "aws_member7_profile" {}
-variable "member7_email" {}
+variable "member_email" {
+}
+
+variable "aws_member1_account_id" {
+}
+
+variable "aws_member1_profile" {
+}
+
+variable "member1_email" {
+}
+
+variable "aws_member2_account_id" {
+}
+
+variable "aws_member2_profile" {
+}
+
+variable "member2_email" {
+}
+
+variable "aws_member3_account_id" {
+}
+
+variable "aws_member3_profile" {
+}
+
+variable "member3_email" {
+}
+
+variable "aws_member4_account_id" {
+}
+
+variable "aws_member4_profile" {
+}
+
+variable "member4_email" {
+}
+
+variable "aws_member5_account_id" {
+}
+
+variable "aws_member5_profile" {
+}
+
+variable "member5_email" {
+}
+
+variable "aws_member6_account_id" {
+}
+
+variable "aws_member6_profile" {
+}
+
+variable "member6_email" {
+}
+
+variable "aws_member7_account_id" {
+}
+
+variable "aws_member7_profile" {
+}
+
+variable "member7_email" {
+}
 
 variable "users" {
-  type = "list"
+  type = list(string)
 }
 
 variable "bucket_prefix" {
@@ -65,3 +117,4 @@ variable "tags" {
     "runbook"                = "none"
   }
 }
+

--- a/terraform/global-resources/versions.tf
+++ b/terraform/global-resources/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
This is related to https://github.com/ministryofjustice/cloud-platform/issues/1367

Updated terraform/global-resources to tf0.12

-> Fix tf0.12 upgrade provider issue in guardduty.tf by adding an alias, as tf0.12 upgrade failed with below error
Error: panic: missing schema for provider type "aws.member"
-> Run tf0.12upgrade command to get global-resources to tf0.12
-> Fix tf0.12 Err Incorrect attribute value type in elasticsearch.tf by removing []
-> Pinned auth0 version in the auth0 provider