### PR TITLE
add servicemonitor check for velero

### DIFF
--- a/smoke-tests/spec/servicemonitors_spec.rb
+++ b/smoke-tests/spec/servicemonitors_spec.rb
@@ -38,4 +38,13 @@ describe "servicemonitors" do
     ]
     expect(names).to eq(expected)
   end
+  
+  specify "expected velero servicemonitors", cluster: "live-1" do
+    names = get_servicemonitors("velero").map { |set| set.dig("metadata", "name") }.sort
+
+    expected = [
+      "velero",
+    ]
+    expect(names).to eq(expected)
+  end
 end

--- a/smoke-tests/spec/servicemonitors_spec.rb
+++ b/smoke-tests/spec/servicemonitors_spec.rb
@@ -38,8 +38,8 @@ describe "servicemonitors" do
     ]
     expect(names).to eq(expected)
   end
-  
-  specify "expected velero servicemonitors", cluster: "live-1" do
+
+  specify "expected velero servicemonitors" do
     names = get_servicemonitors("velero").map { |set| set.dig("metadata", "name") }.sort
 
     expected = [


### PR DESCRIPTION
An integration test was already in place to ensure the essential SM existed in the cluster.
This PR add the test of the velero service monitor.

Tested