### PR TITLE
Renamed dependence on Prometheus

### DIFF
--- a/terraform/cloud-platform-components/velero.tf
+++ b/terraform/cloud-platform-components/velero.tf
@@ -1,6 +1,7 @@
 module "velero" {
   source                = "github.com/ministryofjustice/cloud-platform-terraform-velero?ref=0.0.3"
+
   iam_role_nodes        = data.aws_iam_role.nodes.arn
-  dependence_prometheus = module.monitoring.helm_prometheus_operator_status
+  dependence_prometheus = module.prometheus.helm_prometheus_operator_status
   cluster_domain_name   = data.terraform_remote_state.cluster.outputs.cluster_domain_name
 }


### PR DESCRIPTION
The module dependence is called "Prometheus" instead of "monitoring"
