### PR TITLE
Deploy a docker registry as a pull-through cache

### DIFF
--- a/smoke-tests/spec/docker_registry_cache_spec.rb
+++ b/smoke-tests/spec/docker_registry_cache_spec.rb
@@ -1,0 +1,75 @@
+require "spec_helper"
+
+describe "docker-registry-cache" do
+  let(:namespace) { "docker-registry-cache" }
+
+  context "pod" do
+    let(:pods) { get_running_pods(namespace) }
+    let(:pod) { pods.first }
+
+    specify "one pod running" do
+      expect(pods.length).to eq(1)
+    end
+
+    specify "running the cache image" do
+      image = pod.dig("spec", "containers").first.fetch("image")
+      expect(image).to match("ministryofjustice.docker-registry-cache")
+    end
+
+    # Docker on the worker nodes should hit the docker-registry
+    # instance in the cluster whenever a container is launched.
+    # To test this, we check to see if any log output is generated
+    # when a container is launched. This is a bit indirect, but
+    # it works.
+    it "logs output when a container is launched" do
+      pod_name = pod.dig("metadata", "name")
+
+      before_lines = get_pod_logs(namespace, pod_name).split("\n")
+      execute("kubectl run --generator=run-pod/v1 output-date --image alpine date > /dev/null")
+
+      sleep 1
+
+      after_lines = get_pod_logs(namespace, pod_name).split("\n")
+      execute("kubectl delete pod output-date > /dev/null")
+
+      # Test that there were more lines in the log after the
+      # container was launched.
+      expect((after_lines - before_lines).count).to be > 0
+    end
+
+  end
+
+  context "ingress" do
+    let(:ingresses) { get_ingresses(namespace) }
+    let(:ingress) { ingresses.first }
+
+    specify "one ingress" do
+      expect(ingresses.length).to eq(1)
+    end
+
+    specify "ingress hostname" do
+      host = ingress.dig("spec", "rules").first.dig("host")
+      expect(host).to eq("docker-registry-cache.apps.#{current_cluster}")
+    end
+
+    # This merely tests that the annotation is in place, not that it is doing
+    # what it's supposed to do (return a 403 to any requests from outside the
+    # cluster).
+    # We can test the whitelist by executing this:
+    #
+    #     curl -I https://docker-registry-cache.apps.david-test7.cloud-platform.service.justice.gov.uk/v2/
+    #
+    # From inside the cluster, you get a 200, from outside a 403. But, when
+    # running in the pipeline, these tests run from inside the cluster, so
+    # we can't have a test for this.
+    specify "whitelist annotation" do
+      whitelist = ingress.dig("metadata", "annotations", "nginx.ingress.kubernetes.io/whitelist-source-range")
+      cidr_ranges = whitelist.split(",")
+      expect(cidr_ranges.length).to eq(3)
+      cidr_ranges.each do |cidr|
+        expect(cidr).to match(%r[^\d+\.\d+\.\d+\.\d+/32$])  # e.g. 35.177.183.191/32
+      end
+    end
+  end
+
+end

--- a/smoke-tests/spec/docker_registry_cache_spec.rb
+++ b/smoke-tests/spec/docker_registry_cache_spec.rb
@@ -36,7 +36,6 @@ describe "docker-registry-cache" do
       # container was launched.
       expect((after_lines - before_lines).count).to be > 0
     end
-
   end
 
   context "ingress" do
@@ -67,9 +66,8 @@ describe "docker-registry-cache" do
       cidr_ranges = whitelist.split(",")
       expect(cidr_ranges.length).to eq(3)
       cidr_ranges.each do |cidr|
-        expect(cidr).to match(%r[^\d+\.\d+\.\d+\.\d+/32$])  # e.g. 35.177.183.191/32
+        expect(cidr).to match(%r{^\d+\.\d+\.\d+\.\d+/32$}) # e.g. 35.177.183.191/32
       end
     end
   end
-
 end

--- a/smoke-tests/spec/kubernetes_helper.rb
+++ b/smoke-tests/spec/kubernetes_helper.rb
@@ -162,6 +162,10 @@ def filter_by_role(nodes, role)
   nodes.filter { |node| node.dig("metadata", "labels", "kubernetes.io/role") == role }
 end
 
+def get_ingresses(namespace)
+  kubectl_items "get ingresses -n #{namespace}"
+end
+
 def get_nodes
   kubectl_items "get nodes"
 end

--- a/terraform/cloud-platform-components/docker-registry-cache.tf
+++ b/terraform/cloud-platform-components/docker-registry-cache.tf
@@ -29,6 +29,16 @@ resource "null_resource" "docker-registry-cache-namespace-config" {
   provisioner "local-exec" {
     command = "kubectl apply -n docker-registry-cache -f ${path.module}/templates/docker-registry-cache/namespace.yaml"
   }
+
+  provisioner "local-exec" {
+    when = destroy
+    command = "exit 0"
+  }
+
+  triggers = {
+    namespace = filesha1("${path.module}/templates/docker-registry-cache/namespace.yaml")
+  }
+
   depends_on = [kubernetes_namespace.docker_registry_cache]
 }
 

