### PR TITLE
Add Velero Backup to cloud-platform-components

### DIFF
--- a/terraform/cloud-platform-components/templates/velero/velero.yaml.tpl
+++ b/terraform/cloud-platform-components/templates/velero/velero.yaml.tpl
@@ -69,7 +69,7 @@ configuration:
     # match `configuration.provider`. Required.
     name: aws
     # Bucket to store backups in. Required.
-    bucket: cloud-platform-velero-bucket-test
+    bucket: cloud-platform-velero-backup-${cluster_name}
     # Prefix within bucket under which to store backups. Optional.
     prefix:
     # Additional provider-specific configuration. See link above

--- a/terraform/cloud-platform-components/templates/velero/velero.yaml.tpl
+++ b/terraform/cloud-platform-components/templates/velero/velero.yaml.tpl
@@ -35,7 +35,7 @@ configuration:
   backupStorageLocation:
     name: aws
     # Bucket to store backups in. Required.
-    bucket: cloud-platform-velero-backup-${cluster_name}
+    bucket: cloud-platform-velero-backups
     # Prefix within bucket under which to store backups. Optional.
     prefix: ${cluster_name}
     config:

--- a/terraform/cloud-platform-components/templates/velero/velero.yaml.tpl
+++ b/terraform/cloud-platform-components/templates/velero/velero.yaml.tpl
@@ -1,0 +1,195 @@
+##
+## Configuration settings that directly affect the Velero deployment YAML.
+##
+
+# Details of the container image to use in the Velero deployment & daemonset (if
+# enabling restic). Required.
+image:
+  repository: gcr.io/heptio-images/velero
+#  tag: v1.1.0
+  tag: latest
+  pullPolicy: IfNotPresent
+
+# Annotations to add to the Velero deployment's pod template. Optional.
+#
+# If using kube2iam or kiam, use the following annotation with your AWS_ACCOUNT_ID
+# and VELERO_ROLE_NAME filled in:
+#  iam.amazonaws.com/role: arn:aws:iam::<AWS_ACCOUNT_ID>:role/<VELERO_ROLE_NAME>
+podAnnotations: {}
+
+# Resource requests/limits to specify for the Velero deployment. Optional.
+resources: {}
+
+# Init containers to add to the Velero deployment's pod spec. Optional.
+initContainers: []
+  # - name:
+  #   image:
+  #   volumeMounts:
+  #     - name: plugins
+  #       mountPath: /target
+
+# Tolerations to use for the Velero deployment. Optional.
+tolerations: []
+
+# Node selector to use for the Velero deployment. Optional.
+nodeSelector: {}
+
+# Settings for Velero's prometheus metrics. Disabled by default.
+metrics:
+  enabled: true
+  scrapeInterval: 30s
+
+  # Pod annotations for Prometheus
+  podAnnotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "8085"
+    prometheus.io/path: "/metrics"
+
+  serviceMonitor:
+    enabled: true
+    additionalLabels: {}
+
+##
+## End of deployment-related settings.
+##
+
+
+##
+## Parameters for the `default` BackupStorageLocation and VolumeSnapshotLocation,
+## and additional server settings.
+##
+configuration:
+  # Cloud provider being used (e.g. aws, azure, gcp).
+  provider: aws
+
+  # Parameters for the `default` BackupStorageLocation. See
+  # https://velero.io/docs/v1.0.0/api-types/backupstoragelocation/
+  backupStorageLocation:
+    # Cloud provider where backups should be stored. Usually should
+    # match `configuration.provider`. Required.
+    name: aws
+    # Bucket to store backups in. Required.
+    bucket: cloud-platform-velero-bucket-test
+    # Prefix within bucket under which to store backups. Optional.
+    prefix:
+    # Additional provider-specific configuration. See link above
+    # for details of required/optional fields for your provider.
+    config:
+      region: eu-west-2
+    #  s3ForcePathStyle:
+    #  s3Url:
+    #  kmsKeyId:
+    #  resourceGroup:
+    #  storageAccount:
+    #  publicUrl:
+
+  # Parameters for the `default` VolumeSnapshotLocation. See
+  # https://velero.io/docs/v1.0.0/api-types/volumesnapshotlocation/
+  volumeSnapshotLocation:
+    # Cloud provider where volume snapshots are being taken. Usually
+    # should match `configuration.provider`. Required.,
+    name: aws
+    # Additional provider-specific configuration. See link above
+    # for details of required/optional fields for your provider.
+    config:
+      region: eu-west-2
+  #    apitimeout:
+  #    resourceGroup:
+  #    snapshotLocation:
+  #    project:
+
+  # These are server-level settings passed as CLI flags to the `velero server` command. Velero
+  # uses default values if they're not passed in, so they only need to be explicitly specified
+  # here if using a non-default value. The `velero server` default values are shown in the
+  # comments below.
+  # --------------------
+  # `velero server` default: 1m
+  backupSyncPeriod:
+  # `velero server` default: 1h
+  resticTimeout:
+  # `velero server` default: namespaces,persistentvolumes,persistentvolumeclaims,secrets,configmaps,serviceaccounts,limitranges,pods
+  restoreResourcePriorities:
+  # `velero server` default: false
+  restoreOnlyMode:
+
+  # additional key/value pairs to be used as environment variables such as "AWS_CLUSTER_NAME: 'yourcluster.domain.tld'"
+  extraEnvVars: {}
+
+##
+## End of backup/snapshot location settings.
+##
+
+
+##
+## Settings for additional Velero resources.
+##
+
+# Whether to create the Velero cluster role binding.
+rbac:
+  create: true
+
+# Information about the Kubernetes service account Velero uses.
+serviceAccount:
+  server:
+    create: true
+    name:
+
+# Info about the secret to be used by the Velero deployment, which
+# should contain credentials for the cloud provider IAM account you've
+# set up for Velero.
+credentials:
+  # Whether a secret should be used as the source of IAM account
+  # credentials. Set to false if, for example, using kube2iam or
+  # kiam to provide IAM credentials for the Velero pod.
+  useSecret: true
+  # Name of a pre-existing secret (if any) in the Velero namespace
+  # that should be used to get IAM account credentials. Optional.
+  existingSecret:
+  # Data to be stored in the Velero secret, if `useSecret` is
+  # true and `existingSecret` is empty. This should be the contents
+  # of your IAM credentials file.
+  secretContents:
+    cloud: |
+      [default]
+      aws_access_key_id=
+      aws_secret_access_key=
+
+# Wheter to create volumesnapshotlocation crd, if false => disable snapshot feature
+snapshotsEnabled: true
+
+# Whether to deploy the restic daemonset.
+deployRestic: false
+
+restic:
+  podVolumePath: /var/lib/kubelet/pods
+  privileged: false
+  # Resource requests/limits to specify for the Restic daemonset deployment. Optional.
+  resources: {}
+
+# Backup schedules to create.
+# Eg:
+# schedules:
+#   mybackup:
+#     schedule: "0 0 * * *"
+#     template:
+#       ttl: "240h"
+#       includedNamespaces:
+#        - foo
+schedules:
+  allnamespacebackup:
+    schedule: "0/30 * * * *"
+
+# Velero ConfigMaps.
+# Eg:
+# configMaps:
+#   restic-restore-action-config:
+#     labels:
+#       velero.io/plugin-config: ""
+#       velero.io/restic: RestoreItemAction
+#     data:
+#       image: gcr.io/heptio-images/velero-restic-restore-help
+configMaps: {}
+
+##
+## End of additional Velero resource settings.
+##

