### PR TITLE
Increased timeout for ingresses (otherwise they fails)

### DIFF
--- a/smoke-tests/spec/ingress_spec.rb
+++ b/smoke-tests/spec/ingress_spec.rb
@@ -31,7 +31,7 @@ describe "nginx ingress" do
       )
 
       wait_for(namespace, "ingress", "integration-test-app-ing")
-      sleep 20 # Without this, the test fails
+      sleep 30 # Without this, the test fails
     end
 
     it "returns 200 for http get" do


### PR DESCRIPTION
We are getting timeouts and we see it gets fixed only when we extend the time to 30 seconds. 