### PR TITLE
Fix worker node size of 'production' test clusters

### DIFF
--- a/create-cluster.rb
+++ b/create-cluster.rb
@@ -35,7 +35,7 @@ MACHINE_TYPES = {
   },
   PRODUCTION => {
     "master_node_machine_type" => "c4.4xlarge",
-    "worker_node_machine_type" => "r5.2xlarge",
+    "worker_node_machine_type" => "r5.xlarge",
   },
 }
 


### PR DESCRIPTION
live-1 worker nodes are now r5.xlarge, not r5.2xlarge