### PR TITLE
Bump tools image to 1.13 in makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-TOOLS_IMAGE := ministryofjustice/cloud-platform-tools:1.12
+TOOLS_IMAGE := ministryofjustice/cloud-platform-tools:1.13
 
 tools-shell:
 	docker pull $(TOOLS_IMAGE)


### PR DESCRIPTION
This image contains a later version of the kubectl binary, which allows additional features such as  as a shorthand among other things.