### PR TITLE
Increase docker-registry-cache test sleep delay

### DIFF
--- a/smoke-tests/spec/docker_registry_cache_spec.rb
+++ b/smoke-tests/spec/docker_registry_cache_spec.rb
@@ -27,7 +27,7 @@ describe "docker-registry-cache" do
       before_lines = get_pod_logs(namespace, pod_name).split("\n")
       execute("kubectl run --generator=run-pod/v1 output-date --image alpine date > /dev/null")
 
-      sleep 10
+      sleep 20
 
       after_lines = get_pod_logs(namespace, pod_name).split("\n")
       execute("kubectl delete pod output-date > /dev/null")


### PR DESCRIPTION
This test intermittently fails when running in the integration test
pipeline. This commit increases the sleep delay from 10 to 20
seconds, to try and make the test more consistent.