### PR TITLE
Thanos S3 bucket

### DIFF
--- a/terraform/global-resources/s3.tf
+++ b/terraform/global-resources/s3.tf
@@ -137,4 +137,30 @@ resource "aws_s3_bucket_public_access_block" "velero" {
   ]
 }
 
+resource "aws_s3_bucket" "thanos" {
+  bucket   = "cloud-platform-prometheus-thanos"
+  acl      = "private"
+  provider = aws.cloud-platform
 
+  versioning {
+    enabled = true
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "thanos" {
+  bucket   = aws_s3_bucket.thanos.id
+  provider = aws.cloud-platform
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}


### PR DESCRIPTION
Thanos store the Prometheus Metrics within an S3 bucket, every two hours it pushes into the S3 buckets the metrics. 

This allows multiple Thanos from different cluster store metrics in the same place.
 