### PR TITLE
Log commands which are executed with a timeout

### DIFF
--- a/recycle-node.rb
+++ b/recycle-node.rb
@@ -168,6 +168,8 @@ end
 
 # https://stackoverflow.com/questions/8292031/ruby-timeouts-and-system-commands
 def exec_with_timeout(cmd, timeout)
+  log "CMD: #{cmd}, TIMEOUT: #{timeout}"
+
   pid = Process.spawn(cmd)
 
   begin


### PR DESCRIPTION
We log all commands we execute, as part of this script, unless we
are executing them with a timeout. This commit adds logging to the
`exec_with_timeout` method, so that we can see those commands in
the concourse web interface.