### PR TITLE
EKS integration tests

### DIFF
--- a/create-cluster.rb
+++ b/create-cluster.rb
@@ -254,7 +254,7 @@ def run_integration_tests(cluster_name)
     "cd #{dir}",
     "bundle binstubs bundler --force --path /usr/local/bin",
     "bundle binstubs rspec-core --path /usr/local/bin",
-    "rspec --tag ~cluster:live-1 --format progress --format documentation --out #{output}"
+    "rspec --tag ~live-1 --tag ~eks-manager --format progress --format documentation --out #{output}"
   ].join("; ")
 
   run_and_output(cmd)

--- a/smoke-tests/makefile
+++ b/smoke-tests/makefile
@@ -30,7 +30,7 @@ shell:
 		-e KUBECONFIG=/app/config \
 		$(TAGGED_IMAGE) sh
 
-# Runs all tests, against whichever cluster your .kube/config points to
+# Runs all tests, against whichever kops cluster your .kube/config points to
 test:
 	docker run --rm \
 		-v $(KUBE_CONFIG):/app/config \
@@ -40,9 +40,9 @@ test:
 		-e AWS_PROFILE=$(AWS_PROFILE) \
 		-e AWS_SHARED_CREDENTIALS_FILE=/app/.aws/credentials \
 		-e KUBECONFIG=/app/config \
-		$(TAGGED_IMAGE) rspec
+		$(TAGGED_IMAGE) rspec --tag ~eks-manager
 
-# Only run tests tagged with cluster: live-1
+# Only run tests tagged with "live-1": true and NOT tagged with "eks-manager": true
 test-live-1:
 	docker run --rm \
 		-v $(KUBE_CONFIG):/app/config \
@@ -52,9 +52,9 @@ test-live-1:
 		-e AWS_PROFILE=$(AWS_PROFILE) \
 		-e AWS_SHARED_CREDENTIALS_FILE=/app/.aws/credentials \
 		-e KUBECONFIG=/app/config \
-		$(TAGGED_IMAGE) rspec --tag cluster:live-1
+		$(TAGGED_IMAGE) rspec --tag live-1 --tag ~eks-manager
 
-# Only run tests NOT tagged with cluster: live-1
+# Only run tests NOT tagged with "live-1": true and "eks-manager": true
 test-non-live-1:
 	docker run --rm \
 		-v $(KUBE_CONFIG):/app/config \
@@ -64,7 +64,19 @@ test-non-live-1:
 		-e AWS_PROFILE=$(AWS_PROFILE) \
 		-e AWS_SHARED_CREDENTIALS_FILE=/app/.aws/credentials \
 		-e KUBECONFIG=/app/config \
-		$(TAGGED_IMAGE) rspec --tag ~cluster:live-1
+		$(TAGGED_IMAGE) rspec --tag ~live-1 --tag ~eks-manager
+
+# Only run tests NOT tagged with "live-1": true and kops: true
+test-eks:
+	docker run --rm \
+		-v $(KUBE_CONFIG):/app/config \
+		-v $${PWD}/spec:/app/spec \
+		-v $${HOME}/.aws:/app/.aws \
+		-e AWS_CONFIG_FILE=/app/.aws/config \
+		-e AWS_PROFILE=$(AWS_PROFILE) \
+		-e AWS_SHARED_CREDENTIALS_FILE=/app/.aws/credentials \
+		-e KUBECONFIG=/app/config \
+		$(TAGGED_IMAGE) rspec --tag ~live-1 --tag ~kops
 
 # Only run tests tagged with speed: fast
 test-fast:

--- a/smoke-tests/spec/authorized_keys_spec.rb
+++ b/smoke-tests/spec/authorized_keys_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe "authorized_keys", cluster: "live-1", speed: "fast" do
+describe "authorized_keys", "live-1": true, speed: "fast" do
   context "authorized-keys-provider namespace should exists" do
     it "Fail if namespace doesnt exist" do
       expect(namespace_exists?("authorized-keys-provider")).to eq(true)

--- a/smoke-tests/spec/crds_spec.rb
+++ b/smoke-tests/spec/crds_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe "crds", speed: "fast" do
-  specify "expected crds" do
+  specify "expected crds in all clusters" do
     names = get_crds.map { |set| set.dig("metadata", "name") }.sort
 
     expected = [
@@ -13,10 +13,19 @@ describe "crds", speed: "fast" do
       "issuers.cert-manager.io",
       "orders.acme.cert-manager.io",
       "prometheuses.monitoring.coreos.com",
+      "podmonitors.monitoring.coreos.com",
       "prometheusrules.monitoring.coreos.com",
-      "servicemonitors.monitoring.coreos.com",
+      "servicemonitors.monitoring.coreos.com"
+    ]
+    expect(names).to include(*expected)
+  end
+
+  specify "expected crds in kops cluster", kops: true do
+    names = get_crds.map { |set| set.dig("metadata", "name") }.sort
+
+    expected = [
       "tzcronjobs.cronjobber.hidde.co"
     ]
     expect(names).to include(*expected)
   end
