### PR TITLE
Updating cloudwatch timeout: 60s

### DIFF
--- a/terraform/cloud-platform-components/monitoring.tf
+++ b/terraform/cloud-platform-components/monitoring.tf
@@ -1,6 +1,6 @@
 
 module "prometheus" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=0.1.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=0.1.6"
 
   alertmanager_slack_receivers               = var.alertmanager_slack_receivers
   iam_role_nodes                             = data.aws_iam_role.nodes.arn


### PR DESCRIPTION
To fix "Context Deadline Exceeded" error for cloud-watch in prometheus.