### PR TITLE
Setting clusters within the VPC as terraform variables

### DIFF
--- a/terraform/cloud-platform-network/main.tf
+++ b/terraform/cloud-platform-network/main.tf
@@ -26,6 +26,13 @@ provider "aws" {
 locals {
   vpc_name             = terraform.workspace
   vpc_base_domain_name = "${local.vpc_name}.cloud-platform.service.justice.gov.uk"
+  cluster_tags = {
+    for name in var.cluster_names :
+    "kubernetes.io/cluster/${name}" => "shared"
+  }
+  vpc_tags = merge({
+    "kubernetes.io/cluster/${local.vpc_name}" = "shared"
+  }, local.cluster_tags)
 }
 
 #######
@@ -45,21 +52,21 @@ module "vpc" {
   enable_vpn_gateway   = false
   enable_dns_hostnames = true
 
-  public_subnet_tags = {
-    SubnetType                                                                           = "Utility"
-    "kubernetes.io/cluster/${terraform.workspace}.cloud-platform.service.justice.gov.uk" = "shared"
-    "kubernetes.io/role/elb"                                                             = "1"
-  }
+  public_subnet_tags = merge({
+    SubnetType               = "Utility"
+    "kubernetes.io/role/elb" = "1"
+  }, local.cluster_tags)
 
-  private_subnet_tags = {
-    SubnetType                                                                           = "Private"
-    "kubernetes.io/cluster/${terraform.workspace}.cloud-platform.service.justice.gov.uk" = "shared"
-    "kubernetes.io/role/internal-elb"                                                    = "1"
-  }
+  private_subnet_tags = merge({
+    SubnetType                        = "Private"
+    "kubernetes.io/role/internal-elb" = "1"
+  }, local.cluster_tags)
+
+  vpc_tags = local.vpc_tags
 
   tags = {
     Terraform = "true"
-    Cluster   = "live-1"
-    Domain    = "live-1.cloud-platform.service.justice.gov.uk"
+    Cluster   = local.vpc_name
+    Domain    = local.vpc_base_domain_name 
   }
 }

--- a/terraform/cloud-platform-network/main.tf
+++ b/terraform/cloud-platform-network/main.tf
@@ -67,6 +67,6 @@ module "vpc" {
   tags = {
     Terraform = "true"
     Cluster   = local.vpc_name
-    Domain    = local.vpc_base_domain_name 
+    Domain    = local.vpc_base_domain_name
   }
 }

--- a/terraform/cloud-platform-network/variables.tf
+++ b/terraform/cloud-platform-network/variables.tf
@@ -30,3 +30,9 @@ variable "worker_node_machine_type" {
   description = "The AWS EC2 instance types to use for worker nodes"
   default     = "r5.2xlarge"
 }
+
+variable "cluster_names" {
+  description = "A list of every Kubernetes cluster present in the VPC"
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
When new clusters are deployed inside a VPC, AWS creates some tags inside all subnets the clusters are going to use. 

The new tags created are not going to be inside the terraform code because they were not initially. there In order to support a consistent state in the terraform plan/apply the `module.vpc` has to support tags as terraform variables. 