### PR TITLE
Add alerts for Velero backup

### DIFF
--- a/terraform/cloud-platform-components/resources/prometheusrule-alerts/application-alerts.yaml
+++ b/terraform/cloud-platform-components/resources/prometheusrule-alerts/application-alerts.yaml
@@ -252,4 +252,20 @@ spec:
       for: 5m
       labels:
         severity: warning
+    - alert: VeleroBackupFailed
+      annotations:
+        message: A Veleo backup has failed
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md
+      expr: sum(velero_backup_success_total{service="velero"}) / sum(velero_backup_attempt_total{service="velero"}) < 1
+      for: 1m
+      labels:
+        severity: warning
+    - alert: VeleroAllNamespaceBackupNotSuccessfulForOverFourHours
+      annotations:
+        message: The Velero backup schedule for AllNamespaceBackup does not have a successful timestamp for over 4 hours
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md
+      expr: (time() - velero_backup_last_successful_timestamp{schedule="velero-allnamespacebackup"}) / 60 / 60 > 4
+      for: 1m
+      labels:
+        severity: warning
         

--- a/terraform/cloud-platform-components/resources/prometheusrule-alerts/application-alerts.yaml
+++ b/terraform/cloud-platform-components/resources/prometheusrule-alerts/application-alerts.yaml
@@ -254,7 +254,7 @@ spec:
         severity: warning
     - alert: VeleroBackupFailed
       annotations:
-        message: A Veleo backup has failed
+        message: A Velero backup has failed
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md
       expr: sum(velero_backup_success_total{service="velero"}) / sum(velero_backup_attempt_total{service="velero"}) < 1
       for: 1m


### PR DESCRIPTION
Added 2 alerts in application alerts for Velero:

1. Alert if there is a backup failure for any schedule

2. The 'AllNamespaceBackup' runs every 3 hours and currently takes an average of 2 minutes to run. This alert will trigger is there is not a successful timestamp for this schedule for over 4 hours. 

Both alerts will go into low-priority slack channel 