### PR TITLE
Silence a terraform deprecation warning

### DIFF
--- a/terraform/cloud-platform-components/variables.tf
+++ b/terraform/cloud-platform-components/variables.tf
@@ -4,7 +4,7 @@ variable "pagerduty_config" {
 
 variable "alertmanager_slack_receivers" {
   description = "A list of configuration values for Slack receivers"
-  type        = "list"
+  type        = list
 }
 
 variable "aws_master_account_id" {


### PR DESCRIPTION
This commit silences the following deprecation
warning, when applying the components terraform
code:

```
Warning: Quoted type constraints are deprecated
  on variables.tf line 7, in variable "alertmanager_slack_receivers":
   7:   type        = "list"
```