### PR TITLE
Remove the sleep delay when running via pipeline

### DIFF
--- a/smoke-tests/spec/kubernetes_helper.rb
+++ b/smoke-tests/spec/kubernetes_helper.rb
@@ -92,16 +92,6 @@ def wait_for_job_to_start(namespace, job_name)
 end
 
 def execute(cmd, can_fail: false)
-  # When running in the integration test pipeline, we often see KubeAPILatencyHigh alerts.
-  # This seems to be caused by the tests sending commands to the kubernetes API too fast.
-  # So, if we are running in the integration-test-pipeline, add a delay before we execute
-  # any commands, to avoid spamming the API.
-  # The EXECUTION_CONTEXT env. var. is set in the pipeline definition
-  # https://github.com/ministryofjustice/cloud-platform-concourse/blob/master/pipelines/live-1/main/integration-tests.yaml
-  if ENV["EXECUTION_CONTEXT"] == "integration-test-pipeline"
-    sleep 3
-    puts [Time.now.strftime("%Y-%m-%d %H:%M:%S"), cmd].join(" ")
-  end
   Open3.capture3(cmd)
 end
 


### PR DESCRIPTION
We have disabled the error page integration tests, because we
think they're responsible for the "KubeAPILatencyHigh" alerts we
often receive when the tests are running.
As such, this additional sleep delay should not be necessary, so
this commit removes it.
An additional commit will remove the environment variable from the
integration tests concourse pipeline.