--- a/terraform/cloud-platform-components/templates/velero/velero.yaml.tpl
+++ b/terraform/cloud-platform-components/templates/velero/velero.yaml.tpl
@@ -151,8 +151,6 @@ credentials:
   secretContents:
 #    cloud: |
  #     [default]
- #     aws_access_key_id = AKIAIQVVRUUOCPQBST3Q
- #     aws_secret_access_key = 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
 # Wheter to create volumesnapshotlocation crd, if false => disable snapshot feature
 snapshotsEnabled: true
 

--- a/terraform/cloud-platform-components/templates/velero/velero.yaml.tpl
+++ b/terraform/cloud-platform-components/templates/velero/velero.yaml.tpl
@@ -37,7 +37,7 @@ configuration:
     # Bucket to store backups in. Required.
     bucket: cloud-platform-velero-backup-${cluster_name}
     # Prefix within bucket under which to store backups. Optional.
-    prefix:
+    prefix: ${cluster_name}
     config:
       region: eu-west-2
     #  s3ForcePathStyle:

--- a/terraform/cloud-platform-components/templates/velero/velero.yaml.tpl
+++ b/terraform/cloud-platform-components/templates/velero/velero.yaml.tpl
@@ -7,32 +7,10 @@
 image:
   repository: gcr.io/heptio-images/velero
   tag: v1.1.0