--- a/terraform/cloud-platform-components/docker-registry-cache.tf
+++ b/terraform/cloud-platform-components/docker-registry-cache.tf
@@ -22,6 +22,7 @@ data "template_file" "docker_registry_cache_template" {
   template = file("./templates/docker-registry-cache/docker-registry-cache.yaml.tpl")
   vars = {
     cluster_name = terraform.workspace
+    nat_gateway_ips = "${data.terraform_remote_state.cluster.outputs.nat_gateway_ips}"
   }
 }
 

--- a/terraform/cloud-platform-components/docker-registry-cache.tf
+++ b/terraform/cloud-platform-components/docker-registry-cache.tf
@@ -1,0 +1,59 @@
+resource "kubernetes_namespace" "docker_registry_cache" {
+  metadata {
+    name = "docker-registry-cache"
+
+    labels = {
+      "name"                                           = "docker-registry-cache"
+      "component"                                      = "docker-registry"
+      "cloud-platform.justice.gov.uk/environment-name" = "production"
+      "cloud-platform.justice.gov.uk/is-production"    = "true"
+    }
+
+    annotations = {
+      "cloud-platform.justice.gov.uk/application"   = "docker-registry-cache"
+      "cloud-platform.justice.gov.uk/business-unit" = "cloud-platform"
+      "cloud-platform.justice.gov.uk/owner"         = "Cloud Platform: platforms@digital.justice.gov.uk"
+      "cloud-platform.justice.gov.uk/source-code"   = "https://github.com/ministryofjustice/cloud-platform-docker-registry-cache"
+    }
+  }
+}
+
+data "template_file" "docker_registry_cache_template" {
+  template = file("./templates/docker-registry-cache/docker-registry-cache.yaml.tpl")
+  vars = {
+    cluster_name = terraform.workspace
+  }
+}
+
+resource "null_resource" "docker-registry-cache-namespace-config" {
+  provisioner "local-exec" {
+    command = "kubectl apply -n docker-registry-cache -f ${path.module}/templates/docker-registry-cache/namespace.yaml"
+  }
+  depends_on = [kubernetes_namespace.docker_registry_cache]
+}
+
+resource "null_resource" "docker-registry-cache" {
+  provisioner "local-exec" {
+    command = <<EOS
+kubectl apply -n docker-registry-cache -f - <<EOF
+${data.template_file.docker_registry_cache_template.rendered}
+EOF
+EOS
+  }
+
+  # Everything in the namespace will be destroyed when the namespace is deleted.
+  # We need the `exit 0` here so that terraform thinks it has successfully
+  # destroyed the resource, when it applies changes (by destroying then applying)
+  provisioner "local-exec" {
+    when = destroy
+    command = "exit 0"
+  }
+
+  triggers = {
+    contents = filesha1("${path.module}/templates/docker-registry-cache/docker-registry-cache.yaml.tpl")
+  }
+
+  depends_on = [kubernetes_namespace.docker_registry_cache]
+}
+
+

--- a/terraform/cloud-platform-components/templates/docker-registry-cache/docker-registry-cache.yaml.tpl
+++ b/terraform/cloud-platform-components/templates/docker-registry-cache/docker-registry-cache.yaml.tpl
@@ -46,7 +46,7 @@ metadata:
   name: docker-registry-cache-ingress
   namespace: docker-registry-cache
   annotations:
-    nginx.ingress.kubernetes.io/whitelist-source-range: "3.8.0.0/16"
+    nginx.ingress.kubernetes.io/whitelist-source-range: "${[nat_gateway_ips]}"
 spec:
   tls:
   - hosts:

--- a/terraform/cloud-platform-components/templates/docker-registry-cache/docker-registry-cache.yaml.tpl
+++ b/terraform/cloud-platform-components/templates/docker-registry-cache/docker-registry-cache.yaml.tpl
@@ -1,0 +1,87 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: docker-registry-cache
+  namespace: docker-registry-cache
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: docker-registry-cache
+    spec:
+      containers:
+      - name: registry
+        image: ministryofjustice/docker-registry-cache:1.4
+        ports:
+        - containerPort: 5000
+        livenessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - /usr/local/bin/disk-usage-high
+          initialDelaySeconds: 60
+          periodSeconds: 1800
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: docker-registry-cache-service
+  namespace: docker-registry-cache
+  labels:
+    app: docker-registry-cache
+spec:
+  ports:
+  - port: 5000
+    name: http
+    targetPort: 5000
+  selector:
+    app: docker-registry-cache
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: docker-registry-cache-ingress
+  namespace: docker-registry-cache
+spec:
+  tls:
+  - hosts:
+    - docker-registry-cache.apps.${cluster_name}.cloud-platform.service.justice.gov.uk
+  rules:
+  - host: docker-registry-cache.apps.${cluster_name}.cloud-platform.service.justice.gov.uk
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: docker-registry-cache-service
+          servicePort: 5000
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default
+  namespace: docker-registry-cache
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ingress-controllers
+  namespace: docker-registry-cache
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: ingress-controllers

