### PR TITLE
Extend abilities of cluster-creation script

### DIFF
--- a/create-cluster.rb
+++ b/create-cluster.rb
@@ -44,6 +44,8 @@ def main(options)
   cluster_size = options[:cluster_size]
   vpc_name = options[:vpc_name]
   gitcrypt_unlock = options[:gitcrypt_unlock]
+  extra_wait = options[:extra_wait]
+  
 
   vpc_name = cluster_name if vpc_name.nil?
   usage if cluster_name.nil? || cluster_size.nil?
@@ -55,7 +57,7 @@ def main(options)
   create_vpc(vpc_name)
   create_cluster(cluster_name, cluster_size, vpc_name)
   run_kops(cluster_name)
-  sleep(600)
+  sleep(extra_wait) unless extra_wait.nil?
   install_components(cluster_name)
   run_integration_tests(cluster_name)
 
@@ -269,6 +271,10 @@ def parse_options
 
     opts.on("-g", "--no-gitcrypt", "Avoid the execution of git-crypt unlock (example: pipeline tools might do that for you)") do |name|
       options[:gitcrypt_unlock] = false
+    end
+
+    opts.on("-t", "--extra-wait N", Float, "The time between kops validate and deploy of components. We need to wait for DNS propagation") do |n|
+      options[:extra_wait] = n
     end
 
     opts.on("-s", "--size CLUSTER-SIZE", [SMALL, MEDIUM, PRODUCTION], "Cluster size (#{SMALL} | #{MEDIUM} | #{PRODUCTION})") do |size|

--- a/create-cluster.rb
+++ b/create-cluster.rb
@@ -52,7 +52,7 @@ def main(options)
 
   check_prerequisites(cluster_name)
 
-  execute "git-crypt unlock" if gitcrypt_unlock]
+  execute "git-crypt unlock" if gitcrypt_unlock
 
   create_vpc(vpc_name)
   create_cluster(cluster_name, cluster_size, vpc_name)

--- a/create-cluster.rb
+++ b/create-cluster.rb
@@ -55,6 +55,7 @@ def main(options)
   create_vpc(vpc_name)
   create_cluster(cluster_name, cluster_size, vpc_name)
   run_kops(cluster_name)
+  sleep(300)
   install_components(cluster_name)
   run_integration_tests(cluster_name)
 

--- a/create-cluster.rb
+++ b/create-cluster.rb
@@ -55,7 +55,7 @@ def main(options)
   create_vpc(vpc_name)
   create_cluster(cluster_name, cluster_size, vpc_name)
   run_kops(cluster_name)
-  sleep(300)
+  sleep(600)
   install_components(cluster_name)
   run_integration_tests(cluster_name)
 

--- a/create-cluster.rb
+++ b/create-cluster.rb
@@ -50,10 +50,7 @@ def main(options)
 
   check_prerequisites(cluster_name)
 
-  puts "I have #{gitcrypt_unlock.inspect}"
   execute "git-crypt unlock" if gitcrypt_unlock == true
-
-  exit 1
 
   create_vpc(vpc_name)
   create_cluster(cluster_name, cluster_size, vpc_name)

--- a/create-cluster.rb
+++ b/create-cluster.rb
@@ -27,16 +27,16 @@ PRODUCTION = "production"
 MACHINE_TYPES = {
   SMALL => {
     "master_node_machine_type" => "c4.large",
-    "worker_node_machine_type" => "r5.large",
+    "worker_node_machine_type" => "r5.large"
   },
   MEDIUM => {
     "master_node_machine_type" => "c4.2xlarge",
-    "worker_node_machine_type" => "r5.xlarge",
+    "worker_node_machine_type" => "r5.xlarge"
   },
   PRODUCTION => {
     "master_node_machine_type" => "c4.4xlarge",
-    "worker_node_machine_type" => "r5.xlarge",
-  },
+    "worker_node_machine_type" => "r5.xlarge"
+  }
 }
 
 def main(options)
@@ -46,7 +46,6 @@ def main(options)
   gitcrypt_unlock = options[:gitcrypt_unlock]
   integration_tests = options[:integration_tests]
   extra_wait = options[:extra_wait]
-  
 
   vpc_name = cluster_name if vpc_name.nil?
   usage if cluster_name.nil? || cluster_size.nil?
@@ -72,7 +71,7 @@ def create_vpc(vpc_name)
 
   tf_apply = [
     "terraform apply",
-    "-auto-approve",
+    "-auto-approve"
   ].join(" ")
 
   run_and_output "cd #{dir}; #{tf_apply}"
@@ -91,7 +90,7 @@ def create_cluster(cluster_name, cluster_size, vpc_name)
     "-var master_node_machine_type=#{master_node_machine_type}",
     "-var worker_node_machine_type=#{worker_node_machine_type}",
     *("-var vpc_name=\"#{vpc_name}\"" if vpc_name),
