### PR TITLE
Taint and tolerations for Prometheus

### DIFF
--- a/kops/live-1.yaml
+++ b/kops/live-1.yaml
@@ -421,6 +421,8 @@ spec:
     owner: cloud-platform:platforms@digital.justice.gov.uk
     source-code: https://github.com/ministryofjustice/cloud-platform-infrastructure
   role: Node
+  taints:
+  - monitoring-node=true:NoSchedule
   subnets:
   - eu-west-2a
   - eu-west-2b

--- a/terraform/cloud-platform-components/prometheus.tf
+++ b/terraform/cloud-platform-components/prometheus.tf
@@ -1,13 +1,14 @@
 
 module "prometheus" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-prometheus?ref=0.0.8"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-prometheus?ref=0.0.9"
 
-  alertmanager_slack_receivers = var.alertmanager_slack_receivers
-  iam_role_nodes               = data.aws_iam_role.nodes.arn
-  pagerduty_config             = var.pagerduty_config
-  enable_ecr_exporter          = terraform.workspace == local.live_workspace ? true : false
-  enable_cloudwatch_exporter   = terraform.workspace == local.live_workspace ? true : false
-  enable_prometheus_affinity   = terraform.workspace == local.live_workspace ? true : false
+  alertmanager_slack_receivers               = var.alertmanager_slack_receivers
+  iam_role_nodes                             = data.aws_iam_role.nodes.arn
+  pagerduty_config                           = var.pagerduty_config
+  enable_ecr_exporter                        = terraform.workspace == local.live_workspace ? true : false
+  enable_cloudwatch_exporter                 = terraform.workspace == local.live_workspace ? true : false
+  enable_thanos_helm_chart                   = terraform.workspace == local.live_workspace ? true : false
+  enable_prometheus_affinity_and_tolerations = terraform.workspace == local.live_workspace ? true : false
 
   dependence_deploy = null_resource.deploy
   dependence_opa    = helm_release.open-policy-agent

--- a/terraform/cloud-platform-components/templates/kiam.yaml.tpl
+++ b/terraform/cloud-platform-components/templates/kiam.yaml.tpl
@@ -6,6 +6,12 @@ agent:
 
   gatewayTimeoutCreation: 5000ms
 
+  tolerations:
+    - key: "monitoring-node"
+      operator: "Equal"
+      value: "true"
+      effect: "NoSchedule"
+
   ## Host networking settings
   ##
   host:
@@ -51,7 +57,12 @@ server:
   ## Pod tolerations
   ## Ref https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   ##
-  tolerations: []
+  tolerations:
+    - key: "monitoring-node"
+      operator: "Equal"
+      value: "true"
+      effect: "NoSchedule"
+
   # - key: node-role.kubernetes.io/master
   #   effect: NoSchedule
 

--- a/terraform/cloud-platform/templates/kops.yaml.tpl
+++ b/terraform/cloud-platform/templates/kops.yaml.tpl
@@ -409,6 +409,8 @@ spec:
     owner: cloud-platform:platforms@digital.justice.gov.uk
     source-code: https://github.com/ministryofjustice/cloud-platform-infrastructure
   role: Node
+  taints:
+  - monitoring-node=true:NoSchedule
   subnets:
   - eu-west-2a
   - eu-west-2b


### PR DESCRIPTION
- Update the kops template to set taints for the large nodes dedicated to Prometheus, like that we ensure 
- New prometheus module version which include the following changes:
  * Variable to enable or not thanos helm chart deployment (for test cluster it is not needed it)
  * Added tolerations in a conditional way with a variable (so test cluster don't get affected) for tolerations.