### PR TITLE
Eks kiam tests

### DIFF
--- a/smoke-tests/spec/ingress_spec.rb
+++ b/smoke-tests/spec/ingress_spec.rb
@@ -31,7 +31,7 @@ describe "nginx ingress" do
       )
 
       wait_for(namespace, "ingress", "integration-test-app-ing")
-      sleep 30 # Without this, the test fails
+      sleep 60 # Without this, the test fails
     end
 
     it "returns 200 for http get" do

--- a/smoke-tests/spec/kiam_spec.rb
+++ b/smoke-tests/spec/kiam_spec.rb
@@ -20,9 +20,12 @@ describe "kiam", kops: true do
   }
 
   pod = "" # name of the running pod in our test namespace
+  role = ""
 
   # we want to use the same role every time, so we're not going to clean this up
-  role = fetch_or_create_role(role_args)
+  before(:all, :kops => true) do
+    role = fetch_or_create_role(role_args)
+  end
 
   let(:namespace) { "integrationtest-kiam-#{random_string}-#{readable_timestamp}" }
 
@@ -44,7 +47,7 @@ describe "kiam", kops: true do
     delete_namespace(namespace)
   end
 
-  after(:all) do
+  after(:all, :kops => true) do
     remove_cluster_nodes_from_trust_relationship(role_args, role)
   end
 

--- a/smoke-tests/spec/kiam_spec.rb
+++ b/smoke-tests/spec/kiam_spec.rb
@@ -23,7 +23,7 @@ describe "kiam", kops: true do
   role = ""
 
   # we want to use the same role every time, so we're not going to clean this up
-  before(:all, :kops => true) do
+  before(:all, kops: true) do
     role = fetch_or_create_role(role_args)
   end
 
@@ -47,7 +47,7 @@ describe "kiam", kops: true do
     delete_namespace(namespace)
   end
 
-  after(:all, :kops => true) do
+  after(:all, kops: true) do
     remove_cluster_nodes_from_trust_relationship(role_args, role)
   end
 

--- a/smoke-tests/spec/modsec_spec.rb
+++ b/smoke-tests/spec/modsec_spec.rb
@@ -17,7 +17,7 @@ describe "Testing modsec" do
       binding: binding
     )
     wait_for(namespace, "ingress", ingress_name)
-    sleep 60
+    sleep 90
   end
 
   after(:all) do
@@ -45,7 +45,7 @@ describe "Testing modsec" do
   context "when modsec disabled" do
     before do
       set_modsec_ing_annotation_false(namespace, ingress_name)
-      sleep 30
+      sleep 60
     end
 
     context "when the url is benign" do


### PR DESCRIPTION
This will fix below error, by not running "fetch_or_create_role", for eks cluster tests.

 Error:
 "An error occurred while loading ./spec/kiam_spec.rb.
 Failure/Error:
 client.update_assume_role_policy(policy_document: role_policy.to_json, role_name: role_name)"

Also, Increase sleep time for ingress and mod-security tests.
As some integration test runs are failing, when ingress is deployed, it fails to returns 200 for http get.