### PR TITLE
alertmanagers.monitoring.coreos.com spec

### DIFF
--- a/smoke-tests/spec/alertmanager_spec.rb
+++ b/smoke-tests/spec/alertmanager_spec.rb
@@ -10,6 +10,3 @@ describe "Alertmanager resources" do
     expect(names).to include(*expected)
   end
 end
-
-
-

--- a/smoke-tests/spec/alertmanager_spec.rb
+++ b/smoke-tests/spec/alertmanager_spec.rb
@@ -1,0 +1,15 @@
+require "spec_helper"
+
+describe "Alertmanager resources" do
+  specify "expected Alertmanager resources" do
+    names = get_alertmanagers.map { |set| set.dig("metadata", "name") }.sort
+
+    expected = [
+      "prometheus-operator-alertmanager",
+    ]
+    expect(names).to include(*expected)
+  end
+end
+
+
+

--- a/smoke-tests/spec/kubernetes_helper.rb
+++ b/smoke-tests/spec/kubernetes_helper.rb
@@ -200,6 +200,7 @@ def get_prometheus_rules
   JSON.parse(`kubectl get prometheusrules --all-namespaces -o json`).fetch("items")
 end
 
+# CRD alertmanagers.monitoring.coreos.com
 def get_alertmanagers
   JSON.parse(`kubectl get alertmanagers --all-namespaces -o json`).fetch("items")
 end

--- a/smoke-tests/spec/kubernetes_helper.rb
+++ b/smoke-tests/spec/kubernetes_helper.rb
@@ -200,6 +200,10 @@ def get_prometheus_rules
   JSON.parse(`kubectl get prometheusrules --all-namespaces -o json`).fetch("items")
 end
 
+def get_alertmanagers
+  JSON.parse(`kubectl get alertmanagers --all-namespaces -o json`).fetch("items")
+end
+
 def get_servicemonitors(namespace)
   JSON.parse(`kubectl get servicemonitors -n #{namespace} -o json`).fetch("items")
 end


### PR DESCRIPTION
This PR introduces an integration test that ensures the relevant `alertmanager` (alertmanagers.monitoring.coreos.com) resources (!=CRD) exist.

Works with production and test clusters. 