### PR TITLE
Nginx as terraform module and helm chart pushed to latest

### DIFF
--- a/terraform/cloud-platform-eks/components/main.tf
+++ b/terraform/cloud-platform-eks/components/main.tf
@@ -33,7 +33,7 @@ provider "helm" {
 ###############
 
 module "components" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-eks-components?ref=0.0.9"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-eks-components?ref=0.1.0"
 
   alertmanager_slack_receivers = var.alertmanager_slack_receivers
   pagerduty_config             = var.pagerduty_config


### PR DESCRIPTION
Set up nginx as terraform module and upgrade it to the latest helm chart (1.35). 