### PR TITLE
Commit changes to kops config after tf apply

### DIFF
--- a/kops/live-1.yaml
+++ b/kops/live-1.yaml
@@ -8,6 +8,10 @@ metadata:
   creationTimestamp: null
   name: live-1.cloud-platform.service.justice.gov.uk
 spec:
+  docker:
+    registryMirrors:
+    # The docker-registry-cache is defined in terraform/cloud-platform-components/docker-registry-cache.tf
+    - https://docker-registry-cache.apps.live-1.cloud-platform.service.justice.gov.uk
   fileAssets:
   - name: kubernetes-audit
     path: /srv/kubernetes/audit.yaml


### PR DESCRIPTION
The latest terraform code adds
`spec.docker.registryMirrors` to the node config.

This commits those changes to the live-1 kops
config file.