### PR TITLE
ECR and CloudWatch ServiceMonitor must exist only for live-1

### DIFF
--- a/smoke-tests/spec/servicemonitors_spec.rb
+++ b/smoke-tests/spec/servicemonitors_spec.rb
@@ -38,7 +38,7 @@ describe "servicemonitors" do
     ]
     expect(names).to eq(expected)
   end
-  
+
   specify "expected ECR and CloudWatch servicemonitors", cluster: "live-1" do
     names = get_servicemonitors("monitoring").map { |set| set.dig("metadata", "name") }.sort
 

--- a/smoke-tests/spec/servicemonitors_spec.rb
+++ b/smoke-tests/spec/servicemonitors_spec.rb
@@ -5,8 +5,6 @@ describe "servicemonitors" do
     names = get_servicemonitors("monitoring").map { |set| set.dig("metadata", "name") }.sort
 
     expected = [
-      "ecr-exporter-prometheus-ecr-exporter",
-      "cloudwatch-exporter-prometheus-cloudwatch-exporter",
       "prometheus-operator-alertmanager",
       "prometheus-operator-apiserver",
       "prometheus-operator-grafana",
@@ -39,6 +37,16 @@ describe "servicemonitors" do
       "concourse",
     ]
     expect(names).to eq(expected)
+  end
+  
+  specify "expected ECR and CloudWatch servicemonitors", cluster: "live-1" do
+    names = get_servicemonitors("monitoring").map { |set| set.dig("metadata", "name") }.sort
+
+    expected = [
+      "ecr-exporter-prometheus-ecr-exporter",
+      "cloudwatch-exporter-prometheus-cloudwatch-exporter",
+    ]
+    expect(names).to include(*expected)
   end
 
   specify "expected velero servicemonitors" do


### PR DESCRIPTION
Smoke-tests for ServiceMonitor (ECR and CloudWatch) for live-1. They should only apply for live-1
