### PR TITLE
Components fix and network tags using workspace name as cluster name

### DIFF
--- a/terraform/cloud-platform-components/docker-registry-cache.tf
+++ b/terraform/cloud-platform-components/docker-registry-cache.tf
@@ -56,7 +56,7 @@ kubectl apply -n docker-registry-cache -f - <<EOF
 ${
     templatefile("./templates/docker-registry-cache/docker-registry-cache.yaml.tpl", {
       cluster_name    = terraform.workspace,
-      nat_gateway_ips = data.terraform_remote_state.cluster.outputs.nat_gateway_ips,
+      nat_gateway_ips = data.terraform_remote_state.network.outputs.nat_gateway_ips,
     })
   }
 EOF

--- a/terraform/cloud-platform-components/main.tf
+++ b/terraform/cloud-platform-components/main.tf
@@ -32,6 +32,17 @@ data "terraform_remote_state" "cluster" {
   }
 }
 
+data "terraform_remote_state" "network" {
+  backend = "s3"
+
+  config = {
+    bucket  = "cloud-platform-terraform-state"
+    region  = "eu-west-1"
+    key     = "cloud-platform-network/${terraform.workspace}/terraform.tfstate"
+    profile = "moj-cp"
+  }
+}
+
 data "terraform_remote_state" "global" {
   backend = "s3"
 

--- a/terraform/cloud-platform-network/main.tf
+++ b/terraform/cloud-platform-network/main.tf
@@ -46,15 +46,15 @@ module "vpc" {
   enable_dns_hostnames = true
 
   public_subnet_tags = {
-    SubnetType                                                           = "Utility"
-    "kubernetes.io/cluster/live-1.cloud-platform.service.justice.gov.uk" = "shared"
-    "kubernetes.io/role/elb"                                             = "1"
+    SubnetType                                                                           = "Utility"
+    "kubernetes.io/cluster/${terraform.workspace}.cloud-platform.service.justice.gov.uk" = "shared"
+    "kubernetes.io/role/elb"                                                             = "1"
   }
 
   private_subnet_tags = {
-    SubnetType                                                           = "Private"
-    "kubernetes.io/cluster/live-1.cloud-platform.service.justice.gov.uk" = "shared"
-    "kubernetes.io/role/internal-elb"                                    = "1"
+    SubnetType                                                                           = "Private"
+    "kubernetes.io/cluster/${terraform.workspace}.cloud-platform.service.justice.gov.uk" = "shared"
+    "kubernetes.io/role/internal-elb"                                                    = "1"
   }
 
   tags = {


### PR DESCRIPTION

- Components: New data resource pointing to networking terraform remote state, it allows docker registry cache to get nat_ips output
- Network folder have tags based on workspace
