### PR TITLE
Metrics server uprade

### DIFF
--- a/terraform/cloud-platform-components/metrics-server.tf
+++ b/terraform/cloud-platform-components/metrics-server.tf
@@ -1,7 +1,7 @@
 resource "helm_release" "metrics_server" {
   name      = "metrics-server"
   chart     = "stable/metrics-server"
-  namespace = "kube-system"
+  namespace = "monitoring"
   version   = "2.8.8"
 
   set {

--- a/terraform/cloud-platform-components/metrics-server.tf
+++ b/terraform/cloud-platform-components/metrics-server.tf
@@ -2,7 +2,7 @@ resource "helm_release" "metrics_server" {
   name      = "metrics-server"
   chart     = "stable/metrics-server"
   namespace = "kube-system"
-  version   = "2.0.4"
+  version   = "2.8.8"
 
   set {
     name  = "args[0]"


### PR DESCRIPTION
- upgraded metrics-server from `2.0.4` to `2.8.8`
- moved the metrics-server deployment from `kube-system` to the `monitoring` namespace