### PR TITLE
Commented out ingress with invalid syntax test

### DIFF
--- a/smoke-tests/spec/ingress_spec.rb
+++ b/smoke-tests/spec/ingress_spec.rb
@@ -27,7 +27,7 @@ describe "nginx ingress" do
         namespace: namespace,
         host: host,
         file: "spec/fixtures/helloworld-deployment.yaml.erb",
-        binding: binding,
+        binding: binding
       )
 
       wait_for(namespace, "ingress", "integration-test-app-ing")
@@ -46,7 +46,7 @@ describe "nginx ingress" do
         namespace: namespace,
         host: host,
         file: "spec/fixtures/invalid-nginx-syntax.yaml.erb",
-        binding: binding,
+        binding: binding
       )
       expect(stderr_str).to match(/admission webhook "validate.nginx.ingress.kubernetes.io" denied the request/)
     end

--- a/smoke-tests/spec/ingress_spec.rb
+++ b/smoke-tests/spec/ingress_spec.rb
@@ -40,15 +40,15 @@ describe "nginx ingress" do
     end
   end
 
-  context "when ingress is deployed with invalid syntax" do
-    it "is rejected by the admission webhook" do
-      stdout_str, stderr_str, status = apply_template_file(
-        namespace: namespace,
-        host: host,
-        file: "spec/fixtures/invalid-nginx-syntax.yaml.erb",
-        binding: binding,
-      )
-      expect(stderr_str).to match(/admission webhook "validate.nginx.ingress.kubernetes.io" denied the request/)
-    end
-  end
+  # context "when ingress is deployed with invalid syntax" do
+  #   it "is rejected by the admission webhook" do
+  #     stdout_str, stderr_str, status = apply_template_file(
+  #       namespace: namespace,
+  #       host: host,
+  #       file: "spec/fixtures/invalid-nginx-syntax.yaml.erb",
+  #       binding: binding,
+  #     )
+  #     expect(stderr_str).to match(/admission webhook "validate.nginx.ingress.kubernetes.io" denied the request/)
+  #   end
+  # end
 end

--- a/smoke-tests/spec/ingress_spec.rb
+++ b/smoke-tests/spec/ingress_spec.rb
@@ -40,15 +40,15 @@ describe "nginx ingress" do
     end
   end
 
-  # context "when ingress is deployed with invalid syntax" do
-  #   it "is rejected by the admission webhook" do
-  #     stdout_str, stderr_str, status = apply_template_file(
-  #       namespace: namespace,
-  #       host: host,
-  #       file: "spec/fixtures/invalid-nginx-syntax.yaml.erb",
-  #       binding: binding,
-  #     )
-  #     expect(stderr_str).to match(/admission webhook "validate.nginx.ingress.kubernetes.io" denied the request/)
-  #   end
-  # end
+  xcontext "when ingress is deployed with invalid syntax" do
+    it "is rejected by the admission webhook" do
+      stdout_str, stderr_str, status = apply_template_file(
+        namespace: namespace,
+        host: host,
+        file: "spec/fixtures/invalid-nginx-syntax.yaml.erb",
+        binding: binding,
+      )
+      expect(stderr_str).to match(/admission webhook "validate.nginx.ingress.kubernetes.io" denied the request/)
+    end
+  end
 end


### PR DESCRIPTION
This is to verify if api latency high is caused because of this test.

Will un-do this change after validating the result, by running smoke tests.