### PR TITLE
Add dependency on prometheus operator from fluentd

### DIFF
--- a/terraform/cloud-platform-components/fluentd.tf
+++ b/terraform/cloud-platform-components/fluentd.tf
@@ -47,6 +47,7 @@ resource "helm_release" "fluentd_es" {
 
   depends_on = [
     kubernetes_namespace.logging,
+    helm_release.prometheus_operator,
     null_resource.deploy,
     null_resource.priority_classes,
   ]


### PR DESCRIPTION
When building a cluster, I got this error:

    Error: rpc error: code = Unknown desc = validation failed: unable to recognize "": no matches for kind "PrometheusRule" in version "monitoring.coreos.com/v1"

      on fluentd.tf line 20, in resource "helm_release" "fluentd_es":
      20: resource "helm_release" "fluentd_es" {

    2020-01-02 09:50:46 Cluster components failed to install. Aborting.

I think this is because fluentd needs the PrometheusRule CRD, and
it wasn't there when it tried to install.

After adding this line, I tried another fresh cluster build, and it
worked fine. That's not definitive proof that this fix is required, but
it's a good sign, and does confirm that, at worst, this fix does no
harm.