### PR TITLE
Upgrade cert-manager in EKS manager cluster

### DIFF
--- a/terraform/cloud-platform-eks/components/main.tf
+++ b/terraform/cloud-platform-eks/components/main.tf
@@ -33,7 +33,7 @@ provider "helm" {
 ###############
 
 module "components" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-eks-components?ref=0.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-eks-components?ref=0.2.0"
 
   alertmanager_slack_receivers = var.alertmanager_slack_receivers
   pagerduty_config             = var.pagerduty_config


### PR DESCRIPTION
This change uses the latest cert-manager version