### PR TITLE
Create S3 bucket for Velero backups

### DIFF
--- a/terraform/global-resources/main.tf
+++ b/terraform/global-resources/main.tf
@@ -13,7 +13,7 @@ locals {
 
 provider "auth0" {
   version = ">= 0.2.1"
-  domain = local.auth0_tenant_domain
+  domain  = local.auth0_tenant_domain
 }
 
 # default provider

--- a/terraform/global-resources/s3.tf
+++ b/terraform/global-resources/s3.tf
@@ -105,3 +105,36 @@ resource "aws_s3_bucket" "cluster_components" {
   }
 }
 
+resource "aws_s3_bucket" "velero" {
+  bucket = "cloud-platform-velero-backups"
+  acl    = "private"
+  provider = aws.cloud-platform
+
+  versioning {
+    enabled = true
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "velero" {
+  bucket = "cloud-platform-velero-backups"
+  provider = aws.cloud-platform
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+
+  depends_on = [
+    aws_s3_bucket.velero,
+  ]
+}
+
+

--- a/terraform/global-resources/s3.tf
+++ b/terraform/global-resources/s3.tf
@@ -106,8 +106,8 @@ resource "aws_s3_bucket" "cluster_components" {
 }
 
 resource "aws_s3_bucket" "velero" {
-  bucket = "cloud-platform-velero-backups"
-  acl    = "private"
+  bucket   = "cloud-platform-velero-backups"
+  acl      = "private"
   provider = aws.cloud-platform
 
   versioning {
@@ -124,7 +124,7 @@ resource "aws_s3_bucket" "velero" {
 }
 
 resource "aws_s3_bucket_public_access_block" "velero" {
-  bucket = "cloud-platform-velero-backups"
+  bucket   = "cloud-platform-velero-backups"
   provider = aws.cloud-platform
 
   block_public_acls       = true


### PR DESCRIPTION
WHAT
Create S3 bucket for Velero backups

WHY
This bucket will store all backups from all clusters under each clusters prefix folder 