-    "-auto-approve",
+    "-auto-approve"
   ].join(" ")
 
   run_and_output "cd #{dir}; #{tf_apply}"
@@ -252,7 +251,7 @@ def run_integration_tests(cluster_name)
     "cd #{dir}",
     "bundle binstubs bundler --force --path /usr/local/bin",
     "bundle binstubs rspec-core --path /usr/local/bin",
-    "rspec --tag ~cluster:live-1 --format progress --format documentation --out #{output}",
+    "rspec --tag ~cluster:live-1 --format progress --format documentation --out #{output}"
   ].join("; ")
 
   run_and_output(cmd)
@@ -277,7 +276,6 @@ def parse_options
     opts.on("-i", "--no-integration-test", "Avoid the execution of git-crypt unlock (example: pipeline tools might do that for you)") do |name|
       options[:integration_tests] = false
     end
-
 
     opts.on("-t", "--extra-wait N", Float, "The time between kops validate and deploy of components. We need to wait for DNS propagation") do |n|
       options[:extra_wait] = n

--- a/create-cluster.rb
+++ b/create-cluster.rb
@@ -44,6 +44,7 @@ def main(options)
   cluster_size = options[:cluster_size]
   vpc_name = options[:vpc_name]
   gitcrypt_unlock = options[:gitcrypt_unlock]
+  integration_tests = options[:integration_tests]
   extra_wait = options[:extra_wait]
   
 
@@ -59,7 +60,7 @@ def main(options)
   run_kops(cluster_name)
   sleep(extra_wait) unless extra_wait.nil?
   install_components(cluster_name)
-  run_integration_tests(cluster_name)
+  run_integration_tests(cluster_name) if integration_tests == true
 
   run_and_output "kubectl cluster-info"
 end
@@ -258,7 +259,7 @@ def run_integration_tests(cluster_name)
 end
 
 def parse_options
-  options = {cluster_size: SMALL, gitcrypt_unlock: true}
+  options = {cluster_size: SMALL, gitcrypt_unlock: true, integration_tests: true}
 
   OptionParser.new { |opts|
     opts.on("-n", "--name CLUSTER-NAME", "Cluster name (max. #{MAX_CLUSTER_NAME_LENGTH} chars)") do |name|
@@ -272,6 +273,11 @@ def parse_options
     opts.on("-g", "--no-gitcrypt", "Avoid the execution of git-crypt unlock (example: pipeline tools might do that for you)") do |name|
       options[:gitcrypt_unlock] = false
     end
+
+    opts.on("-i", "--no-integration-test", "Avoid the execution of git-crypt unlock (example: pipeline tools might do that for you)") do |name|
+      options[:integration_tests] = false
+    end
+
 
     opts.on("-t", "--extra-wait N", Float, "The time between kops validate and deploy of components. We need to wait for DNS propagation") do |n|
       options[:extra_wait] = n

--- a/create-cluster.rb
+++ b/create-cluster.rb
@@ -52,14 +52,14 @@ def main(options)
 
   check_prerequisites(cluster_name)
 
-  execute "git-crypt unlock" if gitcrypt_unlock == true
+  execute "git-crypt unlock" if gitcrypt_unlock]
 
   create_vpc(vpc_name)
   create_cluster(cluster_name, cluster_size, vpc_name)
   run_kops(cluster_name)
-  sleep(extra_wait) unless extra_wait.nil?
+  sleep(extra_wait) unless extra_wait
   install_components(cluster_name)
-  run_integration_tests(cluster_name) if integration_tests == true
+  run_integration_tests(cluster_name) if integration_tests
 
   run_and_output "kubectl cluster-info"
 end
@@ -273,7 +273,7 @@ def parse_options
       options[:gitcrypt_unlock] = false
     end
 
-    opts.on("-i", "--no-integration-test", "Avoid the execution of git-crypt unlock (example: pipeline tools might do that for you)") do |name|
+    opts.on("-i", "--no-integration-test", "Don't run integration tests after creating the cluster") do |name|
       options[:integration_tests] = false
     end
 


### PR DESCRIPTION
In order to create the build-test-clusters pipeline, some extra functionalities `create-cluster.rb` script had to be added:

- Make the `git-crypt unlock` optional: When it is executed from the concourse pipeline the repository is already unlocked.
- Make integration tests optional: all of them are failing and for test clusters it looks it is expected
- Optional time (argument in seconds) between cluster validation (kops validate) and components deployment (`terraform apply` inside components folder). We were experimenting failing DNS resolutions and it looks it wasn't fully propagated the DNS API at the moment when components were deployed.

