### PR TITLE
Revert "Log when tests sleep, for the pipeline"

### DIFF
--- a/smoke-tests/spec/kubernetes_helper.rb
+++ b/smoke-tests/spec/kubernetes_helper.rb
@@ -98,10 +98,7 @@ def execute(cmd, can_fail: false)
   # any commands, to avoid spamming the API.
   # The EXECUTION_CONTEXT env. var. is set in the pipeline definition
   # https://github.com/ministryofjustice/cloud-platform-concourse/blob/master/pipelines/live-1/main/integration-tests.yaml
-  if ENV["EXECUTION_CONTEXT"] == "integration-test-pipeline"
-    puts "    running in pipeline. sleeping for 3 seconds..."
-    sleep 3
-  end
+  sleep 3 if ENV["EXECUTION_CONTEXT"] == "integration-test-pipeline"
   Open3.capture3(cmd)
 end
 


### PR DESCRIPTION
This reverts commit 9bc7804e306d26ff31a845d7ba7a57806b17fe5d.

The sleep is definitely happening, so we don't need this extra
logging anymore.