### PR TITLE
Added legacy-TLS support to nginx ingress controller

### DIFF
--- a/terraform/cloud-platform-components/nginx-ingress-acme.tf
+++ b/terraform/cloud-platform-components/nginx-ingress-acme.tf
@@ -1,6 +1,6 @@
 
 module "ingress_controllers" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=0.0.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=0.0.2"
 
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   is_live_cluster     = terraform.workspace == local.live_workspace ? true : false


### PR DESCRIPTION
In order to support IE11 to access our platform, we need to activate legacy TLS support in nginx. This is what this PR does.