### PR TITLE
Increase call delay to 3 seconds, for tests

### DIFF
--- a/smoke-tests/spec/kubernetes_helper.rb
+++ b/smoke-tests/spec/kubernetes_helper.rb
@@ -98,7 +98,7 @@ def execute(cmd, can_fail: false)
   # any commands, to avoid spamming the API.
   # The EXECUTION_CONTEXT env. var. is set in the pipeline definition
   # https://github.com/ministryofjustice/cloud-platform-concourse/blob/master/pipelines/live-1/main/integration-tests.yaml
-  sleep 2 if ENV["EXECUTION_CONTEXT"] == "integration-test-pipeline"
+  sleep 3 if ENV["EXECUTION_CONTEXT"] == "integration-test-pipeline"
   Open3.capture3(cmd)
 end
 


### PR DESCRIPTION
With a 2 second delay, we're still getting a few KubeAPILatencyHigh
alerts.

This change increases the delay to 3 seconds, before each command
is sent. If this doesn't work, we may need a different approach
to fix the problem.