### PR TITLE
Release invalid syntax test

### DIFF
--- a/smoke-tests/spec/ingress_spec.rb
+++ b/smoke-tests/spec/ingress_spec.rb
@@ -40,7 +40,7 @@ describe "nginx ingress" do
     end
   end
 
-  xcontext "when ingress is deployed with invalid syntax" do
+  context "when ingress is deployed with invalid syntax" do
     it "is rejected by the admission webhook" do
       stdout_str, stderr_str, status = apply_template_file(
         namespace: namespace,


### PR DESCRIPTION
To test kubeapi latency alert, commented out  this test, kubeapi latency alert still triggered, while this test is paused. Now the test is complete so uncommented now.

