### PR TITLE
Bugfix: correct the command which disables alerts

### DIFF
--- a/create-cluster.rb
+++ b/create-cluster.rb
@@ -116,10 +116,10 @@ end
 
 def disable_alerts
   # This will disable high-priority pagerduty alarms for your cluster by replacing the pagerduty_config token with a dummy value
-  `sed -i 's/pagerduty_config\s\{1,\}=\s\{1,\}".*"/pagerduty_config = "dummydummy"/g' terraform/cloud-platform-components/terraform.tfvars`
+  `sed -i 's/pagerduty_config\\s\\{1,\\}=\\s\\{1,\\}".*"/pagerduty_config = "dummydummy"/g' terraform/cloud-platform-components/terraform.tfvars`
   # This will disable lower priority alerts for your cluster by replacing the alertmanager slack webhook url with a dummy value
-  `sed -i 's/cloud_platform_slack_webhook\s\{1,\}=\s\{1,\}".*"/cloud_platform_slack_webhook = "dummydummy"/g' terraform/cloud-platform-components/terraform.tfvars`
-  `sed -i 's/webhook\s\{1,\}=\s\{1,\}".*"/webhook = "dummydummy"/g' terraform/cloud-platform-components/terraform.tfvars`
+  `sed -i 's/cloud_platform_slack_webhook\\s\\{1,\\}=\\s\\{1,\\}".*"/cloud_platform_slack_webhook = "dummydummy"/g' terraform/cloud-platform-components/terraform.tfvars`
+  `sed -i 's/webhook\\s\\{1,\\}=\\s\\{1,\\}".*"/webhook = "dummydummy"/g' terraform/cloud-platform-components/terraform.tfvars`
 end
 
 def wait_for_kops_validate


### PR DESCRIPTION
We want to replace the pagerduty token and all
slack webhooks in test clusters, so we run a `sed`
command on the terraform source to replace those
values with `dummydummy`

But, because the code is executed via ruby, we
need to escape every backslash by doubling it
(i.e. wherever you put `\` in bash, e.g. when
running the command a terminal, you need to put
`\\` in your ruby code.

I think this is why we've still been getting 
alerts from our test clusters.