-#  tag: master
   pullPolicy: IfNotPresent
 
-# Annotations to add to the Velero deployment's pod template. Optional.
-#
-# If using kube2iam or kiam, use the following annotation with your AWS_ACCOUNT_ID
-# and VELERO_ROLE_NAME filled in:
-#  iam.amazonaws.com/role: arn:aws:iam::<AWS_ACCOUNT_ID>:role/<VELERO_ROLE_NAME>
-podAnnotations: {}
-
-# Resource requests/limits to specify for the Velero deployment. Optional.
-resources: {}
-
-# Init containers to add to the Velero deployment's pod spec. Optional.
-initContainers: []
-  # - name:
-  #   image:
-  #   volumeMounts:
-  #     - name: plugins
-  #       mountPath: /target
-
-# Tolerations to use for the Velero deployment. Optional.
-tolerations: []
-
-# Node selector to use for the Velero deployment. Optional.
-nodeSelector: {}
+podAnnotations:
+  iam.amazonaws.com/role: ${iam_role}
 
 # Settings for Velero's prometheus metrics. Disabled by default.
 metrics:
@@ -49,31 +27,17 @@ metrics:
     enabled: true
     additionalLabels: {}
 
-##
-## End of deployment-related settings.
-##
-
-
-##
-## Parameters for the `default` BackupStorageLocation and VolumeSnapshotLocation,
-## and additional server settings.
-##
 configuration:
-  # Cloud provider being used (e.g. aws, azure, gcp).
   provider: aws
 
   # Parameters for the `default` BackupStorageLocation. See
   # https://velero.io/docs/v1.0.0/api-types/backupstoragelocation/
   backupStorageLocation:
-    # Cloud provider where backups should be stored. Usually should
-    # match `configuration.provider`. Required.
     name: aws
     # Bucket to store backups in. Required.
     bucket: cloud-platform-velero-backup-${cluster_name}
     # Prefix within bucket under which to store backups. Optional.
     prefix:
-    # Additional provider-specific configuration. See link above
-    # for details of required/optional fields for your provider.
     config:
       region: eu-west-2
     #  s3ForcePathStyle:
@@ -83,14 +47,8 @@ configuration:
     #  storageAccount:
     #  publicUrl:
 
-  # Parameters for the `default` VolumeSnapshotLocation. See
-  # https://velero.io/docs/v1.0.0/api-types/volumesnapshotlocation/
   volumeSnapshotLocation:
-    # Cloud provider where volume snapshots are being taken. Usually
-    # should match `configuration.provider`. Required.,
     name: aws
-    # Additional provider-specific configuration. See link above
-    # for details of required/optional fields for your provider.
     config:
       region: eu-west-2
   #    apitimeout:
@@ -98,12 +56,6 @@ configuration:
   #    snapshotLocation:
   #    project:
 
-  # These are server-level settings passed as CLI flags to the `velero server` command. Velero
-  # uses default values if they're not passed in, so they only need to be explicitly specified
-  # here if using a non-default value. The `velero server` default values are shown in the
-  # comments below.
-  # --------------------
-  # `velero server` default: 1m
   backupSyncPeriod:
   # `velero server` default: 1h
   resticTimeout:
@@ -115,16 +67,6 @@ configuration:
   # additional key/value pairs to be used as environment variables such as "AWS_CLUSTER_NAME: 'yourcluster.domain.tld'"
   extraEnvVars: {}
 
