### PR TITLE
Add `make list-clusters` to show all clusters

### DIFF
--- a/makefile
+++ b/makefile
@@ -13,3 +13,9 @@ tools-shell:
 		-v $${HOME}/.gnupg:/root/.gnupg \
 		-w /app \
 		$(TOOLS_IMAGE) bash
+
+# For CP team-members. List all the clusters which currently exist
+list-clusters:
+	kops get clusters
+	@echo
+	aws eks list-clusters --region=eu-west-2


### PR DESCRIPTION
Now that we have both EKS and KOPS clusters, it's convenient to
have a single command that will list all of our clusters.
This command will only work for Cloud Platform team members, who
have the required AWS credentials.