### PR TITLE
Added tolerations to Thanos

### DIFF
--- a/terraform/cloud-platform-components/prometheus.tf
+++ b/terraform/cloud-platform-components/prometheus.tf
@@ -1,6 +1,6 @@
 
 module "prometheus" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-prometheus?ref=0.0.9"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-prometheus?ref=0.1.0"
 
   alertmanager_slack_receivers               = var.alertmanager_slack_receivers
   iam_role_nodes                             = data.aws_iam_role.nodes.arn


### PR DESCRIPTION
This PR push the Prometheus module one version up in order to use tolerations within the Thanos Helm Chart, specifically Thanos Store, which is consuming a lot of resources.