### PR TITLE
Add a timeout to the node drain step

### DIFF
--- a/recycle-node.rb
+++ b/recycle-node.rb
@@ -3,15 +3,15 @@
 
 # Usage:
 #   export AWS_PROFILE=moj-cp
-#   Edit "K8S_CLUSTER_NAME" to specify the cluster to recycle old node. 
+#   Edit "K8S_CLUSTER_NAME" to specify the cluster to recycle old node.
 #   ./recycle-node.rb
 #
-#  Note: 
+#  Note:
 #   The `get_worker_instance_group_size` method looks for the instance group size in the kops manifest in our github repository, so it will always return the size of the live-1 cluster.
 #   To run this on a test cluster, update method `get_worker_instance_group_size` as shown below, to return number of worker nodes configured as minSize in kops/test-cluster.yaml.
-# 
+#
 #  def get_worker_instance_group_size
-#     return 3 
+#     return 3
 
 require 'json'
 require "yaml"
@@ -76,7 +76,7 @@ def get_worker_instance_group_size
   docs = []
   YAML.load_stream(get_kops_config) { |doc| docs << doc }
   worker_instance_group = docs.last
-  
+
   unless worker_instance_group.dig("metadata", "name") == "nodes"
     raise "Failed to parse kops config. Last document in YAML file is supposed to be worker instancegroup definition."
   end
@@ -121,7 +121,7 @@ def terminate_node(node)
   else
     raise "worker node #{name} was not cordoned."
   end
-end 
+end
 
 def aws_instance_id(node)
   node.dig("spec", "providerID").split("/").last

--- a/recycle-node.rb
+++ b/recycle-node.rb
@@ -17,7 +17,7 @@ require 'json'
 require "yaml"
 require "net/http"
 
-K8S_CLUSTER_NAME = "recycle-node.cloud-platform.service.justice.gov.uk"
+K8S_CLUSTER_NAME = "live-1.cloud-platform.service.justice.gov.uk"
 AWS_REGION = "eu-west-2"
 KOPS_CONFIG_URL = "https://raw.githubusercontent.com/ministryofjustice/cloud-platform-infrastructure/master/kops/live-1.yaml"
 

--- a/recycle-node.rb
+++ b/recycle-node.rb
@@ -1,6 +1,5 @@
 #!/usr/bin/env ruby
 
-
 # Usage:
 #   export AWS_PROFILE=moj-cp
 #   Edit "K8S_CLUSTER_NAME" to specify the cluster to recycle old node.
@@ -13,7 +12,7 @@
 #  def get_worker_instance_group_size
 #     return 3
 
-require 'json'
+require "json"
 require "yaml"
 require "net/http"
 require "timeout"
@@ -92,8 +91,7 @@ end
 
 def get_oldest_worker_node
   get_worker_nodes
-    .sort_by {|node| node.dig("metadata", "creationTimestamp") }
-    .first
+    .min_by { |node| node.dig("metadata", "creationTimestamp") }
 end
 
 def drain_node(node)


### PR DESCRIPTION
This is a pre-requisite for https://github.com/ministryofjustice/cloud-platform/issues/1467

Draining a node can fail for various reasons. When this happens, the drain
command loops forever (or, at least for longer than I was prepared to wait,
during testing).

This commit adds a timeout to the node drain step, so that we only wait a
fixed amount of time before giving up (and killing the spawned `kubectl`
process).