### PR TITLE
Add the AWS error message to kiam helper comment

### DIFF
--- a/smoke-tests/spec/kiam_helper.rb
+++ b/smoke-tests/spec/kiam_helper.rb
@@ -50,6 +50,7 @@ class KiamRole
   # the deleted cluster's ARN in the trust relationships gets replaced with something
   # that looks like an access key ID, and you end up with errors like this:
   #
+  #   Aws::IAM::Errors::MalformedPolicyDocument:
   #     Invalid principal in policy: "AWS":"AROA27XXXXXXXXXXJ2R57"
   #
   # This method removes the cluster ARN from the role trust relationships, so that


### PR DESCRIPTION
This comment provides a solution to a common error case, where
leftover IAM records break the setup of some KIAM tests.
This commit adds the specific type of the error, in case the user
searches for that, rather than "Invalid principal..."