### PR TITLE
Set Auth0 client secret as sensitive terraform output

### DIFF
--- a/terraform/cloud-platform/outputs.tf
+++ b/terraform/cloud-platform/outputs.tf
@@ -69,6 +69,7 @@ output "oidc_components_client_id" {
 
 output "oidc_components_client_secret" {
   value = auth0_client.components.client_secret
+  sensitive = true
 }
 
 output "certificate_arn" {

--- a/terraform/cloud-platform/outputs.tf
+++ b/terraform/cloud-platform/outputs.tf
@@ -59,7 +59,8 @@ output "oidc_kubernetes_client_id" {
 }
 
 output "oidc_kubernetes_client_secret" {
-  value = auth0_client.kubernetes.client_secret
+  value     = auth0_client.kubernetes.client_secret
+  sensitive = true
 }
 
 output "oidc_components_client_id" {

--- a/terraform/cloud-platform/outputs.tf
+++ b/terraform/cloud-platform/outputs.tf
@@ -68,7 +68,7 @@ output "oidc_components_client_id" {
 }
 
 output "oidc_components_client_secret" {
-  value = auth0_client.components.client_secret
+  value     = auth0_client.components.client_secret
   sensitive = true
 }
 


### PR DESCRIPTION
We don't want important information to be shown in pipeline outputs, specially auth0 secret keys. When we define an output as sensitive it doesn't show it