### PR TITLE
Thanos on live-1

### DIFF
--- a/terraform/cloud-platform-components/prometheus.tf
+++ b/terraform/cloud-platform-components/prometheus.tf
@@ -261,6 +261,10 @@ resource "helm_release" "alertmanager_proxy" {
   }
 }
 
+##########
+# THANOS #
+##########
+
 # This is to create a policy which allows Prometheus (thanos to be precise) to have a role to write to S3 without credentials
 data "aws_iam_policy_document" "monitoring_assume" {
   statement {
@@ -303,6 +307,105 @@ resource "aws_iam_role_policy" "monitoring" {
   name   = "route53"
   role   = aws_iam_role.monitoring.id
   policy = data.aws_iam_policy_document.monitoring.json
+}
+
+# Thanos side-car service (not deployment needed because prometheus-operator included it)
+resource "kubernetes_service" "thanos_sidecar" {
+  metadata {
+    name      = "thanos-sidecar"
+    namespace = kubernetes_namespace.monitoring.id
+    labels = {
+      app = "thanos-sidecar"
+    }
+  }
+  spec {
+    selector = {
+      app = "prometheus"
+    }
+    port {
+      name        = "grpc"
+      port        = 10901
+      target_port = "grpc"
+    }
+  }
+}
+
+# Thanos Query deployment
+resource "kubernetes_deployment" "thanos_query" {
+  metadata {
+    name = "thanos-query"
+    namespace = kubernetes_namespace.monitoring.id
+    labels = {
+      app = "thanos-query"
+    }
+  }
+
+  spec {
+    replicas = 1
+
+    selector {
+      match_labels = {
+        app = "thanos-query"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          app = "thanos-query"
+        }
+      }
+
+      spec {
+        container {
+          image = "quay.io/thanos/thanos:v0.10.1"
+          name  = "thanos-query"
+
+          args = [
+            "query",
+            "--log.level=debug",
+            "--query.replica-label=prometheus_replica",
+            "--query.replica-label=thanos_ruler_replica",
+            "--store=dnssrv+_grpc._tcp.thanos-sidecar.${kubernetes_namespace.monitoring.id}.svc.cluster.local",
+            "--store=dnssrv+_grpc._tcp.thanos-ruler.${kubernetes_namespace.monitoring.id}.svc.cluster.local"
+          ]
+
+          port {
+            name = "http"
+            container_port = 10902
+          }
+
+          port {
+            name = "grpc"
+            container_port = 10901
+          }
+
+
+        }
+      }
+    }
+  }
+}
+
+# Thanos side-car service (not deployment needed because prometheus-operator included it)
+resource "kubernetes_service" "thanos_query" {
+  metadata {
+    name      = "thanos-query"
+    namespace = kubernetes_namespace.monitoring.id
+    labels = {
+      app = "thanos-query"
+    }
+  }
+  spec {
+    selector = {
+      app = "thanos-query"
+    }
+    port {
+      name        = "http"
+      port        = 9090
+      target_port = "http"
+    }
+  }
 }
 
 

--- a/terraform/cloud-platform-components/prometheus.tf
+++ b/terraform/cloud-platform-components/prometheus.tf
@@ -149,6 +149,7 @@ resource "helm_release" "prometheus_operator" {
     prometheus_ingress     = local.prometheus_ingress
     random_username        = random_id.username.hex
     random_password        = random_id.password.hex
+    monitoring_aws_role    = aws_iam_role.monitoring.name
   })]
 
   # Depends on Helm being installed
@@ -258,3 +259,46 @@ resource "helm_release" "alertmanager_proxy" {
   }
 }
 
+# This is to create a policy which allows Prometheus (thanos to be precise) to have a role to write to S3 without credentials
+data "aws_iam_policy_document" "monitoring_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+      identifiers = [data.aws_iam_role.nodes.arn]
+    }
+  }
+}
+
+resource "aws_iam_role" "monitoring" {
+  name               = "monitoring.${data.terraform_remote_state.cluster.outputs.cluster_domain_name}"
+  assume_role_policy = data.aws_iam_policy_document.monitoring_assume.json
+}
+
+data "aws_iam_policy_document" "monitoring" {
+
+  statement {
+    actions = [
+      "s3:ListBucket",
+      "s3:GetObject",
+      "s3:DeleteObject",
+      "s3:PutObject"
+    ]
+
+    # Bucket name is hardcoded because it hasn't been created with terraform
+    # files inside this repository. Once we are happy with the test we must: 
+    # 1. Create S3 bucket from the cp-environments repo (or maybe from here?)
+    # 2. Use the output (S3 bucket name) in this policy
+    resources = [
+      "arn:aws:s3:::cloud-platform-2b5483a8020c73862c69b87f44c398b8/*",
+      "arn:aws:s3:::cloud-platform-2b5483a8020c73862c69b87f44c398b8"
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "monitoring" {
+  name   = "route53"
+  role   = aws_iam_role.monitoring.id
+  policy = data.aws_iam_policy_document.monitoring.json
+}

--- a/terraform/cloud-platform-components/prometheus.tf
+++ b/terraform/cloud-platform-components/prometheus.tf
@@ -333,7 +333,7 @@ resource "kubernetes_service" "thanos_sidecar" {
 # Thanos Query deployment
 resource "kubernetes_deployment" "thanos_query" {
   metadata {
-    name = "thanos-query"
+    name      = "thanos-query"
     namespace = kubernetes_namespace.monitoring.id
     labels = {
       app = "thanos-query"
@@ -371,12 +371,12 @@ resource "kubernetes_deployment" "thanos_query" {
           ]
 
           port {
-            name = "http"
+            name           = "http"
             container_port = 10902
           }
 
           port {
-            name = "grpc"
+            name           = "grpc"
             container_port = 10901
           }
 

--- a/terraform/cloud-platform-components/templates/prometheus-operator.yaml.tpl
+++ b/terraform/cloud-platform-components/templates/prometheus-operator.yaml.tpl
@@ -339,3 +339,11 @@ prometheus:
             requests:
               storage: 750Gi
         selector: {}
+
+    thanos: 
+      baseImage: quay.io/thanos/thanos
+      version: v0.10.1
+      objectStorageConfig:
+        key: thanos.yaml
+        name: thanos-objstore-config 
+

--- a/terraform/cloud-platform-components/templates/prometheus-operator.yaml.tpl
+++ b/terraform/cloud-platform-components/templates/prometheus-operator.yaml.tpl
@@ -327,6 +327,10 @@ prometheus:
     ##
     retention: 30d
 
+    podMetadata:
+      annotations:
+        iam.amazonaws.com/role: "${monitoring_aws_role}"
+
     ## Prometheus StorageSpec for persistent data
     ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/user-guides/storage.md
     ##


### PR DESCRIPTION
In order to store Prometheus logs in S3 buckets, we need the Thanos sidecar. Now we have the latest prometheus-operator installed on live-1 we can deploy Thanos sidecar easily.

This PR has:

- _ThanosSpec_/configuration to the Prometheus Operator Values (`values.yaml`) as well as the IAM roles for the pod (to be able to write without credentials)
- IAM roles (and policies) creation for Thanos (through KIAM)
- The Kubernetes `side-car` and `thanos query` service resource
- The Kubernetes `thanos query` deployment
