### PR TITLE
OPA terraform module in EKS components

### DIFF
--- a/terraform/cloud-platform-eks/components/main.tf
+++ b/terraform/cloud-platform-eks/components/main.tf
@@ -33,7 +33,7 @@ provider "helm" {
 ###############
 
 module "components" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-eks-components?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-eks-components?ref=0.0.8"
 
   alertmanager_slack_receivers = var.alertmanager_slack_receivers
   pagerduty_config             = var.pagerduty_config


### PR DESCRIPTION
Bumped the terraform module to the latest one, which includes the OPA terraform module. This OPA module is shared between EKS and KOPS.