### PR TITLE
Updated default PVC size to match live-1.

### DIFF
--- a/terraform/cloud-platform-components/templates/prometheus-operator.yaml.tpl
+++ b/terraform/cloud-platform-components/templates/prometheus-operator.yaml.tpl
@@ -1012,7 +1012,7 @@ prometheus:
           accessModes: ["ReadWriteOnce"]
           resources:
             requests:
-              storage: 500Gi
+              storage: 750Gi
         selector: {}
 
     ## AdditionalScrapeConfigs allows specifying additional Prometheus scrape configurations. Scrape configurations


### PR DESCRIPTION
It was done a volume resize in live-1 to 750GB, this PR represents the change in components