### PR TITLE
Add concourse user to manager cluster

### DIFF
--- a/terraform/cloud-platform-eks/eks.tf
+++ b/terraform/cloud-platform-eks/eks.tf
@@ -88,7 +88,13 @@ module "eks" {
       userarn  = "arn:aws:iam::754256621582:user/VijayVeeranki"
       username = "VijayVeeranki"
       groups   = ["system:masters"]
+    },
+    {
+      userarn  = "arn:aws:iam::754256621582:user/cloud-platform/manager-concourse"
+      username = "manager-concourse"
+      groups   = ["system:masters"]
     }
+
   ]
 
   tags = {


### PR DESCRIPTION
This allows the concourse user full access over our manager cluster, which is required to create namespaces and secrets.