### PR TITLE
Pin version kubernetes

### DIFF
--- a/terraform/cloud-platform-components/main.tf
+++ b/terraform/cloud-platform-components/main.tf
@@ -14,6 +14,7 @@ provider "aws" {
 }
 
 provider "kubernetes" {
+  version = "1.10.0"
 }
 
 provider "helm" {

--- a/terraform/cloud-platform-eks/components/main.tf
+++ b/terraform/cloud-platform-eks/components/main.tf
@@ -23,6 +23,7 @@ provider "kubernetes" {
 }
 
 provider "helm" {
+  version         = "0.10.4"
   service_account = "tiller"
   kubernetes {
     config_path = "../files/kubeconfig_${terraform.workspace}"

--- a/terraform/cloud-platform-eks/eks.tf
+++ b/terraform/cloud-platform-eks/eks.tf
@@ -15,7 +15,7 @@ provider "kubernetes" {
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
   token                  = data.aws_eks_cluster_auth.cluster.token
   load_config_file       = false
-  version                = "~> 1.9"
+  version                = "1.10.0"
 }
 
 module "eks" {


### PR DESCRIPTION
Pin kubernetes provider version to 1.10.0

    Error: Failed to initialize config: invalid configuration:
    no configuration has been provided
    https://github.com/terraform-providers/terraform-provider-kubernetes/issues/759

Pin helm provider version to "0.10.4"

    As latest version is not compatible for helm2