### PR TITLE
Added kube-state-metrics custom image tag

### DIFF
--- a/terraform/cloud-platform-components/templates/prometheus-operator.yaml.tpl
+++ b/terraform/cloud-platform-components/templates/prometheus-operator.yaml.tpl
@@ -227,10 +227,19 @@ kubeControllerManager:
 kubeStateMetrics:
   enabled: true
 
+## Configuration for kube-state-metrics subchart
+##
+kube-state-metrics:
+  image:
+    tag: v1.7.0
+
 ## Manages Prometheus and Alertmanager components
 ##
 prometheusOperator:
   enabled: true
+
+  tlsProxy:
+    enabled: false
 
   admissionWebhooks:
     enabled: false


### PR DESCRIPTION
We need to keep `kube-state-metrics` in an older version because some required metrics used by us and our teams were deleted in the recent versions