### PR TITLE
Tag the tzcronjob test as live-1 only

### DIFF
--- a/smoke-tests/spec/tzcronjob_spec.rb
+++ b/smoke-tests/spec/tzcronjob_spec.rb
@@ -1,6 +1,8 @@
 require "spec_helper"
 
-describe "tzcronjobs" do
+# This test fails on test clusters, but we don't know why
+# https://github.com/ministryofjustice/cloud-platform/issues/1618
+describe "tzcronjobs", cluster: "live-1" do
   let(:namespace) { "integrationtest-tzcronjob-#{readable_timestamp}" }
   let(:job_name) { "tzcronjob-integrationtest" }
 


### PR DESCRIPTION
related to
https://github.com/ministryofjustice/cloud-platform/issues/1618

This test fails on test clusters, but passes on live-1.
We don't know why.