### PR TITLE
Add unique key for tag for AWS resources created by kops

### DIFF
--- a/terraform/cloud-platform/templates/kops.yaml.tpl
+++ b/terraform/cloud-platform/templates/kops.yaml.tpl
@@ -397,6 +397,7 @@ spec:
     application: moj-cloud-platform
     business-unit: platforms
     is-production: "true"
+    k8s.io/cluster/${cluster_domain_name}: ""
     role: node
     owner: cloud-platform:platforms@digital.justice.gov.uk
     source-code: https://github.com/ministryofjustice/cloud-platform-infrastructure


### PR DESCRIPTION
This additional label with add a unique key in the tag used to identify resourced created in AWS by kops for specific clusters.

Currently all tags have the same key and are identifiable by the value of the key.

The cluster-autoscaler has an auto-discover mechanism which looks to unique keys and ignores the values. 