### PR TITLE
prometheuses.monitoring.coreos.com check

### DIFF
--- a/smoke-tests/spec/kubernetes_helper.rb
+++ b/smoke-tests/spec/kubernetes_helper.rb
@@ -180,6 +180,11 @@ def get_certificates
   JSON.parse(`kubectl get certificate --all-namespaces -o json`).fetch("items")
 end
 
+# CRD prometheuses.monitoring.coreos.com
+def get_prometheuses
+  JSON.parse(`kubectl get prometheus --all-namespaces -o json`).fetch("items")
+end
+
 def get_servicemonitors(namespace)
   JSON.parse(`kubectl get servicemonitors -n #{namespace} -o json`).fetch("items")
 end

--- a/smoke-tests/spec/prometheus_crd_spec.rb
+++ b/smoke-tests/spec/prometheus_crd_spec.rb
@@ -1,0 +1,11 @@
+require "spec_helper"
+
+describe "Prometheus" do
+  specify "expected Prometheus resource" do
+    names = get_prometheuses.map { |set| set.dig("metadata", "name") }.sort
+    expected = [
+      "prometheus-operator-prometheus",
+    ]
+    expect(names).to include(*expected)
+  end
+end


### PR DESCRIPTION
This PR introduces a test to ensure that the essential Prometheus (prometheuses.monitoring.coreos.com) resources are there. 

