### PR TITLE
Removed unwanted tab from live-1 manifest

### DIFF
--- a/kops/live-1.yaml
+++ b/kops/live-1.yaml
@@ -241,7 +241,7 @@ spec:
     - ResourceQuota
     - PodSecurityPolicy
     featureGates:
-        TTLAfterFinished: "true"
+      TTLAfterFinished: "true"
   kubeControllerManager:
     featureGates:
       TTLAfterFinished: "true"


### PR DESCRIPTION
This was causing the kops-convergence pipeline to fail.