### PR TITLE
Increase the delay for cache logging test

### DIFF
--- a/smoke-tests/spec/docker_registry_cache_spec.rb
+++ b/smoke-tests/spec/docker_registry_cache_spec.rb
@@ -27,7 +27,7 @@ describe "docker-registry-cache" do
       before_lines = get_pod_logs(namespace, pod_name).split("\n")
       execute("kubectl run --generator=run-pod/v1 output-date --image alpine date > /dev/null")
 
-      sleep 5
+      sleep 10
 
       after_lines = get_pod_logs(namespace, pod_name).split("\n")
       execute("kubectl delete pod output-date > /dev/null")


### PR DESCRIPTION
related to #525

Increasing the delay from 1s to 5s in #525 improved the reliability
of the test, but it's still failing occasionally. This change bumps
the sleep delay from 5s to 10s to try and get the test passing
reliably.