### PR TITLE
Move Fluentd PrometheusRule into Helm chart

### DIFF
--- a/helm-charts/fluentd-es/templates/prometheusrule.yaml
+++ b/helm-charts/fluentd-es/templates/prometheusrule.yaml
@@ -7,7 +7,7 @@ metadata:
   k8s-app: fluentd-es
   version: {{ .Values.image.tag }}
   app: {{ .Release.Name }}
-  chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+  chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
   heritage: {{ .Release.Service }}
   release: {{ .Release.Name }}
 spec:

--- a/helm-charts/fluentd-es/templates/prometheusrule.yaml
+++ b/helm-charts/fluentd-es/templates/prometheusrule.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: fluentd-es
+  namespace: logging
+  k8s-app: fluentd-es
+  version: {{ .Values.image.tag }}
+  app: {{ .Release.Name }}
+  chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+  heritage: {{ .Release.Service }}
+  release: {{ .Release.Name }}
+spec:
+  groups:
+  - name: fluentd
+    rules:
+    - alert: FluentdBufferFull
+      expr: fluentd_output_status_buffer_total_bytes > 256 * 1024 * 1024
+      for: 2m
+      labels:
+        severity: critical
+      annotations:
+        message: The Fluentd buffer (defined by the chunk_limit_size and queue_limit_length values in helm-charts/fluentd-es/config/output.conf) is filling up. This could indicate that Fluentd is having issues writing to the ElasticSearch cluster or it is collecting logs quicker than it can write.
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/cloud-platform-components/README.md


### PR DESCRIPTION
This PR adds a `prometheusrule.yaml` file into the Fluentd helm chart.

This resource is currently defined in the environment repo, under the logging namespace.
Once this is merged in, this resource can will be removed.