### PR TITLE
Correct the instancegroup name to nodes-r52xl

### DIFF
--- a/kops/live-1.yaml
+++ b/kops/live-1.yaml
@@ -404,7 +404,7 @@ spec:
   minSize: 21
   rootVolumeSize: 256
   nodeLabels:
-    kops.k8s.io/instancegroup: nodes
+    kops.k8s.io/instancegroup: nodes-r52xl
   cloudLabels:
     application: moj-cloud-platform
     business-unit: platforms

--- a/terraform/cloud-platform/templates/kops.yaml.tpl
+++ b/terraform/cloud-platform/templates/kops.yaml.tpl
@@ -384,7 +384,7 @@ metadata:
   creationTimestamp: null
   labels:
     kops.k8s.io/cluster: ${cluster_domain_name}
-  name: nodes
+  name: nodes-r52xl
 spec:
   image: kope.io/k8s-1.13-debian-stretch-amd64-hvm-ebs-2019-08-16
   machineType: ${worker_node_machine_type}
@@ -392,7 +392,7 @@ spec:
   minSize: ${cluster_node_count}
   rootVolumeSize: 256
   nodeLabels:
-    kops.k8s.io/instancegroup: nodes
+    kops.k8s.io/instancegroup: nodes-r52xl
   cloudLabels:
     application: moj-cloud-platform
     business-unit: platforms


### PR DESCRIPTION
The last time we changed the cluster, we increased the node size to
r5.2xlarge by creating a new instancegroup called nodes-r52xl and then
deleting the old instancegroup called "nodes"

At that time, we didn't update the yaml file in the github repo.

This change is required so that we can resize the worker nodes via a kops
rolling-update

Clearly, this instancegroup name will be wrong after the resize, however
it's the only way to use a rolling-update to do the resize, so we'll have
to live with it, for now.