### PR TITLE
Configure kops to use a docker registry cache

### DIFF
--- a/kops/live-1.yaml
+++ b/kops/live-1.yaml
@@ -8,6 +8,8 @@ metadata:
   creationTimestamp: null
   name: live-1.cloud-platform.service.justice.gov.uk
 spec:
+  registryMirrors:
+  - https://docker-registry-cache.apps.${cluster_domain_name}
   fileAssets:
   - name: kubernetes-audit
     path: /srv/kubernetes/audit.yaml
@@ -305,7 +307,7 @@ spec:
         done;'
       [Install]
       WantedBy=multi-user.target
-      
+
 
 ---
 

--- a/terraform/cloud-platform/templates/kops.yaml.tpl
+++ b/terraform/cloud-platform/templates/kops.yaml.tpl
@@ -8,6 +8,8 @@ metadata:
   creationTimestamp: null
   name: ${cluster_domain_name}
 spec:
+  registryMirrors:
+  - https://docker-registry-cache.apps.${cluster_domain_name}
   fileAssets:
   - name: kubernetes-audit
     path: /srv/kubernetes/audit.yaml


### PR DESCRIPTION
This change adds a docker registry to the live-1 cluster:
https://github.com/ministryofjustice/cloud-platform-environments/pull/1749

This commit alters the kops config, and the template for new kops
clusters, to use a registry cache via the URL provided.

Once this change has been merged, a rolling update of the live-1
cluster will be required to get worker nodes to start using the
cache.