### PR TITLE
Pin helm provider version to "0.10.4"

### DIFF
--- a/terraform/cloud-platform-components/main.tf
+++ b/terraform/cloud-platform-components/main.tf
@@ -17,7 +17,7 @@ provider "kubernetes" {
 }
 
 provider "helm" {
-  version     = "0.10.4"
+  version = "0.10.4"
   kubernetes {
   }
 }

--- a/terraform/cloud-platform-components/main.tf
+++ b/terraform/cloud-platform-components/main.tf
@@ -17,6 +17,7 @@ provider "kubernetes" {
 }
 
 provider "helm" {
+  version     = "0.10.4"
   kubernetes {
   }
 }


### PR DESCRIPTION
This is because latest provider version 1.0 is compatible for helm3 and we are still using helm2

https://github.com/terraform-providers/terraform-provider-helm#%EF%B8%8F-project-update-helm-3
