### PR TITLE
Bumping prometheus module to the latest release

### DIFF
--- a/terraform/cloud-platform-components/prometheus.tf
+++ b/terraform/cloud-platform-components/prometheus.tf
@@ -1,6 +1,6 @@
 
 module "prometheus" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-prometheus?ref=0.0.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-prometheus?ref=0.0.5"
 
   alertmanager_slack_receivers = var.alertmanager_slack_receivers
   iam_role_nodes               = data.aws_iam_role.nodes.arn


### PR DESCRIPTION
In order to include Thanos sidecar in our Prometheus we need to bump the Prometheus module we need to bump the version of the module to 0.0.5