### PR TITLE
Increased cloudwatch interval to 2 mins

### DIFF
--- a/terraform/cloud-platform-components/prometheus.tf
+++ b/terraform/cloud-platform-components/prometheus.tf
@@ -1,6 +1,6 @@
 
 module "prometheus" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-prometheus?ref=0.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-prometheus?ref=0.1.3"
 
   alertmanager_slack_receivers               = var.alertmanager_slack_receivers
   iam_role_nodes                             = data.aws_iam_role.nodes.arn


### PR DESCRIPTION
In order to fix the PrometheusOutOfOrderTimestamps we are trying to increase the scrape interval