### PR TITLE
Remove the terraform validation & formatting steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,28 +1,6 @@
-# based on: https://github.com/terraform-aws-modules/terraform-aws-vpc/blob/master/.circleci/config.yml
 version: 2
 
-terraform: &terraform
-  docker:
-    - image: hashicorp/terraform:0.11.11
-  working_directory: /tmp/workspace/terraform
-
 jobs:
-  validate:
-    <<: *terraform
-    steps:
-      - checkout
-      - run:
-          name: change to terraform directory
-          command: cd terraform
-      - run:
-          name: Validate Terraform configurations
-          command: find . -type f -name "*.tf" -exec dirname {} \;|sort -u | while read m; do (terraform validate -check-variables=false "$m" && echo "√ $m") || exit 1 ; done
-      - run:
-          name: Check if Terraform configurations are properly formatted
-          command: tf=$(terraform fmt -write=false -diff); if [[ -n "$tf" ]]; then printf "$tf\n\n\nSome terraform files failed syntax validation, run 'terraform fmt' to fix\n\n"; exit 1; fi
-      - persist_to_workspace:
-          root: .
-          paths: .
   test_opa:
     machine:
       image: ubuntu-1604:201903-01
@@ -34,9 +12,6 @@ jobs:
 
 workflows:
   version: 2
-  build:
-    jobs:
-      - validate
   opatest:
     jobs:
       - test_opa


### PR DESCRIPTION
We use the code-formatter github action for this, which is able
to work with terraform 0.12 or 0.11 syntax. So, rather than fix
this action to do the same thing correctly, it makes more sense
to remove the terraform steps from this job, and leave that part
to the github action.