### PR TITLE
Add cross account IAM role creations

### DIFF
--- a/terraform/cloud-platform-components/main.tf
+++ b/terraform/cloud-platform-components/main.tf
@@ -17,6 +17,7 @@ provider "kubernetes" {
 }
 
 provider "helm" {
+  version = "0.10.4"
   kubernetes {
   }
 }

--- a/terraform/cross-account-IAM/iam-money-to-prisoners.tf
+++ b/terraform/cross-account-IAM/iam-money-to-prisoners.tf
@@ -3,13 +3,13 @@
 
 data "aws_iam_policy_document" "kiam-trust-chain" {
   # KIAM trust chain to allow pods to assume roles defined below
-#   statement {
-#     principals {
-#       type        = "Service"
-#       identifiers = ["ec2.amazonaws.com"]
-#     }
-#     actions = ["sts:AssumeRole"]
-#   }
+  #   statement {
+  #     principals {
+  #       type        = "Service"
+  #       identifiers = ["ec2.amazonaws.com"]
+  #     }
+  #     actions = ["sts:AssumeRole"]
+  #   }
   statement {
     principals {
       type        = "AWS"
@@ -36,7 +36,7 @@ data "aws_iam_policy_document" "api" {
     ]
   }
 }
-  
+
 
 resource "aws_iam_policy" "api" {
   name   = "money-to-prisoners-test-iam-policy-api"
@@ -49,7 +49,7 @@ resource "aws_iam_role_policy_attachment" "api" {
 
 resource "kubernetes_secret" "api_output" {
   metadata {
-    name = "api-iam-role"
+    name      = "api-iam-role"
     namespace = "money-to-prisoners-test"
   }
 

--- a/terraform/cross-account-IAM/iam-money-to-prisoners.tf
+++ b/terraform/cross-account-IAM/iam-money-to-prisoners.tf
@@ -1,0 +1,59 @@
+# This is to create IAM role for money-to-prisoners team in namespace money-to-prisoners-test
+# to allow assumeRole inside the namespace to access cross account resources.
+
+data "aws_iam_policy_document" "kiam-trust-chain" {
+  # KIAM trust chain to allow pods to assume roles defined below
+#   statement {
+#     principals {
+#       type        = "Service"
+#       identifiers = ["ec2.amazonaws.com"]
+#     }
+#     actions = ["sts:AssumeRole"]
+#   }
+  statement {
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::754256621582:role/nodes.live-1.cloud-platform.service.justice.gov.uk"]
+    }
+    actions = ["sts:AssumeRole"]
+  }
+}
+resource "aws_iam_role" "api" {
+  name               = "money-to-prisoners-test-iam-role-api"
+  description        = "IAM role for api pods in money-to-prisoners-test"
+  assume_role_policy = data.aws_iam_policy_document.kiam-trust-chain.json
+}
+data "aws_iam_policy_document" "api" {
+  # "api" policy statements
+  # allows direct access to a test-only S3 bucket in mojdsd AWS account
+  statement {
+    actions = [
+      "s3:PutObject",
+      "s3:DeleteObject",
+    ]
+    resources = [
+      "arn:aws:s3:::money-to-prisoners-testing/cp/*",
+    ]
+  }
+}
+  
+
+resource "aws_iam_policy" "api" {
+  name   = "money-to-prisoners-test-iam-policy-api"
+  policy = data.aws_iam_policy_document.api.json
+}
+resource "aws_iam_role_policy_attachment" "api" {
+  role       = aws_iam_role.api.name
+  policy_arn = aws_iam_policy.api.arn
+}
+
+resource "kubernetes_secret" "api_output" {
+  metadata {
+    name = "api-iam-role"
+    namespace = "poornima-dev"
+  }
+
+  data = {
+    api_iam_role = aws_iam_role.api.id
+  }
+}

--- a/terraform/cross-account-IAM/iam-money-to-prisoners.tf
+++ b/terraform/cross-account-IAM/iam-money-to-prisoners.tf
@@ -50,7 +50,7 @@ resource "aws_iam_role_policy_attachment" "api" {
 resource "kubernetes_secret" "api_output" {
   metadata {
     name = "api-iam-role"
-    namespace = "poornima-dev"
+    namespace = "money-to-prisoners-test"
   }
 
   data = {

--- a/terraform/cross-account-IAM/main.tf
+++ b/terraform/cross-account-IAM/main.tf
@@ -1,0 +1,38 @@
+################################
+# Provider Setup & TF Backends #
+################################
+
+terraform {
+  backend "s3" {
+    bucket               = "cloud-platform-terraform-state"
+    region               = "eu-west-1"
+    key                  = "terraform.tfstate"
+    workspace_key_prefix = "cross-platform-IAM"
+    profile              = "moj-cp"
+  }
+}
+
+provider "aws" {
+  profile = "moj-cp"
+  region  = "eu-west-2"
+}
+
+provider "kubernetes" {
+}
+
+provider "helm" {
+  version = "0.10.4"
+  kubernetes {
+  }
+}
+
+data "terraform_remote_state" "cluster" {
+  backend = "s3"
+
+  config = {
+    bucket  = "cloud-platform-terraform-state"
+    region  = "eu-west-1"
+    key     = "cloud-platform/${terraform.workspace}/terraform.tfstate"
+    profile = "moj-cp"
+  }
+}


### PR DESCRIPTION
This PR is to allow access for pods in Cloud Platform cluster to assume role to access a cross-account resources.

All files related to this are placed in infrastructure repo to ensure the code is applied when appropriate.