-##
-## End of backup/snapshot location settings.
-##
-
-
-##
-## Settings for additional Velero resources.
-##
-
-# Whether to create the Velero cluster role binding.
 rbac:
   create: true
 
@@ -134,34 +76,13 @@ serviceAccount:
     create: true
     name:
 
-# Info about the secret to be used by the Velero deployment, which
-# should contain credentials for the cloud provider IAM account you've
-# set up for Velero.
 credentials:
-  # Whether a secret should be used as the source of IAM account
-  # credentials. Set to false if, for example, using kube2iam or
-  # kiam to provide IAM credentials for the Velero pod.
   useSecret: false
-  # Name of a pre-existing secret (if any) in the Velero namespace
-  # that should be used to get IAM account credentials. Optional.
   existingSecret:
-  # Data to be stored in the Velero secret, if `useSecret` is
-  # true and `existingSecret` is empty. This should be the contents
-  # of your IAM credentials file.
   secretContents:
-#    cloud: |
- #     [default]
-# Wheter to create volumesnapshotlocation crd, if false => disable snapshot feature
 snapshotsEnabled: true
 
-# Whether to deploy the restic daemonset.
 deployRestic: false
-
-restic:
-  podVolumePath: /var/lib/kubelet/pods
-  privileged: false
-  # Resource requests/limits to specify for the Restic daemonset deployment. Optional.
-  resources: {}
 
 # Backup schedules to create.
 # Eg:
@@ -174,19 +95,8 @@ restic:
 #        - foo
 schedules:
   allnamespacebackup:
-    schedule: "0/30 * * * *"
+    schedule: "0 0/3 * * *"
 
-# Velero ConfigMaps.
-# Eg:
-# configMaps:
-#   restic-restore-action-config:
-#     labels:
-#       velero.io/plugin-config: ""
-#       velero.io/restic: RestoreItemAction
-#     data:
-#       image: gcr.io/heptio-images/velero-restic-restore-help
 configMaps: {}
 
-##
-## End of additional Velero resource settings.
-##
+

--- a/terraform/cloud-platform-components/templates/velero/velero.yaml.tpl
+++ b/terraform/cloud-platform-components/templates/velero/velero.yaml.tpl
@@ -6,8 +6,8 @@
 # enabling restic). Required.
 image:
   repository: gcr.io/heptio-images/velero
-#  tag: v1.1.0
-  tag: latest
+  tag: v1.1.0
+#  tag: master
   pullPolicy: IfNotPresent
 
 # Annotations to add to the Velero deployment's pod template. Optional.
@@ -141,7 +141,7 @@ credentials:
   # Whether a secret should be used as the source of IAM account
   # credentials. Set to false if, for example, using kube2iam or
   # kiam to provide IAM credentials for the Velero pod.
-  useSecret: true
+  useSecret: false
   # Name of a pre-existing secret (if any) in the Velero namespace
   # that should be used to get IAM account credentials. Optional.
   existingSecret:
@@ -149,11 +149,10 @@ credentials:
   # true and `existingSecret` is empty. This should be the contents
   # of your IAM credentials file.
   secretContents:
-    cloud: |
-      [default]
-      aws_access_key_id=
-      aws_secret_access_key=
-
+#    cloud: |
+ #     [default]
+ #     aws_access_key_id = AKIAIQVVRUUOCPQBST3Q
+ #     aws_secret_access_key = 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
 # Wheter to create volumesnapshotlocation crd, if false => disable snapshot feature
 snapshotsEnabled: true
 

