### PR TITLE
Prometheus upgrade latest

### DIFF
--- a/terraform/cloud-platform-components/prometheus.tf
+++ b/terraform/cloud-platform-components/prometheus.tf
@@ -137,8 +137,7 @@ resource "helm_release" "prometheus_operator" {
   name         = "prometheus-operator"
   chart        = "stable/prometheus-operator"
   namespace    = "monitoring"
-  version      = "7.4.0"
-  force_update = "true"
+  version      = "8.7.0"
 
   values = [templatefile("${path.module}/templates/prometheus-operator.yaml.tpl", {
     alertmanager_ingress   = local.alertmanager_ingress
@@ -163,8 +162,6 @@ resource "helm_release" "prometheus_operator" {
     command = "kubectl apply -n monitoring -f ${path.module}/resources/prometheusrule-alerts/"
   }
 
-  # Delete Prometheus leftovers
-  # Ref: https://github.com/coreos/prometheus-operator#removal
   # Delete Prometheus leftovers
   # Ref: https://github.com/coreos/prometheus-operator#removal
   provisioner "local-exec" {

--- a/terraform/cloud-platform-components/prometheus.tf
+++ b/terraform/cloud-platform-components/prometheus.tf
@@ -134,10 +134,10 @@ locals {
 }
 
 resource "helm_release" "prometheus_operator" {
-  name         = "prometheus-operator"
-  chart        = "stable/prometheus-operator"
-  namespace    = "monitoring"
-  version      = "8.7.0"
+  name      = "prometheus-operator"
+  chart     = "stable/prometheus-operator"
+  namespace = "monitoring"
+  version   = "8.7.0"
 
   values = [templatefile("${path.module}/templates/prometheus-operator.yaml.tpl", {
     alertmanager_ingress   = local.alertmanager_ingress

--- a/terraform/cloud-platform-components/templates/prometheus-operator.yaml.tpl
+++ b/terraform/cloud-platform-components/templates/prometheus-operator.yaml.tpl
@@ -215,7 +215,12 @@ kubeEtcd:
 ## Component scraping kube scheduler
 ##
 kubeScheduler:
-  enabled: true
+  enabled: false
+
+## Component scraping the kube controller manager
+##
+kubeControllerManager:
+  enabled: false
 
 ## Component scraping kube state metrics
 ##
@@ -226,6 +231,9 @@ kubeStateMetrics:
 ##
 prometheusOperator:
   enabled: true
+
+  admissionWebhooks:
+    enabled: false
 
   ## Deploy CRDs used by Prometheus Operator.
   ##
@@ -249,6 +257,50 @@ prometheus:
     ## External URL at which Prometheus will be reachable.
     ##
     externalUrl: "${ prometheus_ingress }"
+
+    ## Namespaces to be selected for PrometheusRules discovery.
+    ## If unspecified, only the same namespace as the Prometheus object is in is used.
+    ##
+    ruleNamespaceSelector:
+      any: true
+
+    ## Rules CRD selector
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/design.md
+    ## If unspecified the release `app` and `release` will be used as the label selector
+    ## to load rules
+    ##
+    ruleSelector:
+      any: true
+    ## Example which select all prometheusrules resources
+    ## with label "prometheus" with values any of "example-rules" or "example-rules-2"
+    # ruleSelector:
+    #   matchExpressions:
+    #     - key: prometheus
+    #       operator: In
+    #       values:
+    #         - example-rules
+    #         - example-rules-2
+    #
+    ## Example which select all prometheusrules resources with label "role" set to "example-rules"
+    # ruleSelector:
+    #   matchLabels:
+    #     role: example-rules
+
+    ## serviceMonitorSelector will limit which servicemonitors are used to create scrape
+    ## configs in Prometheus. See serviceMonitorSelectorUseHelmLabels
+    ##
+    serviceMonitorSelector:
+      any: true
+
+    # serviceMonitorSelector: {}
+    #   matchLabels:
+    #     prometheus: somelabel
+
+    ## serviceMonitorNamespaceSelector will limit namespaces from which serviceMonitors are used to create scrape
+    ## configs in Prometheus. By default all namespaces will be used
+    ##
+    serviceMonitorNamespaceSelector:
+      any: true
 
     ## How long to retain metrics
     ##


### PR DESCRIPTION
Prometheus upgrade to latest chart version 8.7.0

Updated prometheus-operator.yaml.tpl

  ->  Set admissionWebhooks to false, as this is causing error

    Internal error occurred: failed calling webhook "prometheusrulemutate.monitoring.coreos.com": Post https://prometheus-operator-operator.monitoring.svc:443/admission-prometheusrules/mutate?timeout=30s: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)

->    Set kubeControllerManager and kubeScheduler to false, as they are not available in our cluster, which is causing high priority alerts.

->    Added any: true for ruleNamespaceSelector, serviceMonitorSelector, ruleSelector, serviceMonitorNamespaceSelector, this is to get alertmanager to not look for particular labels