### PR TITLE
Fix Prometheus Rules eks tests

### DIFF
--- a/smoke-tests/spec/prometheusrules_spec.rb
+++ b/smoke-tests/spec/prometheusrules_spec.rb
@@ -39,15 +39,6 @@ describe "Prometheus Rules", speed: "fast" do
     expect(names).to include(*expected)
   end
 
-  specify "expected in eks", "eks-manager": true do
-    names = get_prometheus_rules.map { |set| set.dig("metadata", "name") }.sort
-
-    expected = [
-      "prometheus-operator-kubernetes-apps"
-    ]
-    expect(names).to include(*expected)
-  end
-
   specify "in production", "live-1": true do
     names = get_prometheus_rules.map { |set| set.dig("metadata", "name") }.sort
 


### PR DESCRIPTION
Removed "prometheus-operator-kubernetes-apps", not using this after prometheus module change.