### PR TITLE
New module with silenced api high latency alarm

### DIFF
--- a/terraform/cloud-platform-components/monitoring.tf
+++ b/terraform/cloud-platform-components/monitoring.tf
@@ -1,6 +1,6 @@
 
 module "prometheus" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=0.1.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=0.1.8"
 
   alertmanager_slack_receivers               = var.alertmanager_slack_receivers
   iam_role_nodes                             = data.aws_iam_role.nodes.arn


### PR DESCRIPTION
New module with silenced api high latency alarm.
Custom alarms have been created with differing trigger values and separated out specifically for ingress post api calls.  