### PR TITLE
Add helloworld app and Multi container app for starter pack

### DIFF
--- a/terraform/cloud-platform-starter-pack/main.tf
+++ b/terraform/cloud-platform-starter-pack/main.tf
@@ -1,0 +1,38 @@
+################################
+# Provider Setup & TF Backends #
+################################
+
+terraform {
+  backend "s3" {
+    bucket               = "cloud-platform-terraform-state"
+    region               = "eu-west-1"
+    key                  = "terraform.tfstate"
+    workspace_key_prefix = "cross-platform-starter-pack"
+    profile              = "moj-cp"
+  }
+}
+
+provider "aws" {
+  profile = "moj-cp"
+  region  = "eu-west-2"
+}
+
+provider "kubernetes" {
+}
+
+provider "helm" {
+  version = "0.10.4"
+  kubernetes {
+  }
+}
+
+data "terraform_remote_state" "cluster" {
+  backend = "s3"
+
+  config = {
+    bucket  = "cloud-platform-terraform-state"
+    region  = "eu-west-1"
+    key     = "cloud-platform/${terraform.workspace}/terraform.tfstate"
+    profile = "moj-cp"
+  }
+}

--- a/terraform/cloud-platform-starter-pack/starter-pack.tf
+++ b/terraform/cloud-platform-starter-pack/starter-pack.tf
@@ -1,0 +1,120 @@
+resource "kubernetes_namespace" "starter-pack" {
+  metadata {
+    name = "starter-pack"
+
+    labels = {
+      "name" = "starter-pack"
+    }
+
+    annotations = {
+      "cloud-platform.justice.gov.uk/application"   = "Cloud Platform starter pack test app"
+      "cloud-platform.justice.gov.uk/business-unit" = "cloud-platform"
+      "cloud-platform.justice.gov.uk/owner"         = "Cloud Platform: platforms@digital.justice.gov.uk"
+      "cloud-platform.justice.gov.uk/source-code"   = "https://github.com/ministryofjustice/cloud-platform-infrastructure"
+    }
+  }
+}
+
+data "template_file" "helloworld_deploy" {
+  template = "${file("${path.module}/templates/helloworld-rubyapp/deploy.yaml")}"
+
+  vars = {
+    helloworld-rubyapp-ingress = format(
+      "%s-%s.%s.%s",
+      "helloworld-app",
+      kubernetes_namespace.starter-pack.id,
+      "apps",
+      data.terraform_remote_state.cluster.outputs.cluster_domain_name,
+  ) }
+
+}
+
+resource "null_resource" "helloworld_deploy" {
+  triggers = {
+    manifest_sha1 = "${sha1("${data.template_file.helloworld_deploy.rendered}")}"
+  }
+
+  provisioner "local-exec" {
+    command = "kubectl -n ${kubernetes_namespace.starter-pack.id} apply -f -<<EOF\n${data.template_file.helloworld_deploy.rendered}\nEOF"
+  }
+}
+
+
+resource "random_id" "user" {
+  byte_length = 8
+}
+
+resource "random_id" "password" {
+  byte_length = 8
+}
+
+resource "kubernetes_secret" "postgres_secrets" {
+  metadata {
+    name = "postgres-credentials"
+    namespace = kubernetes_namespace.starter-pack.id
+  }
+
+  data = {
+    user     = random_id.user.hex
+    password = random_id.password.hex
+  }
+  type = "Opaque"
+}
+
+
+data "template_file" "postgres_deploy" {
+  template = "${file("${path.module}/templates/multi-container-app/pg-deploy.yaml")}"
+  vars = {
+    postgres_user = kubernetes_secret.postgres_secrets.data.user
+    postgres_password = kubernetes_secret.postgres_secrets.data.password
+  }
+}
+
+resource "null_resource" "postgres_deploy" {
+  triggers = {
+    manifest_sha1 = "${sha1("${data.template_file.postgres_deploy.rendered}")}"
+  }
+
+  provisioner "local-exec" {
+    command = "kubectl -n ${kubernetes_namespace.starter-pack.id} apply -f -<<EOF\n${data.template_file.postgres_deploy.rendered}\nEOF"
+  }
+}
+
+#  postgres://dummy:dummy@multi-container-demo-postgres.starter-pack.svc.cluster.local:5432/multi_container_demo_app
+
+
+data "template_file" "multi_container_app_deploy" {
+  template = "${file("${path.module}/templates/multi-container-app/deploy.yaml")}"
+
+  vars = {
+    multi-container-app-ingress = format(
+      "%s-%s.%s.%s",
+      "multi-container-app",
+      kubernetes_namespace.starter-pack.id,
+      "apps",
+      data.terraform_remote_state.cluster.outputs.cluster_domain_name,
+    )
+    postgres-url = format(
+      "%s%s:%s@%s.%s.%s",
+      "postgres://",
+      kubernetes_secret.postgres_secrets.data.user,
+      kubernetes_secret.postgres_secrets.data.password,
+      "multi-container-demo-postgres",
+      kubernetes_namespace.starter-pack.id,
+      "svc.cluster.local:5432/multi_container_demo_app",
+    )
+  }
+}
+
+resource "null_resource" "multi_container_app_deploy" {
+  triggers = {
+    manifest_sha1 = "${sha1("${data.template_file.multi_container_app_deploy.rendered}")}"
+  }
+
+  provisioner "local-exec" {
+    command = "kubectl -n ${kubernetes_namespace.starter-pack.id} apply -f -<<EOF\n${data.template_file.multi_container_app_deploy.rendered}\nEOF"
+  }
+}
+
+
+

