### PR TITLE
Add AlertManager slack integration for notification/information type events

### DIFF
--- a/terraform/cloud-platform-components/prometheus.tf
+++ b/terraform/cloud-platform-components/prometheus.tf
@@ -98,18 +98,12 @@ data "template_file" "alertmanager_receivers" {
     send_resolved: False
     title: '{{ template "slack.cp.title" . }}'
     text: '{{ template "slack.cp.text" . }}'
-    color: '{{ if eq .Status "firing" }}good{{ else }}good{{ end }}'
+    color: 'good'
     footer: ${local.alertmanager_ingress}
     actions:
     - type: button
-      text: 'Runbook :blue_book:'
-      url: '{{ (index .Alerts 0).Annotations.runbook_url }}'
-    - type: button
       text: 'Query :mag:'
       url: '{{ (index .Alerts 0).GeneratorURL }}'
-    - type: button
-      text: 'Silence :no_bell:'
-      url: '{{ template "__alert_silence_link" . }}'
 EOS
 
 

--- a/terraform/cloud-platform-components/prometheus.tf
+++ b/terraform/cloud-platform-components/prometheus.tf
@@ -101,6 +101,7 @@ data "template_file" "alertmanager_receivers" {
     color: '{{ if eq .Status "firing" }}good{{ else }}good{{ end }}'
     footer: ${local.alertmanager_ingress}
     actions:
+    - type: button
       text: 'Runbook :blue_book:'
       url: '{{ (index .Alerts 0).Annotations.runbook_url }}'
     - type: button

--- a/terraform/cloud-platform-components/templates/prometheus-operator.yaml.tpl
+++ b/terraform/cloud-platform-components/templates/prometheus-operator.yaml.tpl
@@ -185,6 +185,8 @@ alertmanager:
           :warning:
           {{- else if eq .CommonLabels.severity "info" -}}
           :information_source:
+          {{- else if eq .CommonLabels.status_icon "information" -}}
+          :information_source:
           {{- else -}}
           :question:
           {{- end }}


### PR DESCRIPTION
Related to https://github.com/ministryofjustice/cloud-platform/issues/1489

- add AlertManager route and receiver for notifications. 
- add label `status_icon` for prometheus rules to change the message icon to information type.