-end
+end   

--- a/smoke-tests/spec/crds_spec.rb
+++ b/smoke-tests/spec/crds_spec.rb
@@ -28,4 +28,4 @@ describe "crds", speed: "fast" do
     ]
     expect(names).to include(*expected)
   end
-end   
+end

--- a/smoke-tests/spec/daemonsets_spec.rb
+++ b/smoke-tests/spec/daemonsets_spec.rb
@@ -15,7 +15,7 @@ describe "daemonsets", speed: "fast" do
       "fluentd-es",
       "kiam-agent",
       "kiam-server",
-      "prometheus-operator-prometheus-node-exporter",
+      "prometheus-operator-prometheus-node-exporter"
     ]
 
     expect(names).to eq(expected)
@@ -29,8 +29,8 @@ describe "daemonsets", speed: "fast" do
       "calico-node",
       "fluentd-es",
       "kube-proxy",
-      "kube2iam", 
-      "prometheus-operator-prometheus-node-exporter",
+      "kube2iam",
+      "prometheus-operator-prometheus-node-exporter"
     ]
 
     expect(names).to eq(expected)
@@ -128,7 +128,7 @@ describe "daemonsets", speed: "fast" do
     end
   end
 
-  context "calico-kube-controllers",kops: true do
+  context "calico-kube-controllers", kops: true do
     specify "there can be only one" do
       pods = get_running_app_pods("kube-system", "calico-kube-controllers", "k8s-app")
       expect(pods.size).to eq(1)

--- a/smoke-tests/spec/docker_registry_cache_spec.rb
+++ b/smoke-tests/spec/docker_registry_cache_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe "docker-registry-cache" do
+describe "docker-registry-cache",kops: true do
   let(:namespace) { "docker-registry-cache" }
 
   context "pod" do

--- a/smoke-tests/spec/docker_registry_cache_spec.rb
+++ b/smoke-tests/spec/docker_registry_cache_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe "docker-registry-cache",kops: true do
+describe "docker-registry-cache", kops: true do
   let(:namespace) { "docker-registry-cache" }
 
   context "pod" do

--- a/smoke-tests/spec/external_dns_spec.rb
+++ b/smoke-tests/spec/external_dns_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 # This test can only be ran against live-1. Test clusters do not have enough privileges.
-describe "external DNS", cluster: "live-1" do
+describe "external DNS", "live-1": true do
   namespace = "integrationtest-dns-#{readable_timestamp}"
   zone = nil
   parent_zone = nil

--- a/smoke-tests/spec/kiam_spec.rb
+++ b/smoke-tests/spec/kiam_spec.rb
@@ -16,7 +16,7 @@ describe "kiam", kops: true do
     role_name: KIAM_ROLE_NAME,
     account_id: AWS[:account_id],
     aws_region: AWS[:region],
-    kubernetes_cluster: current_cluster,
+    kubernetes_cluster: current_cluster
   }
 
   pod = "" # name of the running pod in our test namespace
@@ -31,7 +31,7 @@ describe "kiam", kops: true do
       namespace: namespace,
       pod: pod,
       role_arn: role.arn,
-      pod_annotations: pod_annotations,
+      pod_annotations: pod_annotations
     }
   }
 

--- a/smoke-tests/spec/kiam_spec.rb
+++ b/smoke-tests/spec/kiam_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 # Kiam will enable code running in the cluster to assume an AWS role if
 # both the pod and the namespace are annotated appropriately.
-describe "kiam" do
+describe "kiam", kops: true do
   KIAM_ROLE_NAME = "integration-test-kiam-iam-role"
 
   # Do not use a dynamically-generated role_name here. This test

--- a/smoke-tests/spec/logging_spec.rb
+++ b/smoke-tests/spec/logging_spec.rb
@@ -32,7 +32,7 @@ describe "Log collection", "live-1": true do
     # this job queries elasticsearch, looking for all log data for our namespace, today
     create_job(namespace, "spec/fixtures/logging-job.yaml.erb", {
       job_name: "smoketest-logging-job",
-      search_url: search_url,
+      search_url: search_url
     })
 
     pod = get_pod_matching_name(namespace, "smoketest-logging-job")

--- a/smoke-tests/spec/logging_spec.rb
+++ b/smoke-tests/spec/logging_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 # Use the cluster: 'live-1' tag to identify tests which can only run against the live-1 cluster
 # (in this case, because that's the only place where elasticsearch is set up with these values)
