### PR TITLE
Tf12 upgrade cloud platform account

### DIFF
--- a/terraform/cloud-platform-account/cloudtrail.tf
+++ b/terraform/cloud-platform-account/cloudtrail.tf
@@ -1,16 +1,16 @@
 resource "aws_cloudtrail" "cloud-platform_cloudtrail" {
-  provider = "aws.ireland"
+  provider = aws.ireland
 
   name                          = "cloud-platform-cloudtrail"
-  s3_bucket_name                = "${aws_s3_bucket.cloudtrail_bucket.id}"
+  s3_bucket_name                = aws_s3_bucket.cloudtrail_bucket.id
   include_global_service_events = true
   is_multi_region_trail         = true
   enable_log_file_validation    = true
 
-  tags {
-    business-unit          = "${var.business_unit}"
-    owner                  = "${var.team_name}"
-    infrastructure-support = "${var.infrastructure_support}"
+  tags = {
+    business-unit          = var.business_unit
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure_support
   }
 }
 
@@ -19,13 +19,13 @@ resource "random_id" "id" {
 }
 
 resource "aws_s3_bucket" "cloudtrail_bucket" {
-  provider = "aws.ireland"
+  provider = aws.ireland
   bucket   = "${var.cloudtrail_bucket_name}-${random_id.id.hex}"
 
-  tags {
-    business-unit          = "${var.business_unit}"
-    owner                  = "${var.team_name}"
-    infrastructure-support = "${var.infrastructure_support}"
+  tags = {
+    business-unit          = var.business_unit
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure_support
   }
 
   lifecycle_rule {
@@ -82,4 +82,6 @@ resource "aws_s3_bucket" "cloudtrail_bucket" {
     ]
 }
 POLICY
+
 }
+

--- a/terraform/cloud-platform-account/cloudwatch_events.tf
+++ b/terraform/cloud-platform-account/cloudwatch_events.tf
@@ -6,7 +6,7 @@ module "cloudwatch_slack" {
 
   slack_channel        = "lower-priority-alarms"
   slack_username       = "reporter"
-  slack_webhook_url    = "${ var.slack_config_cloudwatch_lp }"
+  slack_webhook_url    = var.slack_config_cloudwatch_lp
   lambda_function_name = "cloudwatch_to_slack_lp"
 }
 
@@ -30,17 +30,15 @@ resource "aws_cloudwatch_event_rule" "dlm_state" {
 }
 PATTERN
 
-  depends_on = [
-    "module.cloudwatch_slack",
-  ]
+
+  depends_on = [module.cloudwatch_slack]
 }
 
 resource "aws_cloudwatch_event_target" "dlm_sns" {
-  rule      = "${aws_cloudwatch_event_rule.dlm_state.name}"
+  rule      = aws_cloudwatch_event_rule.dlm_state.name
   target_id = "SendToSNS"
-  arn       = "${module.cloudwatch_slack.this_slack_topic_arn}"
+  arn       = module.cloudwatch_slack.this_slack_topic_arn
 
-  depends_on = [
-    "aws_cloudwatch_event_rule.dlm_state",
-  ]
+  depends_on = [aws_cloudwatch_event_rule.dlm_state]
 }
+

--- a/terraform/cloud-platform-account/cloudwatch_events.tf
+++ b/terraform/cloud-platform-account/cloudwatch_events.tf
@@ -1,6 +1,6 @@
 module "cloudwatch_slack" {
   source  = "terraform-aws-modules/notify-slack/aws"
-  version = "~> 1.0"
+  version = "~> 2.0"
 
   sns_topic_name = "slack-lower-priority-alarms"
 

--- a/terraform/cloud-platform-account/dlm.tf
+++ b/terraform/cloud-platform-account/dlm.tf
@@ -16,6 +16,7 @@ resource "aws_iam_role" "dlm_lifecycle_role" {
   ]
 }
 EOF
+
 }
 
 resource "aws_iam_policy" "dlm_policy" {
@@ -46,16 +47,17 @@ resource "aws_iam_policy" "dlm_policy" {
   ]
 }
 EOF
+
 }
 
 resource "aws_iam_role_policy_attachment" "dlm_attach" {
-  role       = "${aws_iam_role.dlm_lifecycle_role.name}"
-  policy_arn = "${aws_iam_policy.dlm_policy.arn}"
+  role       = aws_iam_role.dlm_lifecycle_role.name
+  policy_arn = aws_iam_policy.dlm_policy.arn
 }
 
 resource "aws_dlm_lifecycle_policy" "etcd_backup" {
   description        = "etcd data lifecycle policy"
-  execution_role_arn = "${aws_iam_role.dlm_lifecycle_role.arn}"
+  execution_role_arn = aws_iam_role.dlm_lifecycle_role.arn
   state              = "ENABLED"
 
   policy_details {
@@ -74,15 +76,16 @@ resource "aws_dlm_lifecycle_policy" "etcd_backup" {
         count = 14
       }
 
-      tags_to_add {
+      tags_to_add = {
         SnapshotCreator = "DLM"
       }
 
       copy_tags = true
     }
 
-    target_tags {
+    target_tags = {
       "k8s.io/role/master" = "1"
     }
   }
 }
+

--- a/terraform/cloud-platform-account/main.tf
+++ b/terraform/cloud-platform-account/main.tf
@@ -18,10 +18,11 @@ locals {
 provider "aws" {
   version = ">= 1.44.0"
   region  = "eu-west-2"
-  profile = "${lookup(local.workspace_to_profile, terraform.workspace)}"
+  profile = local.workspace_to_profile[terraform.workspace]
 }
 
 provider "aws" {
   region = "eu-west-1"
   alias  = "ireland"
 }
+

--- a/terraform/cloud-platform-account/variables.tf
+++ b/terraform/cloud-platform-account/variables.tf
@@ -20,3 +20,4 @@ variable "cloudtrail_bucket_name" {
 variable "slack_config_cloudwatch_lp" {
   description = "Add Slack webhook API URL for integration with slack."
 }
+

--- a/terraform/cloud-platform-account/versions.tf
+++ b/terraform/cloud-platform-account/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
This is related to https://github.com/ministryofjustice/cloud-platform/issues/1366

Updated terraform/cloud-platform-account to tf0.12.

--> Ran tf 0.12upgrade command to get cloud-platform-account changed to tf0.12
--> To fix the issue with module "cloudwatch_slack" updated the module to use version = "~> 2.0", which is created for tf0.12.