### PR TITLE
New nodegroup and templatefile() migration

### DIFF
--- a/kops/live-1.yaml
+++ b/kops/live-1.yaml
@@ -423,3 +423,36 @@ spec:
   - eu-west-2a
   - eu-west-2b
   - eu-west-2c
+
+
+
+---
+
+apiVersion: kops/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: null
+  labels:
+    kops.k8s.io/cluster: live-1.cloud-platform.service.justice.gov.uk
+  name: 2xlarge-nodes-1.14.10
+spec:
+  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2020-01-17
+  machineType: r5.2xlarge
+  maxSize: 2
+  minSize: 2
+  rootVolumeSize: 256
+  nodeLabels:
+    kops.k8s.io/instancegroup: 2xlarge-nodes-1.14.10
+  cloudLabels:
+    application: moj-cloud-platform
+    business-unit: platforms
+    is-production: "true"
+    k8s.io/cluster/live-1.cloud-platform.service.justice.gov.uk: ""
+    role: node
+    owner: cloud-platform:platforms@digital.justice.gov.uk
+    source-code: https://github.com/ministryofjustice/cloud-platform-infrastructure
+  role: Node
+  subnets:
+  - eu-west-2a
+  - eu-west-2b
+

--- a/terraform/cloud-platform-components/prometheus.tf
+++ b/terraform/cloud-platform-components/prometheus.tf
@@ -1,12 +1,15 @@
 
 module "prometheus" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-prometheus?ref=0.0.7"
+  #source = "github.com/ministryofjustice/cloud-platform-terraform-prometheus?ref=0.0.7"
+  source = "/Users/mogaal/workspace/github/ministryofjustice/cloud-platform-terraform-prometheus"
 
   alertmanager_slack_receivers = var.alertmanager_slack_receivers
   iam_role_nodes               = data.aws_iam_role.nodes.arn
   pagerduty_config             = var.pagerduty_config
   enable_ecr_exporter          = terraform.workspace == local.live_workspace ? true : false
   enable_cloudwatch_exporter   = terraform.workspace == local.live_workspace ? true : false
+  #enable_prometheus_affinity   = terraform.workspace == local.live_workspace ? true : false
+  enable_prometheus_affinity   = true
 
   dependence_deploy = null_resource.deploy
   dependence_opa    = helm_release.open-policy-agent

--- a/terraform/cloud-platform-components/prometheus.tf
+++ b/terraform/cloud-platform-components/prometheus.tf
@@ -1,15 +1,13 @@
 
 module "prometheus" {
-  #source = "github.com/ministryofjustice/cloud-platform-terraform-prometheus?ref=0.0.7"
-  source = "/Users/mogaal/workspace/github/ministryofjustice/cloud-platform-terraform-prometheus"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-prometheus?ref=0.0.8"
 
   alertmanager_slack_receivers = var.alertmanager_slack_receivers
   iam_role_nodes               = data.aws_iam_role.nodes.arn
   pagerduty_config             = var.pagerduty_config
   enable_ecr_exporter          = terraform.workspace == local.live_workspace ? true : false
   enable_cloudwatch_exporter   = terraform.workspace == local.live_workspace ? true : false
-  #enable_prometheus_affinity   = terraform.workspace == local.live_workspace ? true : false
-  enable_prometheus_affinity   = true
+  enable_prometheus_affinity   = terraform.workspace == local.live_workspace ? true : false
 
   dependence_deploy = null_resource.deploy
   dependence_opa    = helm_release.open-policy-agent

--- a/terraform/cloud-platform/kops.tf
+++ b/terraform/cloud-platform/kops.tf
@@ -1,16 +1,7 @@
 resource "local_file" "kops" {
-  content  = data.template_file.kops.rendered
   filename = "../../kops/${terraform.workspace}.yaml"
-}
 
-resource "aws_kms_key" "kms" {
-  description = "Creates KMS key for etcd volume encryption"
-}
-
-data "template_file" "kops" {
-  template = file("./templates/kops.yaml.tpl")
-
-  vars = {
+  content = templatefile("${path.module}/templates/kops.yaml.tpl", {
     cluster_domain_name                  = local.cluster_base_domain_name
     cluster_node_count                   = local.is_live_cluster ? var.cluster_node_count : 3
     kops_state_store                     = data.terraform_remote_state.global.outputs.cloud_platform_kops_state
@@ -28,6 +19,11 @@ data "template_file" "kops" {
     kms_key                              = aws_kms_key.kms.arn
     worker_node_machine_type             = var.worker_node_machine_type
     master_node_machine_type             = var.master_node_machine_type
-  }
+    enable_large_nodesgroup              = var.enable_large_nodesgroup
+  })
+}
+
+resource "aws_kms_key" "kms" {
+  description = "Creates KMS key for etcd volume encryption"
 }
 

--- a/terraform/cloud-platform/templates/kops.yaml.tpl
+++ b/terraform/cloud-platform/templates/kops.yaml.tpl
@@ -411,3 +411,38 @@ spec:
   - eu-west-2a
   - eu-west-2b
   - eu-west-2c
+
+%{ if enable_large_nodesgroup }
+
+---
+
+apiVersion: kops/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: null
+  labels:
+    kops.k8s.io/cluster: ${cluster_domain_name}
+  name: 2xlarge-nodes-1.14.10
+spec:
+  image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2020-01-17
+  machineType: r5.2xlarge
+  maxSize: 2
+  minSize: 1
+  rootVolumeSize: 256
+  nodeLabels:
+    kops.k8s.io/instancegroup: 2xlarge-nodes-1.14.10
+  cloudLabels:
+    application: moj-cloud-platform
+    business-unit: platforms
+    is-production: "true"
+    k8s.io/cluster/${cluster_domain_name}: ""
+    role: node
+    owner: cloud-platform:platforms@digital.justice.gov.uk
+    source-code: https://github.com/ministryofjustice/cloud-platform-infrastructure
+  role: Node
+  subnets:
+  - eu-west-2a
+  - eu-west-2b
+  - eu-west-2c
+
+%{ endif }

--- a/terraform/cloud-platform/templates/kops.yaml.tpl
+++ b/terraform/cloud-platform/templates/kops.yaml.tpl
@@ -427,7 +427,7 @@ spec:
   image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2020-01-17
   machineType: r5.2xlarge
   maxSize: 2
-  minSize: 1
+  minSize: 2
   rootVolumeSize: 256
   nodeLabels:
     kops.k8s.io/instancegroup: 2xlarge-nodes-1.14.10
@@ -443,6 +443,5 @@ spec:
   subnets:
   - eu-west-2a
   - eu-west-2b
-  - eu-west-2c
 
 %{ endif }

--- a/terraform/cloud-platform/variables.tf
+++ b/terraform/cloud-platform/variables.tf
@@ -41,3 +41,8 @@ variable "worker_node_machine_type" {
   default     = "r5.xlarge"
 }
 
+variable "enable_large_nodesgroup" {
+  description = "Due to Prometheus resource consumption we added a larger node groups (r5.2xlarge), this variable you enable the creation of it"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
- From terraform 0.12 it is advised to use `templatefile()` to render templates. This PR migrates from data template to `templatefile()`
- Added new variable (`enable_large_nodesgroup`) to enable a larger node group (mainly for Prometheus) be available within the cluster
- Within components, we added new variable and module version which implements NodeAffinity