### PR TITLE
Pin Kubernetes Terraform provider to v1.10.0

### DIFF
--- a/terraform/cloud-platform-eks/components/main.tf
+++ b/terraform/cloud-platform-eks/components/main.tf
@@ -20,7 +20,7 @@ provider "aws" {
 
 provider "kubernetes" {
   config_path = "../files/kubeconfig_${terraform.workspace}"
-  version = "v1.10.0"
+  version     = "v1.10.0"
 }
 
 provider "helm" {

--- a/terraform/cloud-platform-eks/components/main.tf
+++ b/terraform/cloud-platform-eks/components/main.tf
@@ -20,6 +20,7 @@ provider "aws" {
 
 provider "kubernetes" {
   config_path = "../files/kubeconfig_${terraform.workspace}"
+  version = "v1.10.0"
 }
 
 provider "helm" {


### PR DESCRIPTION
The latest version of the kubernetes provider for terraform is failing with:

```
...
...
module.components.null_resource.cert_manager_issuers: Refreshing state... [id=1077953103912348481]
module.components.null_resource.nginx_ingress_default_certificate: Refreshing state... [id=6234213918410003309]
module.components.aws_iam_role_policy_attachment.externaldns_attach_policy: Refreshing state... [id=externaldns.manager.cloud-platform.service.justice.gov.uk-20200107102431644800000001]
module.components.aws_iam_role_policy_attachment.cert_manager_attach_policy: Refreshing state... [id=cert-manager.manager.cloud-platform.service.justice.gov.uk-20200107102431860400000003]

Error: invalid resource name "/cluster-critical": [may not contain '/']



Error: invalid resource name "/node-critical": [may not contain '/']

```

Unknown reasons why, I just [opened an issue in our backlog](https://github.com/ministryofjustice/cloud-platform/issues/1710) to find the reason why. Meanwhile, let's just pin the version