### PR TITLE
Add a dependency on prometheus to velero

### DIFF
--- a/terraform/cloud-platform-components/velero.tf
+++ b/terraform/cloud-platform-components/velero.tf
@@ -90,6 +90,7 @@ resource "helm_release" "velero" {
     kubernetes_namespace.velero,
     aws_iam_role.velero,
     aws_iam_role_policy.velero,
+    helm_release.prometheus_operator,
   ]
   values = [templatefile("${path.module}/templates/velero/velero.yaml.tpl", {
     cluster_name = terraform.workspace


### PR DESCRIPTION
If prometheus does not install correctly, we get the following
error when terraform tries to install velero:

    Error: rpc error: code = Unknown desc = validation failed: unable to recognize "": no matches for kind "ServiceMonitor" in version "monitoring.coreos.com/v1"
      on velero.tf line 82, in resource "helm_release" "velero":
      82: resource "helm_release" "velero" {

This change makes velero depend on prometheus, so that terraform
won't try to install velero until prometheus is installed.