--- a/terraform/cloud-platform-starter-pack/starter-pack.tf
+++ b/terraform/cloud-platform-starter-pack/starter-pack.tf
@@ -50,7 +50,7 @@ resource "random_id" "password" {
 
 resource "kubernetes_secret" "postgres_secrets" {
   metadata {
-    name = "postgres-credentials"
+    name      = "postgres-credentials"
     namespace = kubernetes_namespace.starter-pack.id
   }
 
@@ -65,7 +65,7 @@ resource "kubernetes_secret" "postgres_secrets" {
 data "template_file" "postgres_deploy" {
   template = "${file("${path.module}/templates/multi-container-app/pg-deploy.yaml")}"
   vars = {
-    postgres_user = kubernetes_secret.postgres_secrets.data.user
+    postgres_user     = kubernetes_secret.postgres_secrets.data.user
     postgres_password = kubernetes_secret.postgres_secrets.data.password
   }
 }

--- a/terraform/cloud-platform-starter-pack/templates/helloworld-rubyapp/deploy.yaml
+++ b/terraform/cloud-platform-starter-pack/templates/helloworld-rubyapp/deploy.yaml
@@ -1,0 +1,48 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: helloworld-rubyapp
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: helloworld-rubyapp
+    spec:
+      containers:
+      - name: rubyapp
+        image: ministryofjustice/cloud-platform-helloworld-ruby:1.1
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 4567
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: helloworld-rubyapp-ingress
+spec:
+  tls:
+  - hosts:
+    - ${helloworld-rubyapp-ingress}
+  rules:
+  - host: ${helloworld-rubyapp-ingress}
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: rubyapp-service
+          servicePort: 4567
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rubyapp-service
+  labels:
+    app: rubyapp-service
+spec:
+  ports:
+  - port: 4567
+    name: http
+    targetPort: 4567
+  selector:
+    app: helloworld-rubyapp

--- a/terraform/cloud-platform-starter-pack/templates/multi-container-app/deploy.yaml
+++ b/terraform/cloud-platform-starter-pack/templates/multi-container-app/deploy.yaml
@@ -1,0 +1,120 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: content-api
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: content-api
+    spec:
+      containers:
+      - name: content-api
+        image: ministryofjustice/cloud-platform-multi-container-demo-app:content-api-1.4
+        ports:
+        - containerPort: 4567
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: content-api-service
+  labels:
+    app: content-api-service
+spec:
+  ports:
+  - port: 4567
+    name: http
+    targetPort: 4567
+  selector:
+    app: content-api
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: rails-app
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: rails-app
+    spec:
+      containers:
+      - name: rails-app
+        image: ministryofjustice/cloud-platform-multi-container-demo-app:rails-app-1.4
+        ports:
+        - containerPort: 3000
+        env:
+          - name: DATABASE_URL
+            value: ${postgres-url}
+          - name: CONTENT_API_URL
+            value: "http://content-api-service:4567/image_url.json"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rails-app-service
+  labels:
+    app: rails-app-service
+spec:
+  ports:
+  - port: 3000
+    name: http
+    targetPort: 3000
+  selector:
+    app: rails-app
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rails-migrations
+spec:
+  backoffLimit: 4
+  template:
+    spec:
+      containers:
+      - name: rails-app
+        image: ministryofjustice/cloud-platform-multi-container-demo-app:rails-app-1.4
+        command: [ "bundle", "exec", "rails", "db:migrate" ]
+        env:
+          - name: DATABASE_URL
+            value: ${postgres-url}
+      restartPolicy: OnFailure
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: worker
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: worker
+    spec:
+      containers:
+      - name: worker
+        image: ministryofjustice/cloud-platform-multi-container-demo-app:worker-1.4
+        ports:
+        - containerPort: 4567
+        env:
+          - name: DATABASE_URL
+            value: ${postgres-url}
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: multi-container-app
+spec:
+  tls:
+  - hosts:
+    - ${multi-container-app-ingress}
+  rules:
+  - host: ${multi-container-app-ingress}
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: rails-app-service
+          servicePort: 3000

--- a/terraform/cloud-platform-starter-pack/templates/multi-container-app/pg-deploy.yaml
+++ b/terraform/cloud-platform-starter-pack/templates/multi-container-app/pg-deploy.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres-container
+  template:
+    metadata:
+      labels:
+        app: postgres-container
+        tier: backend
+    spec:
+      containers:
+        - name: postgres-container
+          image: bitnami/postgresql:latest
+          env:
+            - name: POSTGRES_USER
+              value: ${postgres_user}
+
+            - name: POSTGRES_PASSWORD
+              value: ${postgres_password}
+
+            - name: POSTGRES_DB
+              value: multi_container_demo_app
+
+          ports:
+            - containerPort: 5432
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: multi-container-demo-postgres
+spec:
+  selector:
+    app: postgres-container
+  ports:
+    - protocol: TCP
+      port: 5432
+      targetPort: 5432

--- a/terraform/cloud-platform-starter-pack/versions.tf
+++ b/terraform/cloud-platform-starter-pack/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Related to [https://github.com/ministryofjustice/cloud-platform/issues/1631](https://github.com/ministryofjustice/cloud-platform/issues/1631)

This terraform code when applied will create a namespace "starter-pack" and deploy the [helloworld-app](https://github.com/ministryofjustice/cloud-platform-helloworld-ruby-app) and [Multi container app](https://github.com/ministryofjustice/cloud-platform-multi-container-demo-app) with postgres database running in a container.
