### PR TITLE
Grafana cloudwatch datasource

### DIFF
--- a/terraform/cloud-platform-components/prometheus.tf
+++ b/terraform/cloud-platform-components/prometheus.tf
@@ -292,7 +292,7 @@ data "aws_iam_policy_document" "grafana_datasource" {
     resources = ["*"]
   }
   statement {
-    actions = ["sts:AssumeRole"]
+    actions   = ["sts:AssumeRole"]
     resources = [aws_iam_role.grafana_datasource.arn]
   }
 }

--- a/terraform/cloud-platform-components/prometheus.tf
+++ b/terraform/cloud-platform-components/prometheus.tf
@@ -149,6 +149,8 @@ resource "helm_release" "prometheus_operator" {
     prometheus_ingress     = local.prometheus_ingress
     random_username        = random_id.username.hex
     random_password        = random_id.password.hex
+    grafana_pod_annotation = aws_iam_role.grafana_datasource.name
+    grafana_assumerolearn  = aws_iam_role.grafana_datasource.arn
   })]
 
   # Depends on Helm being installed

--- a/terraform/cloud-platform-components/templates/prometheus-operator.yaml.tpl
+++ b/terraform/cloud-platform-components/templates/prometheus-operator.yaml.tpl
@@ -158,6 +158,10 @@ grafana:
   adminUser: "${ random_username }"
   adminPassword: "${ random_password }"
 
+  ## Pod Annotations
+  podAnnotations: 
+    iam.amazonaws.com/role: "${ grafana_pod_annotation }"
+
   ingress:
     ## If true, Prometheus Ingress will be created
     ##

--- a/terraform/cloud-platform-components/templates/prometheus-operator.yaml.tpl
+++ b/terraform/cloud-platform-components/templates/prometheus-operator.yaml.tpl
@@ -201,6 +201,20 @@ grafana:
       enabled: true
       label: grafana_datasource
 
+  ## Configure additional grafana datasources
+  ## ref: http://docs.grafana.org/administration/provisioning/#datasources
+  additionalDataSources:
+  - name: Cloudwatch
+    type: cloudwatch
+    editable: true
+    access: proxy
+    jsonData:
+      authType: arn
+      defaultRegion: eu-west-2
+      assumeRoleArn: "${ grafana_assumerolearn }"
+    orgId: 1
+    version: 1
+
 ## Component scraping coreDns. Use either this or kubeDns
 ##
 coreDns:


### PR DESCRIPTION
Added cloudwatch datasource for grafana, with auth type arn using assume role
    ref:https://grafana.com/docs/grafana/latest/features/datasources/cloudwatch/#configure-the-data-source-with-provisioning

Assume role policy for grafana datasource cloudwatch

Added minimal policy permissions
ref:https://grafana.com/docs/grafana/latest/features/datasources/cloudwatch/#iam-policies

Added grafana pod annotation for assume role

In addition, added assume role for role to fix Error: kiam-kiam is not authorized to perform: sts:AssumeRole on resource: arn:aws:iam::754256621582:role/

Open issue related to the arn authentication 
https://github.com/grafana/grafana/issues/19173