--- a/terraform/cloud-platform-components/velero.tf
+++ b/terraform/cloud-platform-components/velero.tf
@@ -1,0 +1,138 @@
+# -----------------------------------------------------------
+# set up S3 bucket
+# -----------------------------------------------------------
+
+resource "aws_s3_bucket" "velero-test" {
+  #  provider      = "aws.cloud-platform-ireland"
+  #  bucket_prefix = "${var.bucket_prefix}"
+  acl    = "private"
+  region = "eu-west-2"
+
+  lifecycle {
+    prevent_destroy = false
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+}
+
+# Velero
+# KIAM role and policy creation
+# expressing which roles are permitted to be assumed within that namespace.
+# Correct annotation are added to the Pod to indicate which role should be assumed.
+# Without correct Pod annotation Kiam cannot provide access to the Pod to execute required actions.
+
+data "aws_iam_policy_document" "velero_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+      identifiers = [data.aws_iam_role.nodes.arn]
+    }
+  }
+}
+
+resource "aws_iam_role" "velero" {
+  name               = "velero.${data.terraform_remote_state.cluster.outputs.cluster_domain_name}"
+  assume_role_policy = data.aws_iam_policy_document.velero_assume.json
+}
+
+data "aws_iam_policy_document" "velero" {
+  statement {
+    actions = [
+      "sts:AssumeRole",
+      "ec2:DescribeSnapshots",
+      "ec2:DescribeVolumes",
+      "ec2:CreateTags",
+      "ec2:CreateVolume",
+      "ec2:CreateSnapshot",
+      "ec2:DeleteSnapshot",
+    ]
+
+    resources = ["*"]
+  }
+  statement {
+    actions = [
+      "s3:GetObject",
+      "s3:DeleteObject",
+      "s3:PutObject",
+      "s3:AbortMultipartUpload",
+      "s3:ListMultipartUploadParts",
+    ]
+
+    resources = ["arn:aws:s3:::$cloud-platform-velero-bucket-test/*"]
+  }
+  statement {
+    actions = [
+      "s3:ListBucket",
+    ]
+
+    resources = ["arn:aws:s3:::$cloud-platform-velero-bucket-test"]
+  }
+}
+
+resource "aws_iam_role_policy" "velero" {
+  name   = "velero"
+  role   = aws_iam_role.velero.id
+  policy = data.aws_iam_policy_document.velero.json
+}
+
+resource "kubernetes_namespace" "velero" {
+  metadata {
+    name = "velero"
+
+    labels = {
+      "name"                        = "velero"
+      "openpolicyagent.org/webhook" = "ignore"
+    }
+
+    annotations = {
+      "cloud-platform.justice.gov.uk/application"   = "Velero"
+      "cloud-platform.justice.gov.uk/business-unit" = "cloud-platform"
+      "cloud-platform.justice.gov.uk/owner"         = "Cloud Platform: platforms@digital.justice.gov.uk"
+      "cloud-platform.justice.gov.uk/source-code"   = "https://github.com/ministryofjustice/cloud-platform-infrastructure"
+    }
+  }
+}
+
+data "template_file" "velero" {
+  template = file("./templates/velero/velero.yaml.tpl")
+  vars = {
+    cluster_domain_name = local.cluster_base_domain_name
+  }
+}
+
+resource "helm_release" "velero" {
+  name       = "velero"
+  namespace  = "velero"
+  repository = "stable"
+  chart      = "velero"
+  version    = "2.1.7"
+
+  depends_on = [
+    null_resource.kube_system_ns_label,
+    kubernetes_namespace.velero,
+    null_resource.deploy,
+  ]
+  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+  # force an interpolation expression to be interpreted as a list by wrapping it
+  # in an extra set of list brackets. That form was supported for compatibility in
+  # v0.11, but is no longer supported in Terraform v0.12.
+  #
+  # If the expression in the following list itself returns a list, remove the
+  # brackets to avoid interpretation as a list of lists. If the expression
+  # returns a single list item then leave it as-is and remove this TODO comment.
+  values = [
+    data.template_file.values.rendered,
+  ]
+
+  lifecycle {
+    ignore_changes = [keyring]
+  }
+}