-describe "Log collection", cluster: "live-1" do
+describe "Log collection", "live-1": true do
   let(:namespace) { "smoketest-logging-#{readable_timestamp}" }
 
   ELASTIC_SEARCH = "https://search-cloud-platform-live-dibidbfud3uww3lpxnhj2jdws4.eu-west-2.es.amazonaws.com"

--- a/smoke-tests/spec/master_nodes_spec.rb
+++ b/smoke-tests/spec/master_nodes_spec.rb
@@ -19,7 +19,7 @@ describe "master nodes", speed: "fast", kops: true do
     node_pods.map { |p|
       [
         p.dig("metadata", "namespace"),
-        shorten_pod_name(p.dig("metadata", "name"), node_name),
+        shorten_pod_name(p.dig("metadata", "name"), node_name)
       ]
     } .sort
   end
@@ -47,7 +47,7 @@ describe "master nodes", speed: "fast", kops: true do
       ["kube-system", "kube-proxy"],
       ["kube-system", "kube-scheduler"],
       ["logging", "fluentd-es"],
-      ["monitoring", "prometheus-operator-prometheus-node-exporter"],
+      ["monitoring", "prometheus-operator-prometheus-node-exporter"]
     ]
 
     masters.each do |node|

--- a/smoke-tests/spec/master_nodes_spec.rb
+++ b/smoke-tests/spec/master_nodes_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe "master nodes", speed: "fast" do
+describe "master nodes", speed: "fast", kops: true do
   # normalise pod names for ease of comparison, e.g.
   #
   #   calico-node-mv48v -> calico-node

--- a/smoke-tests/spec/namespace_annotations_spec.rb
+++ b/smoke-tests/spec/namespace_annotations_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe "namespaces", cluster: "live-1", speed: "fast" do
+describe "namespaces", "live-1": true, speed: "fast" do
   # Monitoring is automatically set up for all namespaces which have specific
   # annotations. So, if any namespaces don't have any, it's a problem.
   specify "must have annotations" do

--- a/smoke-tests/spec/prometheusrules_spec.rb
+++ b/smoke-tests/spec/prometheusrules_spec.rb
@@ -7,10 +7,8 @@ describe "Prometheus Rules", speed: "fast" do
     expected = [
       "prometheus-operator-alertmanager.rules",
       "prometheus-operator-custom-kubernetes-apps.rules",
-      "prometheus-operator-etcd",
       "prometheus-operator-k8s.rules",
       "prometheus-operator-kube-apiserver.rules",
-      "prometheus-operator-kube-scheduler.rules",
       "prometheus-operator-kubernetes-absent",
       "prometheus-operator-kubernetes-resources",
       "prometheus-operator-kubernetes-storage",
@@ -18,19 +16,39 @@ describe "Prometheus Rules", speed: "fast" do
       "prometheus-operator-node.rules",
       "prometheus-operator-prometheus-operator",
       "prometheus-operator-prometheus",
-      "prometheus-operator-kube-apiserver-error",
-      "prometheus-operator-kubernetes-system-scheduler",
       "prometheus-operator-node-exporter.rules",
-      "prometheus-operator-kubernetes-system-controller-manager",
       "prometheus-operator-kubernetes-system-apiserver",
       "prometheus-operator-kubernetes-system-kubelet",
       "prometheus-operator-node-exporter",
-      "fluentd-es"
+      "fluentd-es",
+      "certificate-expiry"
     ]
     expect(names).to include(*expected)
   end
 
