### PR TITLE
ECR and CloudWatch ServiceMonitor tests

### DIFF
--- a/smoke-tests/spec/servicemonitors_spec.rb
+++ b/smoke-tests/spec/servicemonitors_spec.rb
@@ -5,6 +5,8 @@ describe "servicemonitors" do
     names = get_servicemonitors("monitoring").map { |set| set.dig("metadata", "name") }.sort
 
     expected = [
+      "ecr-exporter-prometheus-ecr-exporter",
+      "cloudwatch-exporter-prometheus-cloudwatch-exporter", 
       "prometheus-operator-alertmanager",
       "prometheus-operator-apiserver",
       "prometheus-operator-grafana",

--- a/smoke-tests/spec/servicemonitors_spec.rb
+++ b/smoke-tests/spec/servicemonitors_spec.rb
@@ -6,7 +6,7 @@ describe "servicemonitors" do
 
     expected = [
       "ecr-exporter-prometheus-ecr-exporter",
-      "cloudwatch-exporter-prometheus-cloudwatch-exporter", 
+      "cloudwatch-exporter-prometheus-cloudwatch-exporter",
       "prometheus-operator-alertmanager",
       "prometheus-operator-apiserver",
       "prometheus-operator-grafana",


### PR DESCRIPTION
This PR adds ECR and CloudWatch integration tests, which is basically check their ServiceMonitor resources are deployed. 

More information in [#1309](ministryofjustice/cloud-platform#1309)