### PR TITLE
Update cluster build wrt. bundler

### DIFF
--- a/create-cluster.rb
+++ b/create-cluster.rb
@@ -244,7 +244,15 @@ end
 def run_integration_tests(cluster_name)
   dir = "smoke-tests/"
   output = "./#{cluster_name}-rspec.txt"
-  run_and_output "cd #{dir}; bundle install; rspec --tag ~cluster:live-1 --format progress --format documentation --out #{output}"
+
+  cmd = [
+    "cd #{dir}",
+    "bundle binstubs bundler --force --path /usr/local/bin",
+    "bundle binstubs rspec-core --path /usr/local/bin",
+    "rspec --tag ~cluster:live-1 --format progress --format documentation --out #{output}",
+  ].join("; ")
+
+  run_and_output(cmd)
 end
 
 def parse_options


### PR DESCRIPTION
The latest version of bundler, which is installed
on the fly during the cluster build process, works
differently wrt. the executables provided by gems
(e.g. the `rspec` command provided by the `rspec-
core` gem).

This change ensures that the integration tests run
correctly at the end of the cluster build script.