### PR TITLE
Add a test for the OPA label on kube-system

### DIFF
--- a/smoke-tests/spec/kubernetes_helper.rb
+++ b/smoke-tests/spec/kubernetes_helper.rb
@@ -230,8 +230,12 @@ def get_servicemonitors(namespace)
 end
 
 def kubectl_items(cmd)
+  kubectl_get(cmd).fetch("items")
+end
+
+def kubectl_get(cmd)
   json, _, _ = execute("kubectl #{cmd} -o json")
-  JSON.parse(json).fetch("items")
+  JSON.parse(json)
 end
 
 # Set the enable-modsecurity flag to false on the ingress annotation

--- a/smoke-tests/spec/namespace_labels_spec.rb
+++ b/smoke-tests/spec/namespace_labels_spec.rb
@@ -1,0 +1,13 @@
+require "spec_helper"
+
+describe "namespaces", speed: "fast" do
+  context "kube-system" do
+    # The kube-system namespace MUST have this label, or the
+    # OPA will prevent any pods from being launched in it.
+    it "has opa webhook label" do
+      data = kubectl_get("get namespace kube-system")
+      label = data.dig("metadata", "labels", "openpolicyagent.org/webhook")
+      expect(label).to eq("ignore")
+    end
+  end
+end


### PR DESCRIPTION
This test checks that the `kube-system` namespace has
the "openpolicyagent.org/webhook" label set to "ignore"