### PR TITLE
No create larger instance node groups for tests clusters

### DIFF
--- a/create-cluster.rb
+++ b/create-cluster.rb
@@ -91,6 +91,7 @@ def create_cluster(cluster_name, cluster_size, vpc_name)
     "terraform apply",
     "-var master_node_machine_type=#{master_node_machine_type}",
     "-var worker_node_machine_type=#{worker_node_machine_type}",
+    "-var enable_large_nodesgroup=false",
     *("-var vpc_name=\"#{vpc_name}\"" if vpc_name),
     "-auto-approve"
   ].join(" ")


### PR DESCRIPTION
Updated create test clusters script with the new variable `enable_large_nodesgroup` set to false. If we leave the default value (`true`) it will be created a couple of large (r5.2xlarge) nodes which are not required for test clusters.