### PR TITLE
Skipping error page test

### DIFF
--- a/smoke-tests/spec/error_page_spec.rb
+++ b/smoke-tests/spec/error_page_spec.rb
@@ -48,7 +48,7 @@ def expect_backend_error_page(url, message, body)
                           }
 end
 
-describe "http request error responses" do
+xdescribe "http request error responses" do
   let(:unmatched_url) { "https://foobar.apps.#{current_cluster}" }
 
   context "cluster default backend" do


### PR DESCRIPTION
Skipping error page test due to causing high api latency error. Will remove test if this is confirmed and look into a int test for error pages again at a later date .