### PR TITLE
Revert "Remove sleep when running via pipeline"

### DIFF
--- a/smoke-tests/spec/kubernetes_helper.rb
+++ b/smoke-tests/spec/kubernetes_helper.rb
@@ -92,6 +92,16 @@ def wait_for_job_to_start(namespace, job_name)
 end
 
 def execute(cmd, can_fail: false)
+  # When running in the integration test pipeline, we often see KubeAPILatencyHigh alerts.
+  # This seems to be caused by the tests sending commands to the kubernetes API too fast.
+  # So, if we are running in the integration-test-pipeline, add a delay before we execute
+  # any commands, to avoid spamming the API.
+  # The EXECUTION_CONTEXT env. var. is set in the pipeline definition
+  # https://github.com/ministryofjustice/cloud-platform-concourse/blob/master/pipelines/live-1/main/integration-tests.yaml
+  if ENV["EXECUTION_CONTEXT"] == "integration-test-pipeline"
+    sleep 3
+    puts [Time.now.strftime("%Y-%m-%d %H:%M:%S"), cmd].join(" ")
+  end
   Open3.capture3(cmd)
 end
 


### PR DESCRIPTION
This reverts commit 4d0bc44c5f24d64eb7c43c9446f6cf4a9b2cc836.

It seems that the integration tests send a lot of AWS API calls,
particularly to the route53, where we have an API requests/second
limit (of 7, a global limit we can't alter).

This change reinstates the sleep delay between every command that
the tests execute, to reduce the chances of the integration tests
pushing us over that limit again.