### PR TITLE
Enable running just the quick cluster tests

### DIFF
--- a/smoke-tests/makefile
+++ b/smoke-tests/makefile
@@ -65,3 +65,16 @@ test-non-live-1:
 		-e AWS_SHARED_CREDENTIALS_FILE=/app/.aws/credentials \
 		-e KUBECONFIG=/app/config \
 		$(TAGGED_IMAGE) rspec --tag ~cluster:live-1
+
+# Only run tests tagged with speed: fast
+test-fast:
+	docker run --rm \
+		-v $(KUBE_CONFIG):/app/config \
+		-v $${PWD}/spec:/app/spec \
+		-v $${HOME}/.aws:/app/.aws \
+		-e AWS_CONFIG_FILE=/app/.aws/config \
+		-e AWS_PROFILE=$(AWS_PROFILE) \
+		-e AWS_SHARED_CREDENTIALS_FILE=/app/.aws/credentials \
+		-e KUBECONFIG=/app/config \
+		$(TAGGED_IMAGE) rspec --tag speed:fast
+

--- a/smoke-tests/spec/alertmanager_spec.rb
+++ b/smoke-tests/spec/alertmanager_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe "Alertmanager resources" do
+describe "Alertmanager resources", speed: "fast" do
   specify "expected Alertmanager resources" do
     names = get_alertmanagers.map { |set| set.dig("metadata", "name") }.sort
 

--- a/smoke-tests/spec/authorized_keys_spec.rb
+++ b/smoke-tests/spec/authorized_keys_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe "authorized_keys", cluster: "live-1" do
+describe "authorized_keys", cluster: "live-1", speed: "fast" do
   context "authorized-keys-provider namespace should exists" do
     it "Fail if namespace doesnt exist" do
       expect(namespace_exists?("authorized-keys-provider")).to eq(true)

--- a/smoke-tests/spec/certificates_spec.rb
+++ b/smoke-tests/spec/certificates_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe "certificates" do
+describe "certificates", speed: "fast" do
   specify "expected Certificate" do
     names = get_certificates.map { |set| set.dig("metadata", "name") }.sort
 

--- a/smoke-tests/spec/crds_spec.rb
+++ b/smoke-tests/spec/crds_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe "crds" do
+describe "crds", speed: "fast" do
 
   specify "expected crds" do
     names = get_crds.map { |set| set.dig("metadata", "name") }.sort

--- a/smoke-tests/spec/crds_spec.rb
+++ b/smoke-tests/spec/crds_spec.rb
@@ -1,7 +1,6 @@
 require "spec_helper"
 
 describe "crds", speed: "fast" do
-
   specify "expected crds" do
     names = get_crds.map { |set| set.dig("metadata", "name") }.sort
 

--- a/smoke-tests/spec/daemonsets_spec.rb
+++ b/smoke-tests/spec/daemonsets_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe "daemonsets" do
+describe "daemonsets", speed: "fast" do
   let(:worker_ips) { node_ips worker_nodes }
   let(:master_ips) { node_ips master_nodes }
   let(:all_node_ips) { node_ips(get_nodes) }

--- a/smoke-tests/spec/docker_registry_cache_spec.rb
+++ b/smoke-tests/spec/docker_registry_cache_spec.rb
@@ -7,11 +7,11 @@ describe "docker-registry-cache" do
     let(:pods) { get_running_pods(namespace) }
     let(:pod) { pods.first }
 
-    specify "one pod running" do
+    specify "one pod running", speed: "fast" do
       expect(pods.length).to eq(1)
     end
 
-    specify "running the cache image" do
+    specify "running the cache image", speed: "fast" do
       image = pod.dig("spec", "containers").first.fetch("image")
       expect(image).to match("ministryofjustice.docker-registry-cache")
     end
@@ -38,7 +38,7 @@ describe "docker-registry-cache" do
     end
   end
 
-  context "ingress" do
+  context "ingress", speed: "fast" do
     let(:ingresses) { get_ingresses(namespace) }
     let(:ingress) { ingresses.first }
 

--- a/smoke-tests/spec/issuers_spec.rb
+++ b/smoke-tests/spec/issuers_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe "Clusterissuer" do
+describe "Clusterissuer", speed: "fast" do
   specify "expected Clusterissuer" do
     names = get_clusterissuers.map { |set| set.dig("metadata", "name") }.sort
 
@@ -12,7 +12,7 @@ describe "Clusterissuer" do
   end
 end
 
-describe "Issuer" do
+describe "Issuer", speed: "fast" do
   specify "expected Issuer" do
     names = get_issuers.map { |set| set.dig("metadata", "name") }.sort
 

--- a/smoke-tests/spec/namespace_annotations_spec.rb
+++ b/smoke-tests/spec/namespace_annotations_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe "namespaces", cluster: "live-1" do
+describe "namespaces", cluster: "live-1", speed: "fast" do
   # Monitoring is automatically set up for all namespaces which have specific
   # annotations. So, if any namespaces don't have any, it's a problem.
   specify "must have annotations" do

--- a/smoke-tests/spec/prometheus_crd_spec.rb
+++ b/smoke-tests/spec/prometheus_crd_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe "Prometheus" do
+describe "Prometheus", speed: "fast" do
   specify "expected Prometheus resource" do
     names = get_prometheuses.map { |set| set.dig("metadata", "name") }.sort
     expected = [

--- a/smoke-tests/spec/prometheusrules_spec.rb
+++ b/smoke-tests/spec/prometheusrules_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe "Prometheus Rules" do
+describe "Prometheus Rules", speed: "fast" do
   specify "expected in all clusters" do
     names = get_prometheus_rules.map { |set| set.dig("metadata", "name") }.sort
 

--- a/smoke-tests/spec/servicemonitors_spec.rb
+++ b/smoke-tests/spec/servicemonitors_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe "servicemonitors" do
+describe "servicemonitors", speed: "fast" do
   specify "expected prometheus servicemonitors" do
     names = get_servicemonitors("monitoring").map { |set| set.dig("metadata", "name") }.sort
 


### PR DESCRIPTION
These tests can be run more frequently to get a  quick and incomplete check
of the cluster state.

On my machine, running natively (i.e. not inside a tools image container),
these tests complete in 21 seconds.

    rspec --tag speed:fast