### PR TITLE
Increase wait time for cache log output

### DIFF
--- a/smoke-tests/spec/docker_registry_cache_spec.rb
+++ b/smoke-tests/spec/docker_registry_cache_spec.rb
@@ -27,7 +27,7 @@ describe "docker-registry-cache" do
       before_lines = get_pod_logs(namespace, pod_name).split("\n")
       execute("kubectl run --generator=run-pod/v1 output-date --image alpine date > /dev/null")
 
-      sleep 1
+      sleep 5
 
       after_lines = get_pod_logs(namespace, pod_name).split("\n")
       execute("kubectl delete pod output-date > /dev/null")


### PR DESCRIPTION
The test which confirms that the docker registry cache is actually
being used by the cluster worker nodes is failing intermittently
on live-1.

This change increases the sleep delay between pulling an image and
checking that the cache logged some output from 1 to 5 seconds, to
try and make this test more reliable.