### PR TITLE
Set extra_wait default value to 0

### DIFF
--- a/create-cluster.rb
+++ b/create-cluster.rb
@@ -258,7 +258,7 @@ def run_integration_tests(cluster_name)
 end
 
 def parse_options
-  options = {cluster_size: SMALL, gitcrypt_unlock: true, integration_tests: true}
+  options = {cluster_size: SMALL, gitcrypt_unlock: true, integration_tests: true, extra_wait: 0}
 
   OptionParser.new { |opts|
     opts.on("-n", "--name CLUSTER-NAME", "Cluster name (max. #{MAX_CLUSTER_NAME_LENGTH} chars)") do |name|


### PR DESCRIPTION
If we don't default value is fails with:

```console
Traceback (most recent call last):
        2: from ./create-cluster.rb:303:in `<main>'
        1: from ./create-cluster.rb:60:in `main'
./create-cluster.rb:60:in `sleep': can't convert NilClass into time interval (TypeError)

```