### PR TITLE
Fixed EKS cluster creation. 

### DIFF
--- a/terraform/cloud-platform-eks/components/main.tf
+++ b/terraform/cloud-platform-eks/components/main.tf
@@ -33,7 +33,7 @@ provider "helm" {
 ###############
 
 module "components" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-eks-components?ref=0.2.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-eks-components?ref=0.2.1"
 
   alertmanager_slack_receivers = var.alertmanager_slack_receivers
   pagerduty_config             = var.pagerduty_config


### PR DESCRIPTION
The cluster creation was failing because of missing Prometheus dependencies. Below the error.

```
  on .terraform/modules/components.cert_manager/irsa.tf line 14, in resource "aws_iam_policy" "cert_manager":
  14: resource "aws_iam_policy" "cert_manager" {
Error: rpc error: code = Unknown desc = validation failed: unable to recognize "": no matches for kind "ServiceMonitor" in version "monitoring.coreos.com/v1"
  on .terraform/modules/components.cert_manager/main.tf line 49, in resource "helm_release" "cert_manager":
  49: resource "helm_release" "cert_manager" {
```