--- a/terraform/cloud-platform-components/velero.tf
+++ b/terraform/cloud-platform-components/velero.tf
@@ -1,7 +1,3 @@
-# -----------------------------------------------------------
-# Create Velero Namespace
-# -----------------------------------------------------------
-
 resource "kubernetes_namespace" "velero" {
   metadata {
     name = "velero"
@@ -25,47 +21,7 @@ data "template_file" "velero" {
   vars = {
     cluster_name = terraform.workspace
     iam_role     = aws_iam_role.velero.name
-    #  cluster_domain_name = local.cluster_base_domain_name
   }
-}
-
-# -----------------------------------------------------------
-# set up S3 bucket
-# -----------------------------------------------------------
-
-resource "aws_s3_bucket" "velero" {
-  bucket = "cloud-platform-velero-backup-${terraform.workspace}"
-  acl    = "private"
-  region = "eu-west-2"
-
-  versioning {
-    enabled = true
-  }
-
-  lifecycle {
-    prevent_destroy = true
-  }
-
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
-    }
-  }
-}
-
-resource "aws_s3_bucket_public_access_block" "velero" {
-  bucket = "cloud-platform-velero-backup-${terraform.workspace}"
-
-  block_public_acls       = true
-  block_public_policy     = true
-  ignore_public_acls      = true
-  restrict_public_buckets = true
-
-  depends_on = [
-    aws_s3_bucket.velero,
-  ]
 }
 
 data "aws_iam_policy_document" "velero_assume" {
@@ -105,13 +61,13 @@ data "aws_iam_policy_document" "velero" {
       "s3:AbortMultipartUpload",
       "s3:ListMultipartUploadParts",
     ]
-    resources = ["arn:aws:s3:::cloud-platform-velero-backup-${terraform.workspace}/*"]
+    resources = ["arn:aws:s3:::cloud-platform-velero-backups/*"]
   }
   statement {
     actions = [
       "s3:ListBucket",
     ]
-    resources = ["arn:aws:s3:::cloud-platform-velero-backup-${terraform.workspace}"]
+    resources = ["arn:aws:s3:::cloud-platform-velero-backups"]
   }
 }
 
@@ -120,10 +76,6 @@ resource "aws_iam_role_policy" "velero" {
   role   = aws_iam_role.velero.id
   policy = data.aws_iam_policy_document.velero.json
 }
-
-# -----------------------------------------------------------
-# Create Velero Helm chart
-# -----------------------------------------------------------
 
 resource "helm_release" "velero" {
   name       = "velero"

--- a/terraform/cloud-platform-components/velero.tf
+++ b/terraform/cloud-platform-components/velero.tf
@@ -68,7 +68,7 @@ data "aws_iam_policy_document" "velero" {
       "s3:ListMultipartUploadParts",
     ]
 
-#    resources = ["*"]
+    #    resources = ["*"]
     resources = ["arn:aws:s3:::cloud-platform-velero-bucket-test/*"]
   }
   statement {
@@ -76,7 +76,7 @@ data "aws_iam_policy_document" "velero" {
       "s3:ListBucket",
     ]
 
- #   resources = ["*"]
+    #   resources = ["*"]
     resources = ["arn:aws:s3:::cloud-platform-velero-bucket-test"]
   }
 }
@@ -112,9 +112,9 @@ resource "kubernetes_namespace" "velero" {
 
 data "template_file" "velero" {
   template = file("./templates/velero/velero.yaml.tpl")
-#  vars = {
-#    cluster_domain_name = local.cluster_base_domain_name
-#  }
+  #  vars = {
+  #    cluster_domain_name = local.cluster_base_domain_name
+  #  }
 }
 
 # -----------------------------------------------------------
@@ -146,11 +146,11 @@ resource "helm_release" "velero" {
   # returns a single list item then leave it as-is and remove this TODO comment.
   values = [
     data.template_file.velero.rendered,
-<<EOF
+    <<EOF
 podAnnotations:
   iam.amazonaws.com/role: "${aws_iam_role.velero.name}"
 EOF
-,
+    ,
   ]
 
   lifecycle {

--- a/terraform/cloud-platform-components/velero.tf
+++ b/terraform/cloud-platform-components/velero.tf
@@ -3,7 +3,9 @@ resource "kubernetes_namespace" "velero" {
     name = "velero"
 
     labels = {
-      "component" = "velero"
+      "component"                                      = "velero"
+      "cloud-platform.justice.gov.uk/environment-name" = "production"
+      "cloud-platform.justice.gov.uk/is-production"    = "true"
     }
 
     annotations = {


### PR DESCRIPTION
WHAT
Add Velero backup to cloud-platform-components to install as parr of new cluster creation

WHY
Velero backup gives you tools to back up and restore your Kubernetes cluster resources and persistent volumes