### PR TITLE
Only recycle nodes in target instance group

### DIFF
--- a/recycle-node.rb
+++ b/recycle-node.rb
@@ -79,7 +79,8 @@ def node_ready?(node)
 end
 
 def worker_node?(node)
-  node.dig("metadata", "labels")["kubernetes.io/role"] == "node"
+  node.dig("metadata", "labels")["kubernetes.io/role"] == "node" \
+    && node.dig("metadata", "labels", "kops.k8s.io/instancegroup") == WORKER_NODE_INSTANCEGROUP
 end
 
 def get_worker_instance_group_size


### PR DESCRIPTION
We just added an extra instancegroup so that prometheus/thanos could run on a bigger node. 

So the node recycler can't just count all worker nodes; it needs to only count the number of running worker nodes in the relevant instance group.