### PR TITLE
Live-1 only for the ECR prometheusrule test

### DIFF
--- a/smoke-tests/spec/prometheusrules_spec.rb
+++ b/smoke-tests/spec/prometheusrules_spec.rb
@@ -34,6 +34,4 @@ describe "Prometheus Rules" do
     ]
     expect(names).to include(*expected)
   end
-
-
 end

--- a/smoke-tests/spec/prometheusrules_spec.rb
+++ b/smoke-tests/spec/prometheusrules_spec.rb
@@ -1,11 +1,10 @@
 require "spec_helper"
 
 describe "Prometheus Rules" do
-  specify "expected Prometheus Rule" do
+  specify "expected in all clusters" do
     names = get_prometheus_rules.map { |set| set.dig("metadata", "name") }.sort
 
     expected = [
-      "prometheus-custom-alerts-ecr-exporter",
       "prometheus-operator-alertmanager.rules",
       "prometheus-operator-custom-alerts-node.rules",
       "prometheus-operator-custom-kubernetes-apps.rules",
@@ -26,4 +25,15 @@ describe "Prometheus Rules" do
     ]
     expect(names).to include(*expected)
   end
+
+  specify "in production", cluster: "live-1" do
+    names = get_prometheus_rules.map { |set| set.dig("metadata", "name") }.sort
+
+    expected = [
+      "prometheus-custom-alerts-ecr-exporter",
+    ]
+    expect(names).to include(*expected)
+  end
+
+
 end


### PR DESCRIPTION
This PR ensure some prometheus rules are only expected when testing against live-1.