### PR TITLE
Fixed grafana callback URL in Auth0

### DIFF
--- a/terraform/cloud-platform-eks/main.tf
+++ b/terraform/cloud-platform-eks/main.tf
@@ -137,7 +137,7 @@ module "bastion" {
 #########
 
 module "auth0" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-auth0?ref=0.0.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-auth0?ref=0.0.2"
 
   cluster_name         = local.cluster_name
   services_base_domain = local.services_base_domain


### PR DESCRIPTION
Grafana callback URL in EKS is pointing to the wrong domain causing fail logins, this PR fixes it