### PR TITLE
Update policy so the role has permissions to perform assumeRole

### DIFF
--- a/terraform/cross-account-IAM/iam-money-to-prisoners.tf
+++ b/terraform/cross-account-IAM/iam-money-to-prisoners.tf
@@ -35,6 +35,14 @@ data "aws_iam_policy_document" "api" {
       "arn:aws:s3:::money-to-prisoners-testing/cp/*",
     ]
   }
+  statement {
+    actions = [
+      "sts:AssumeRole"
+    ]
+    resources = [
+      aws_iam_role.api.arn,
+    ]
+  }
 }
 
 


### PR DESCRIPTION
Service team wants to assumeRole from their app in their namespace and hence the role created should have a policy to allow `assumeRole` for the created role itself.
