### PR TITLE
Smoke tests for authorized_keys

### DIFF
--- a/smoke-tests/spec/authorized_keys_spec.rb
+++ b/smoke-tests/spec/authorized_keys_spec.rb
@@ -1,0 +1,25 @@
+require "spec_helper"
+
+describe "authorized_keys", cluster: "live-1" do
+
+  context "authorized-keys-provider namespace should exists" do
+    it "Fail if namespace doesnt exist" do
+        expect(namespace_exists?('authorized-keys-provider')).to eq(true)
+    end
+  end
+
+  context "expected all pods running inside authorized-keys-provider namespace" do
+    let(:pods) { get_running_app_pods("authorized-keys-provider", "authorized-keys-provider") }
+
+    it "all pods inside authorized-keys-provider are running" do
+        expect(all_containers_running?(pods)).to eq(true)
+    end
+  end
+
+  context "expected authorized_keys file within the S3 bucket" do
+    it "authorized_keys file exists and it can be downloaded" do
+        URI.open('https://s3-eu-west-2.amazonaws.com/cloud-platform-ab9d0cbde59c3b3112de9d117068515d/authorized_keys')
+    end
+  end
+
+end

--- a/smoke-tests/spec/authorized_keys_spec.rb
+++ b/smoke-tests/spec/authorized_keys_spec.rb
@@ -17,8 +17,8 @@ describe "authorized_keys", cluster: "live-1" do
 
   context "expected authorized_keys file within the S3 bucket" do
     it "authorized_keys file exists and it can be downloaded" do
-        response = URI.open('https://s3-eu-west-2.amazonaws.com/cloud-platform-ab9d0cbde59c3b3112de9d117068515d/authorized_keys')
-        expect(response.status).to eq(["200", "OK"])
+      response = URI.open("https://s3-eu-west-2.amazonaws.com/cloud-platform-ab9d0cbde59c3b3112de9d117068515d/authorized_keys")
+      expect(response.status).to eq(["200", "OK"])
     end
   end
 end

--- a/smoke-tests/spec/authorized_keys_spec.rb
+++ b/smoke-tests/spec/authorized_keys_spec.rb
@@ -18,7 +18,8 @@ describe "authorized_keys", cluster: "live-1" do
 
   context "expected authorized_keys file within the S3 bucket" do
     it "authorized_keys file exists and it can be downloaded" do
-        URI.open('https://s3-eu-west-2.amazonaws.com/cloud-platform-ab9d0cbde59c3b3112de9d117068515d/authorized_keys')
+        response = URI.open('https://s3-eu-west-2.amazonaws.com/cloud-platform-ab9d0cbde59c3b3112de9d117068515d/authorized_keys')
+        expect(response.status).to eq(["200", "OK"])
     end
   end
 


### PR DESCRIPTION
This PR closes [#1358](ministryofjustice/cloud-platform#1358). 

It includes smoke tests to check `authorized-keys-provider` namespace exists, it has all pods running and the authorized_keys file exists within S3 bucket.