-  specify "in production", cluster: "live-1" do
+  specify "expected in kops clusters", kops: true do
+    names = get_prometheus_rules.map { |set| set.dig("metadata", "name") }.sort
+
+    expected = [
+      "prometheus-operator-etcd",
+      "prometheus-operator-kube-apiserver-error",
+      "prometheus-operator-kube-scheduler.rules",
+      "prometheus-operator-kubernetes-system-controller-manager",
+      "prometheus-operator-kubernetes-system-scheduler"
+    ]
+    expect(names).to include(*expected)
+  end
+
+  specify "expected in eks", "eks-manager": true do
+    names = get_prometheus_rules.map { |set| set.dig("metadata", "name") }.sort
+
+    expected = [
+      "prometheus-operator-kubernetes-apps"
+    ]
+    expect(names).to include(*expected)
+  end
+
+  specify "in production", "live-1": true do
     names = get_prometheus_rules.map { |set| set.dig("metadata", "name") }.sort
 
     expected = [

--- a/smoke-tests/spec/servicemonitors_spec.rb
+++ b/smoke-tests/spec/servicemonitors_spec.rb
@@ -1,22 +1,30 @@
 require "spec_helper"
 
 describe "servicemonitors", speed: "fast" do
-  specify "expected prometheus servicemonitors" do
+  specify "expected prometheus servicemonitors in all clusters" do
     names = get_servicemonitors("monitoring").map { |set| set.dig("metadata", "name") }.sort
 
     expected = [
       "prometheus-operator-alertmanager",
       "prometheus-operator-apiserver",
       "prometheus-operator-grafana",
-      "prometheus-operator-kube-controller-manager",
-      "prometheus-operator-kube-dns",
-      "prometheus-operator-kube-etcd",
-      "prometheus-operator-kube-scheduler",
       "prometheus-operator-kube-state-metrics",
       "prometheus-operator-kubelet",
       "prometheus-operator-node-exporter",
       "prometheus-operator-operator",
       "prometheus-operator-prometheus",
+    ]
+    expect(names).to include(*expected)
+  end
+
+  specify "expected prometheus servicemonitors in kops clusters", kops: true do
+    names = get_servicemonitors("monitoring").map { |set| set.dig("metadata", "name") }.sort
+
+    expected = [
+      "prometheus-operator-kube-controller-manager",
+      "prometheus-operator-kube-dns",
+      "prometheus-operator-kube-etcd",
+      "prometheus-operator-kube-scheduler"
     ]
     expect(names).to include(*expected)
   end
@@ -30,7 +38,7 @@ describe "servicemonitors", speed: "fast" do
     expect(names).to eq(expected)
   end
 
-  specify "expected ECR and CloudWatch servicemonitors", cluster: "live-1" do
+  specify "expected ECR and CloudWatch servicemonitors", "live-1": true do
     names = get_servicemonitors("monitoring").map { |set| set.dig("metadata", "name") }.sort
 
     expected = [
@@ -40,7 +48,7 @@ describe "servicemonitors", speed: "fast" do
     expect(names).to include(*expected)
   end
 
-  specify "expected velero servicemonitors" do
+  specify "expected velero servicemonitors",kops: true do
     names = get_servicemonitors("velero").map { |set| set.dig("metadata", "name") }.sort
 
     expected = [

--- a/smoke-tests/spec/servicemonitors_spec.rb
+++ b/smoke-tests/spec/servicemonitors_spec.rb
@@ -12,7 +12,7 @@ describe "servicemonitors", speed: "fast" do
       "prometheus-operator-kubelet",
       "prometheus-operator-node-exporter",
       "prometheus-operator-operator",
-      "prometheus-operator-prometheus",
+      "prometheus-operator-prometheus"
     ]
     expect(names).to include(*expected)
   end
@@ -33,7 +33,7 @@ describe "servicemonitors", speed: "fast" do
     names = get_servicemonitors("ingress-controllers").map { |set| set.dig("metadata", "name") }.sort
 
     expected = [
-      "nginx-ingress-acme-controller",
+      "nginx-ingress-acme-controller"
     ]
     expect(names).to eq(expected)
   end
@@ -43,16 +43,16 @@ describe "servicemonitors", speed: "fast" do
 
     expected = [
       "ecr-exporter-prometheus-ecr-exporter",
-      "cloudwatch-exporter-prometheus-cloudwatch-exporter",
+      "cloudwatch-exporter-prometheus-cloudwatch-exporter"
     ]
     expect(names).to include(*expected)
   end
 
-  specify "expected velero servicemonitors",kops: true do
+  specify "expected velero servicemonitors", kops: true do
     names = get_servicemonitors("velero").map { |set| set.dig("metadata", "name") }.sort
 
     expected = [
-      "velero",
+      "velero"
     ]
     expect(names).to eq(expected)
   end

--- a/smoke-tests/spec/tzcronjob_spec.rb
+++ b/smoke-tests/spec/tzcronjob_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 # This test fails on test clusters, but we don't know why
 # https://github.com/ministryofjustice/cloud-platform/issues/1618
-xdescribe "tzcronjobs", cluster: "live-1" do
+xdescribe "tzcronjobs", "live-1": true do
   let(:namespace) { "integrationtest-tzcronjob-#{readable_timestamp}" }
   let(:job_name) { "tzcronjob-integrationtest" }
 


### PR DESCRIPTION
This is for EKS integration tests.    

Updated rspec tag cluster: live-1 to live-1: true, and create new tag for kops: true and eks-manager: true. New tags can be used to differentiate tests to run on kops cluster and EKS cluster.   

Updated create-cluster.rb to exclude eks tests

Update makefile to use new tags.
    The --tag ~eks-manager will exclude eks tests, running on kops clusters.
    The --tag ~kops will exclude kops specific tests, running on eks clusters.

