### PR TITLE
Add a 1-second delay to all calls, in pipeline

### DIFF
--- a/smoke-tests/spec/cert_manager_spec.rb
+++ b/smoke-tests/spec/cert_manager_spec.rb
@@ -75,5 +75,5 @@ def create_certificate(namespace, host)
   jsn = JSON.parse(json).to_json
 
   cmd = %(echo '#{jsn}' | kubectl -n #{namespace} apply -f -)
-  `#{cmd}`
+  execute(cmd)
 end

--- a/smoke-tests/spec/external_dns_helper.rb
+++ b/smoke-tests/spec/external_dns_helper.rb
@@ -11,13 +11,14 @@ end
 # delete ingress if namespace and ingress exist
 def delete_ingress(namespace, ingress_name)
   if namespace_exists?(namespace) && object_exists?(namespace, "ingress", ingress_name)
-    `kubectl delete ingress #{ingress_name} -n #{namespace}`
+    execute("kubectl delete ingress #{ingress_name} -n #{namespace}")
   end
 end
 
 # Returns an ingress endpoint (ELB enpoint)
 def get_ingress_endpoint(namespace, ingress_name)
-  `kubectl get ingress #{ingress_name} -n #{namespace} -o json -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'`
+  stdout, _, _ = execute("kubectl get ingress #{ingress_name} -n #{namespace} -o json -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'")
+  stdout
 end
 
 # Dedicated to A record created by External DNS

--- a/smoke-tests/spec/kiam_helper.rb
+++ b/smoke-tests/spec/kiam_helper.rb
@@ -197,8 +197,9 @@ def try_to_assume_role(args)
   role_arn = args.fetch(:role_arn)
   pod = args.fetch(:pod)
 
-  cmd = %(kubectl exec -n #{namespace} #{pod} -- aws sts assume-role --role-arn "#{role_arn}" --role-session-name dummy)
-  `#{cmd} 2>&1`
+  cmd = %(kubectl exec -n #{namespace} #{pod} -- aws sts assume-role --role-arn "#{role_arn}" --role-session-name dummy 2>&1)
+  stdout, _, _ = execute(cmd)
+  stdout
 end
 
 # Deploy a container into a namespace. The container just runs 'sleep 86400'.
@@ -241,8 +242,7 @@ def create_deployment(args)
   jsn = JSON.parse(json).to_json
 
   cmd = %(echo '#{jsn}' | kubectl -n #{namespace} apply -f -)
-
-  `#{cmd}`
+  execute(cmd)
 
   pods = []
 

--- a/smoke-tests/spec/kubernetes_helper.rb
+++ b/smoke-tests/spec/kubernetes_helper.rb
@@ -70,7 +70,7 @@ end
 
 def create_job(namespace, yaml_file, args)
   job_name = args.fetch(:job_name)
-  search_url = args[:search_url]
+  search_url = args[:search_url] # This line is necessary to make 'search_url' available via 'binding'
 
   apply_template_file(namespace: namespace, file: yaml_file, binding: binding)
   wait_for_job_to_start(namespace, job_name)

--- a/smoke-tests/spec/kubernetes_helper.rb
+++ b/smoke-tests/spec/kubernetes_helper.rb
@@ -92,6 +92,13 @@ def wait_for_job_to_start(namespace, job_name)
 end
 
 def execute(cmd, can_fail: false)
+  # When running in the integration test pipeline, we often see KubeAPILatencyHigh alerts.
+  # This seems to be caused by the tests sending commands to the kubernetes API too fast.
+  # So, if we are running in the integration-test-pipeline, add a delay before we execute
+  # any commands, to avoid spamming the API.
+  # The EXECUTION_CONTEXT env. var. is set in the pipeline definition
+  # https://github.com/ministryofjustice/cloud-platform-concourse/blob/master/pipelines/live-1/main/integration-tests.yaml
+  sleep 1 if ENV["EXECUTION_CONTEXT"] == "integration-test-pipeline"
   Open3.capture3(cmd)
 end
 

--- a/smoke-tests/spec/namespace_spec.rb
+++ b/smoke-tests/spec/namespace_spec.rb
@@ -2,7 +2,8 @@ require "spec_helper"
 
 describe "namespace" do
   def can_i_get(type, team, namespace = "kube-system")
-    `kubectl auth can-i get #{type} --namespace #{namespace} --as test --as-group github:#{team} --as-group system:authenticated`.chomp
+    stdout, _, _ = execute("kubectl auth can-i get #{type} --namespace #{namespace} --as test --as-group github:#{team} --as-group system:authenticated")
+    stdout.chomp
   end
 
   let(:yes) { "yes" }


### PR DESCRIPTION
If we're running in the concourse pipeline, add a 1-second delay before
every executed command, so  that we don't flood the kubernetes API and
cause KubeAPILatencyHigh alerts