### PR TITLE
Reduce live-1 worker node instance size

### DIFF
--- a/kops/live-1.yaml
+++ b/kops/live-1.yaml
@@ -396,7 +396,7 @@ metadata:
   creationTimestamp: null
   labels:
     kops.k8s.io/cluster: live-1.cloud-platform.service.justice.gov.uk
-  name: nodes
+  name: nodes-r52xl
 spec:
   image: kope.io/k8s-1.13-debian-stretch-amd64-hvm-ebs-2019-08-16
   machineType: r5.xlarge

--- a/kops/live-1.yaml
+++ b/kops/live-1.yaml
@@ -399,7 +399,7 @@ metadata:
   name: nodes
 spec:
   image: kope.io/k8s-1.13-debian-stretch-amd64-hvm-ebs-2019-08-16
-  machineType: r5.2xlarge
+  machineType: r5.xlarge
   maxSize: 21
   minSize: 21
   rootVolumeSize: 256

--- a/kops/live-1.yaml
+++ b/kops/live-1.yaml
@@ -409,6 +409,7 @@ spec:
     application: moj-cloud-platform
     business-unit: platforms
     is-production: "true"
+    k8s.io/cluster/live-1.cloud-platform.service.justice.gov.uk: ""
     role: node
     owner: cloud-platform:platforms@digital.justice.gov.uk
     source-code: https://github.com/ministryofjustice/cloud-platform-infrastructure

--- a/terraform/cloud-platform/variables.tf
+++ b/terraform/cloud-platform/variables.tf
@@ -33,6 +33,6 @@ variable "master_node_machine_type" {
 
 variable "worker_node_machine_type" {
   description = "The AWS EC2 instance types to use for worker nodes"
-  default     = "r5.2xlarge"
+  default     = "r5.xlarge"
 }
 


### PR DESCRIPTION
This changes the worker nodes from r5.2xlarge to r5.xlarge

This change should still leave plenty of extra capacity to accomodate some
growth, while saving the MoJ almost $5,000/month in AWS hosting costs.

NB: After merging this change, we need to do a kops update and rolling
update of the cluster, before the change takes effect.