### PR TITLE
Created persistentvolume_backup policy

### DIFF
--- a/terraform/cloud-platform-account/dlm.tf
+++ b/terraform/cloud-platform-account/dlm.tf
@@ -119,7 +119,7 @@ resource "aws_dlm_lifecycle_policy" "persistentvolume_backup" {
     }
 
     target_tags = {
-      "k8s.io/pvc/persistentvolume" = "1"
+      "k8s.io/pvc/persistentvolume" = "daily-backup"
     }
   }
 }

--- a/terraform/cloud-platform-account/dlm.tf
+++ b/terraform/cloud-platform-account/dlm.tf
@@ -89,3 +89,37 @@ resource "aws_dlm_lifecycle_policy" "etcd_backup" {
   }
 }
 
+resource "aws_dlm_lifecycle_policy" "persistentvolume_backup" {
+  description        = "PersistentVolume lifecycle policy"
+  execution_role_arn = aws_iam_role.dlm_lifecycle_role.arn
+  state              = "ENABLED"
+
+  policy_details {
+    resource_types = ["VOLUME"]
+
+    schedule {
+      name = "Daily 30 days persistentvolume snapshots"
+
+      create_rule {
+        interval      = 24
+        interval_unit = "HOURS"
+        times         = ["05:00"]
+      }
+
+      retain_rule {
+        count = 30
+      }
+
+      tags_to_add = {
+        SnapshotCreator = "DLM"
+        volume_type     = "persistentvolume"
+      }
+
+      copy_tags = true
+    }
+
+    target_tags = {
+      "k8s.io/pvc/persistentvolume" = "1"
+    }
+  }
+}


### PR DESCRIPTION
This policy will take a snapshot of volume which is tagged as,
"k8s.io/pvc/persistentvolume" = "1"

This policy will run every day at 5:00 AM, and will retain 30days.