### PR TITLE
We don't want to delete the prometheus CRD when we delete the prometheus-operator

### DIFF
--- a/terraform/cloud-platform-components/templates/prometheus-operator.yaml.tpl
+++ b/terraform/cloud-platform-components/templates/prometheus-operator.yaml.tpl
@@ -280,7 +280,7 @@ prometheusOperator:
 
   ## Attempt to clean up CRDs created by Prometheus Operator.
   ##
-  cleanupCustomResource: true
+  cleanupCustomResource: false
 
 ## Deploy a Prometheus instance
 ##


### PR DESCRIPTION
Prometheus-operator helm chart deletes CRDs when you delete the chart itself. We do want to avoid it.

The reason to avoid it is quite simple: we don't want to lose already existing ServiceMonitor and PromtheusRules