### PR TITLE
Log whenever the tests sleep, for the pipeline

### DIFF
--- a/smoke-tests/spec/kubernetes_helper.rb
+++ b/smoke-tests/spec/kubernetes_helper.rb
@@ -98,7 +98,10 @@ def execute(cmd, can_fail: false)
   # any commands, to avoid spamming the API.
   # The EXECUTION_CONTEXT env. var. is set in the pipeline definition
   # https://github.com/ministryofjustice/cloud-platform-concourse/blob/master/pipelines/live-1/main/integration-tests.yaml
-  sleep 3 if ENV["EXECUTION_CONTEXT"] == "integration-test-pipeline"
+  if ENV["EXECUTION_CONTEXT"] == "integration-test-pipeline"
+    puts "    running in pipeline. sleeping for 3 seconds..."
+    sleep 3
+  end
   Open3.capture3(cmd)
 end
 


### PR DESCRIPTION
We have started seeing KubeAPILatencyHigh errors again, although
they seemed to have more or less stopped after we added this delay.
They started again after we moved the integration test pipeline to
the manager cluster concourse instance.
This commit is a temporary change to 100% confirm that the sleep
delay is still happening, in the new pipeline.