### PR TITLE
Updated Integration tests to match new PrometheusRules for K8S >= 1.14

### DIFF
--- a/smoke-tests/spec/prometheusrules_spec.rb
+++ b/smoke-tests/spec/prometheusrules_spec.rb
@@ -20,7 +20,7 @@ describe "Prometheus Rules", speed: "fast" do
       "prometheus-operator-node.rules",
       "prometheus-operator-prometheus-operator",
       "prometheus-operator-prometheus",
-      "fluentd-es",
+      "fluentd-es"
     ]
     expect(names).to include(*expected)
   end
@@ -29,7 +29,7 @@ describe "Prometheus Rules", speed: "fast" do
     names = get_prometheus_rules.map { |set| set.dig("metadata", "name") }.sort
 
     expected = [
-      "prometheus-custom-alerts-ecr-exporter",
+      "prometheus-custom-alerts-ecr-exporter"
     ]
     expect(names).to include(*expected)
   end

--- a/smoke-tests/spec/prometheusrules_spec.rb
+++ b/smoke-tests/spec/prometheusrules_spec.rb
@@ -6,7 +6,6 @@ describe "Prometheus Rules", speed: "fast" do
 
     expected = [
       "prometheus-operator-alertmanager.rules",
-      "prometheus-operator-custom-alerts-node.rules",
       "prometheus-operator-custom-kubernetes-apps.rules",
       "prometheus-operator-etcd",
       "prometheus-operator-k8s.rules",
@@ -20,7 +19,7 @@ describe "Prometheus Rules", speed: "fast" do
       "prometheus-operator-kubernetes-system",
       "prometheus-operator-node.rules",
       "prometheus-operator-prometheus-operator",
-      "prometheus-operator-prometheus.rules",
+      "prometheus-operator-prometheus",
       "fluentd-es",
     ]
     expect(names).to include(*expected)

--- a/smoke-tests/spec/prometheusrules_spec.rb
+++ b/smoke-tests/spec/prometheusrules_spec.rb
@@ -20,6 +20,13 @@ describe "Prometheus Rules", speed: "fast" do
       "prometheus-operator-node.rules",
       "prometheus-operator-prometheus-operator",
       "prometheus-operator-prometheus",
+      "prometheus-operator-kube-apiserver-error",
+      "prometheus-operator-kubernetes-system-scheduler",
+      "prometheus-operator-node-exporter.rules",
+      "prometheus-operator-kubernetes-system-controller-manager",
+      "prometheus-operator-kubernetes-system-apiserver",
+      "prometheus-operator-kubernetes-system-kubelet",
+      "prometheus-operator-node-exporter",
       "fluentd-es"
     ]
     expect(names).to include(*expected)


### PR DESCRIPTION
Because of the Kubernetes upgrade some of the conditions within Prometheus Operator helm chart made to drift in the rules names which is causing integration tests to fail.

From the Helm Chart it was deleted the rule `prometheus-operator-kube-prometheus-node-alerting.rules`, [this rule only had disk space checks](https://github.com/helm/charts/blob/master/stable/prometheus-operator/templates/prometheus/rules/kube-prometheus-node-alerting.rules.yaml#L25-L40) which is already being [implemented by the Cloud Platform team in our custom rules](https://github.com/ministryofjustice/cloud-platform-terraform-prometheus/blob/master/resources/prometheusrule-alerts/node-alerts.yaml#L12-L19)