### PR TITLE
Updated cloudwatch_exporter set_timestamp to false

### DIFF
--- a/terraform/cloud-platform-components/monitoring.tf
+++ b/terraform/cloud-platform-components/monitoring.tf
@@ -1,6 +1,6 @@
 
 module "prometheus" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=0.1.6"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=0.1.7"
 
   alertmanager_slack_receivers               = var.alertmanager_slack_receivers
   iam_role_nodes                             = data.aws_iam_role.nodes.arn


### PR DESCRIPTION
For some metrics which are updated very
infrequently (such as S3/BucketSize), Prometheus
may refuse to scrape them if this is set to true. So set it to false.