### PR TITLE
Increase call delay from 1 to 2 seconds for tests

### DIFF
--- a/smoke-tests/spec/kubernetes_helper.rb
+++ b/smoke-tests/spec/kubernetes_helper.rb
@@ -98,7 +98,7 @@ def execute(cmd, can_fail: false)
   # any commands, to avoid spamming the API.
   # The EXECUTION_CONTEXT env. var. is set in the pipeline definition
   # https://github.com/ministryofjustice/cloud-platform-concourse/blob/master/pipelines/live-1/main/integration-tests.yaml
-  sleep 1 if ENV["EXECUTION_CONTEXT"] == "integration-test-pipeline"
+  sleep 2 if ENV["EXECUTION_CONTEXT"] == "integration-test-pipeline"
   Open3.capture3(cmd)
 end
 


### PR DESCRIPTION
We're still getting KubeAPILatencyHigh alerts when running the
tests in the pipeline. So, try a higher delay, to see if that
works around the problem.