### PR TITLE
Remove large nodegroup access to AZ-A

### DIFF
--- a/kops/live-1.yaml
+++ b/kops/live-1.yaml
@@ -424,7 +424,6 @@ spec:
   taints:
   - monitoring-node=true:NoSchedule
   subnets:
-  - eu-west-2a
   - eu-west-2b
 
 

--- a/terraform/cloud-platform/templates/kops.yaml.tpl
+++ b/terraform/cloud-platform/templates/kops.yaml.tpl
@@ -412,7 +412,6 @@ spec:
   taints:
   - monitoring-node=true:NoSchedule
   subnets:
-  - eu-west-2a
   - eu-west-2b
 
 %{ endif }


### PR DESCRIPTION
Following up decisions taken after our meeting, this PR moves `r5.2xlarge` nodes from AZ-A to AZ-B. 