### PR TITLE
Encrypting EKS.tf 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@ iplist.txt filter=git-crypt diff=git-crypt
 
 # The EKS kubeconfig files
 terraform/cloud-platform-eks/files/* filter=git-crypt diff=git-crypt
+terraform/cloud-platform-eks/eks.tf filter=git-crypt diff=git-crypt


### PR DESCRIPTION
In order to avoid publishing all our CP Team usernames in AWS we decided to encrypt the `EKS.tf` file.

This ticket closes [#1622](https://github.com/ministryofjustice/cloud-platform/issues/1622)
