### PR TITLE
Use terraform12 to destroy test clusters

### DIFF
--- a/destroy-cluster.sh
+++ b/destroy-cluster.sh
@@ -16,13 +16,13 @@ terraform_components() {
   kops export kubecfg ${CLUSTER}.cloud-platform.service.justice.gov.uk
   (
     cd terraform/cloud-platform-components
-    terraform init
-    terraform workspace select ${CLUSTER}
+    terraform12 init
+    terraform12 workspace select ${CLUSTER}
     # prometheus_operator often fails to delete cleanly if anything has
     # happened to the open policy agent beforehand. Delete it first to
     # avoid any issues
-    terraform destroy -target helm_release.prometheus_operator -auto-approve
-    terraform destroy -auto-approve
+    terraform12 destroy -target helm_release.prometheus_operator -auto-approve
+    terraform12 destroy -auto-approve
   )
 }
 
@@ -33,9 +33,9 @@ kops_cluster() {
 terraform_base() {
   (
     cd terraform/cloud-platform
-    terraform init
-    terraform workspace select ${CLUSTER}
-    terraform destroy -auto-approve
+    terraform12 init
+    terraform12 workspace select ${CLUSTER}
+    terraform12 destroy -auto-approve
   )
 }
 
@@ -43,8 +43,8 @@ terraform_workspaces() {
   for dir in terraform/cloud-platform terraform/cloud-platform-components; do
     (
       cd ${dir}
-      terraform workspace select default
-      terraform workspace delete ${CLUSTER}
+      terraform12 workspace select default
+      terraform12 workspace delete ${CLUSTER}
     )
   done
 }

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-TOOLS_IMAGE := ministryofjustice/cloud-platform-tools:1.3
+TOOLS_IMAGE := ministryofjustice/cloud-platform-tools:1.5
 
 tools-shell:
 	docker pull $(TOOLS_IMAGE)


### PR DESCRIPTION
Now that we have upgraded infrastructure and
components to terraform 0.12, the 0.11 version of
terraform will not destroy test clusters.

This change fixes that.