### PR TITLE
Add eks.tf as eks-cluster.tf to fix git-crypt

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,4 +3,4 @@ iplist.txt filter=git-crypt diff=git-crypt
 
 # The EKS kubeconfig files
 terraform/cloud-platform-eks/files/* filter=git-crypt diff=git-crypt
-terraform/cloud-platform-eks/eks.tf filter=git-crypt diff=git-crypt
+terraform/cloud-platform-eks/eks-cluster.tf filter=git-crypt diff=git-crypt

--- a/terraform/cloud-platform-eks/README.md
+++ b/terraform/cloud-platform-eks/README.md
@@ -1,6 +1,6 @@
 # Cloud Platform - EKS Cluster
 
-This README describes the main infrastructure components required to deliver a production-ready EKS cluster. Terraform is used as a main tool to bootstrap the infrastructure layer and EKS clusters. This terraform code requires you already have a VPC provisioned (go to [`terraform/cloud-platform-network/` folder for more info](https://github.com/ministryofjustice/cloud-platform-infrastructure/tree/master/terraform/cloud-platform-network)). If no VPC is provided it'll look for a VPC named as your terraform workspace 
+This README describes the main infrastructure components required to deliver a production-ready EKS cluster. Terraform is used as a main tool to bootstrap the infrastructure layer and EKS clusters. This terraform code requires you already have a VPC provisioned (go to [`terraform/cloud-platform-network/` folder for more info](https://github.com/ministryofjustice/cloud-platform-infrastructure/tree/master/terraform/cloud-platform-network)). If no VPC is provided it'll look for a VPC named as your terraform workspace
 
 **IMPORTANT:** All cluster's names **must be globally unique**, each of them (EKS or kOps, doesn't matter) creates a Route53 hostzone which is unique
 
@@ -16,7 +16,7 @@ This README describes the main infrastructure components required to deliver a p
 - Terraform >= 12
 - [aws-iam-authenticator](https://docs.aws.amazon.com/eks/latest/userguide/install-aws-iam-authenticator.html)
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
-- [Helm <= 2.14.3](https://github.com/helm/helm/releases/tag/v2.14.3) 
+- [Helm <= 2.14.3](https://github.com/helm/helm/releases/tag/v2.14.3)
 - Ensure you have `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` exported
 
 ## What it contains?
@@ -31,9 +31,9 @@ Within `main.tf` you'll find creation of:
 - Bastion: It calls the bastion module which creates a bastion instance inside a VPC that will grant access to internal subnets to the members of the team. You can use this host to ssh onto your worker nodes.
 - etc
 
-### EKS (`eks.tf`)
+### EKS (`eks-cluster.tf`)
 
-`eks.tf` holds the EKS definition, it is being used the official EKS module. Inside this file you'll specify workers, IAM permissions, etc. 
+`eks-cluster.tf` holds the EKS definition, it is being used the official EKS module. Inside this file you'll specify workers, IAM permissions, etc.
 
 **NOTE**: Default cluster size is **21** nodes and default worker node types are **r5.2xlarge**. If you are just playing around or testing a feature it doesn't make sense to have these specs, please change them.
 

--- a/terraform/cloud-platform-eks/eks-cluster.tf
+++ b/terraform/cloud-platform-eks/eks-cluster.tf
@@ -1,0 +1,105 @@
+###############
+# EKS Cluster #
+###############
+
+data "aws_eks_cluster" "cluster" {
+  name = module.eks.cluster_id
+}
+
+data "aws_eks_cluster_auth" "cluster" {
+  name = module.eks.cluster_id
+}
+
+provider "kubernetes" {
+  host                   = data.aws_eks_cluster.cluster.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+  token                  = data.aws_eks_cluster_auth.cluster.token
+  load_config_file       = false
+  version                = "1.10.0"
+}
+
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "v8.1.0"
+
+  cluster_name       = local.cluster_name
+  subnets            = concat(tolist(data.aws_subnet_ids.private.ids), tolist(data.aws_subnet_ids.public.ids))
+  vpc_id             = data.aws_vpc.selected.id
+  config_output_path = "./files/"
+
+  node_groups = {
+    default_ng = {
+      desired_capacity = var.cluster_node_count
+      max_capacity     = 30
+      min_capacity     = 1
+      subnets          = data.aws_subnet_ids.private.ids
+
+      instance_type = var.worker_node_machine_type
+      k8s_labels = {
+        Terraform = "true"
+        Cluster   = local.cluster_name
+        Domain    = local.cluster_base_domain_name
+      }
+      additional_tags = {
+        default_ng = "true"
+      }
+    }
+  }
+
+  # Out of the box you can't specify groups to map, just users. Some people did some workarounds
+  # we can explore later: https://ygrene.tech/mapping-iam-groups-to-eks-user-access-66fd745a6b77
+  map_users = [
+    {
+      userarn  = "arn:aws:iam::754256621582:user/AlejandroGarrido"
+      username = "AlejandroGarrido"
+      groups   = ["system:masters"]
+    },
+    {
+      userarn  = "arn:aws:iam::754256621582:user/PoornimaKrishnasamy"
+      username = "PoornimaKrishnasamy"
+      groups   = ["system:masters"]
+    },
+    {
+      userarn  = "arn:aws:iam::754256621582:user/MouradTrabelsi"
+      username = "MouradTrabelsi"
+      groups   = ["system:masters"]
+    },
+    {
+      userarn  = "arn:aws:iam::754256621582:user/DavidSalgado"
+      username = "DavidSalgado"
+      groups   = ["system:masters"]
+    },
+    {
+      userarn  = "arn:aws:iam::754256621582:user/paulWyborn"
+      username = "paulWyborn"
+      groups   = ["system:masters"]
+    },
+    {
+      userarn  = "arn:aws:iam::754256621582:user/SabluMiah"
+      username = "SabluMiah"
+      groups   = ["system:masters"]
+    },
+    {
+      userarn  = "arn:aws:iam::754256621582:user/jasonBirchall"
+      username = "jasonBirchall"
+      groups   = ["system:masters"]
+    },
+    {
+      userarn  = "arn:aws:iam::754256621582:user/VijayVeeranki"
+      username = "VijayVeeranki"
+      groups   = ["system:masters"]
+    },
+    {
+      userarn  = "arn:aws:iam::754256621582:user/cloud-platform/manager-concourse"
+      username = "manager-concourse"
+      groups   = ["system:masters"]
+    }
+
+  ]
+
+  tags = {
+    Terraform = "true"
+    Cluster   = local.cluster_name
+    Domain    = local.cluster_base_domain_name
+  }
+}


### PR DESCRIPTION
git-crypt remembers when a file you tell it to encrypt has existed
in the repo previously, in cleartext. So, commit e75f22ff had the
side-effect of breaking git-crypt and making it impossible to add
the eks.tf file encrypted.

This commit renames the file to eks-cluster, which has never
existed in the repo before, and so git-crypt should encrypt it as
normal.

related to #588