### PR TITLE
Move metrics-server to kube-system

### DIFF
--- a/terraform/cloud-platform-components/metrics-server.tf
+++ b/terraform/cloud-platform-components/metrics-server.tf
@@ -1,7 +1,7 @@
 resource "helm_release" "metrics_server" {
   name      = "metrics-server"
   chart     = "stable/metrics-server"
-  namespace = "monitoring"
+  namespace = "kube-system"
   version   = "2.8.8"
 
   depends_on = [null_resource.deploy]


### PR DESCRIPTION
Move metrics server back to  kube-system from monitoring NS.

This is due to metrics-server requiring access to configmap extention-apiserver-authentication on kube-system which is not possible when restoring metrics-server using Velero. 