### PR TITLE
Use timestamp in cert. manager test namespace name

### DIFF
--- a/smoke-tests/spec/cert_manager_spec.rb
+++ b/smoke-tests/spec/cert_manager_spec.rb
@@ -35,46 +35,45 @@ describe "cert-manager" do
 end
 
 def validate_certificate(host)
-  cmd = %[echo | openssl s_client -showcerts -servername #{host} -connect #{host}:443 2>/dev/null | openssl x509 -inform pem -noout -text | grep DNS]
+  cmd = %(echo | openssl s_client -showcerts -servername #{host} -connect #{host}:443 2>/dev/null | openssl x509 -inform pem -noout -text | grep DNS)
 
   `#{cmd} 2>&1`
 end
 
 def create_certificate(namespace, host)
-
   json = <<~EOF
-  {
-    "apiVersion": "certmanager.k8s.io/v1alpha1",
-    "kind": "Certificate",
-    "metadata": {
-      "name": "cert-manager-integration-test",
-      "namespace": "#{namespace}"
-    },
-    "spec": {
-      "acme": {
-        "config": [
-          {
-            "dns01": {
-              "provider": "route53-cloud-platform"
-            },
-            "domains": [
-              "#{host}"
-            ]
-          }
-        ]
+    {
+      "apiVersion": "certmanager.k8s.io/v1alpha1",
+      "kind": "Certificate",
+      "metadata": {
+        "name": "cert-manager-integration-test",
+        "namespace": "#{namespace}"
       },
-      "commonName": "#{host}",
-      "issuerRef": {
-        "kind": "ClusterIssuer",
-        "name": "letsencrypt-staging"
-      },
-      "secretName": "hello-world-ssl"
+      "spec": {
+        "acme": {
+          "config": [
+            {
+              "dns01": {
+                "provider": "route53-cloud-platform"
+              },
+              "domains": [
+                "#{host}"
+              ]
+            }
+          ]
+        },
+        "commonName": "#{host}",
+        "issuerRef": {
+          "kind": "ClusterIssuer",
+          "name": "letsencrypt-staging"
+        },
+        "secretName": "hello-world-ssl"
+      }
     }
-  }
   EOF
 
   jsn = JSON.parse(json).to_json
 
-  cmd = %[echo '#{jsn}' | kubectl -n #{namespace} apply -f -]
+  cmd = %(echo '#{jsn}' | kubectl -n #{namespace} apply -f -)
   `#{cmd}`
 end

--- a/smoke-tests/spec/cert_manager_spec.rb
+++ b/smoke-tests/spec/cert_manager_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe "cert-manager" do
-  let(:namespace) { "cert-manager-test-#{random_string}" }
+  let(:namespace) { "cert-manager-test-#{readable_timestamp}" }
 
   before do
     create_namespace(namespace)
@@ -32,7 +32,7 @@ describe "cert-manager" do
       expect(result).to match(/#{host}/)
     end
   end
-end 
+end
 
 def validate_certificate(host)
   cmd = %[echo | openssl s_client -showcerts -servername #{host} -connect #{host}:443 2>/dev/null | openssl x509 -inform pem -noout -text | grep DNS]


### PR DESCRIPTION
Changing random_string to readable_timestamp means we will be
able to easily determine the age of a test namespace, whenever any
get leftover in the cluster.