--- a/terraform/cloud-platform-components/templates/docker-registry-cache/docker-registry-cache.yaml.tpl
+++ b/terraform/cloud-platform-components/templates/docker-registry-cache/docker-registry-cache.yaml.tpl
@@ -46,7 +46,7 @@ metadata:
   name: docker-registry-cache-ingress
   namespace: docker-registry-cache
   annotations:
-    nginx.ingress.kubernetes.io/whitelist-source-range: "${[nat_gateway_ips]}"
+    nginx.ingress.kubernetes.io/whitelist-source-range: ${join(",", [for ip in nat_gateway_ips : "${ip}/32"])}
 spec:
   tls:
   - hosts:

--- a/terraform/cloud-platform-components/templates/docker-registry-cache/docker-registry-cache.yaml.tpl
+++ b/terraform/cloud-platform-components/templates/docker-registry-cache/docker-registry-cache.yaml.tpl
@@ -45,6 +45,8 @@ kind: Ingress
 metadata:
   name: docker-registry-cache-ingress
   namespace: docker-registry-cache
+  annotations:
+    nginx.ingress.kubernetes.io/whitelist-source-range: "3.8.0.0/16"
 spec:
   tls:
   - hosts:

--- a/terraform/cloud-platform-components/templates/docker-registry-cache/namespace.yaml
+++ b/terraform/cloud-platform-components/templates/docker-registry-cache/namespace.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: namespace-quota
+  namespace: docker-registry-cache
+spec:
+  hard:
+    pods: "50"
+---
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: limitrange
+  namespace: docker-registry-cache
+spec:
+  limits:
+  - default:
+      cpu: 1000m
+      memory: 1000Mi
+    defaultRequest:
+      cpu: 10m
+      memory: 100Mi
+    type: Container
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: docker-registry-cache-admin
+  namespace: docker-registry-cache
+subjects:
+  - kind: Group
+    name: "github:webops"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/terraform/cloud-platform/outputs.tf
+++ b/terraform/cloud-platform/outputs.tf
@@ -50,6 +50,10 @@ output "instance_key_name" {
   value = aws_key_pair.cluster.key_name
 }
 
+output "nat_gateway_ips" {
+  value = module.cluster_vpc.nat_public_ips
+}
+
 output "oidc_issuer_url" {
   value = local.oidc_issuer_url
 }

--- a/terraform/cloud-platform/templates/kops.yaml.tpl
+++ b/terraform/cloud-platform/templates/kops.yaml.tpl
@@ -8,6 +8,10 @@ metadata:
   creationTimestamp: null
   name: ${cluster_domain_name}
 spec:
+  docker:
+    registryMirrors:
+    # The docker-registry-cache is defined in terraform/cloud-platform-components/docker-registry-cache.tf
+    - https://docker-registry-cache.apps.${cluster_domain_name}
   fileAssets:
   - name: kubernetes-audit
     path: /srv/kubernetes/audit.yaml


### PR DESCRIPTION
closes https://github.com/ministryofjustice/cloud-platform/issues/1443

This PR deploys an instance of docker registry into the cluster, configured as
a pull-through cache (https://docs.docker.com/registry/recipes/mirror/).

To do this, we create a `docker-registry-cache` namespace, with a deployment
running a single replica of the registry. A health check is used to limit the
amount of disk space the cache consumes. Once the amount of disk space used in
the container exceeds a threshold, the health check will fail and the pod will
be terminated and replaced.

The worker nodes of the cluster are configured to use the registry mirror by
specifying a `registryMirrors` entry pointing to the ingress' public URL.  If
the registry is not available, the dockerd instance on the worker nodes will
simply fallback to fetching from docker hub directly, so there is no impact on
the cluster if the registry fails, and no dependency issue installing
components into the cluster before the registry is active.

The `nginx.ingress.kubernetes.io/whitelist-source-range` ingress annotation is
used to restrict access to the registry, so that it only serves requests which
originate from within the cluster VPC. To do this, we add the `nat_gateway_ips`
as an output when building the cluster VPC, and interpolate those IP numbers as
comma-separated CIDR ranges ("aa.bb.cc.dd/32") in the annotation.

NB: The split-components branch will need to be updated to output the IPs, and
to interpolate them correctly into the docker-registry-cache template.

Finally, this PR includes some integration tests to confirm that the cache is
running and correctly configured.

### Deploying

Once this PR is merged, we will need to do a `kops replace` and a `kops update`
as per [this runbook](https://runbooks.cloud-platform.service.justice.gov.uk/running-kops-update-rollingupdate.html)

It will not be necessary to do a `kops rolling-update`, since the node recycler
will eventually replace all the worker nodes with nodes configured to use the
cache, although we might want to accelerate this process to get the cluster
into a stable state as quickly as possible.