### PR TITLE
Explicitly added namespaces as part of the transition to Helm 3

### DIFF
--- a/terraform/cloud-platform-components/kiam.tf
+++ b/terraform/cloud-platform-components/kiam.tf
@@ -1,3 +1,28 @@
+#############
+# Namespace #
+#############
+
+resource "kubernetes_namespace" "kiam" {
+  metadata {
+    name = "kiam"
+
+    labels = {
+      "name"                                           = "kiam"
+      "component"                                      = "kiam"
+      "cloud-platform.justice.gov.uk/environment-name" = "production"
+      "cloud-platform.justice.gov.uk/is-production"    = "true"
+    }
+
+    annotations = {
+      "cloud-platform.justice.gov.uk/application"                   = "Kubernetes kiam component"
+      "cloud-platform.justice.gov.uk/business-unit"                 = "cloud-platform"
+      "cloud-platform.justice.gov.uk/owner"                         = "Cloud Platform: platforms@digital.justice.gov.uk"
+      "cloud-platform.justice.gov.uk/source-code"                   = "https://github.com/ministryofjustice/cloud-platform-infrastructure"
+      "cloud-platform.justice.gov.uk/can-use-loadbalancer-services" = "true"
+    }
+  }
+}
+
 resource "tls_private_key" "ca" {
   algorithm   = "ECDSA"
   ecdsa_curve = "P384"
@@ -112,10 +137,11 @@ resource "null_resource" "kube_system_kiam_annotation" {
 
 resource "helm_release" "kiam" {
   name          = "kiam"
-  chart         = "stable/kiam"
-  namespace     = "kiam"
-  version       = "2.4.0"
+  chart         = "kiam"
+  repository    = data.helm_repository.stable.metadata[0].name
+  namespace     = kubernetes_namespace.kiam.id
   recreate_pods = "true"
+  version       = "2.4.0"
 
   values = [
     data.template_file.kiam.rendered,

--- a/terraform/cloud-platform-components/kiam.tf
+++ b/terraform/cloud-platform-components/kiam.tf
@@ -14,11 +14,10 @@ resource "kubernetes_namespace" "kiam" {
     }
 
     annotations = {
-      "cloud-platform.justice.gov.uk/application"                   = "Kubernetes kiam component"
-      "cloud-platform.justice.gov.uk/business-unit"                 = "cloud-platform"
-      "cloud-platform.justice.gov.uk/owner"                         = "Cloud Platform: platforms@digital.justice.gov.uk"
-      "cloud-platform.justice.gov.uk/source-code"                   = "https://github.com/ministryofjustice/cloud-platform-infrastructure"
-      "cloud-platform.justice.gov.uk/can-use-loadbalancer-services" = "true"
+      "cloud-platform.justice.gov.uk/application"   = "KIAM"
+      "cloud-platform.justice.gov.uk/business-unit" = "cloud-platform"
+      "cloud-platform.justice.gov.uk/owner"         = "Cloud Platform: platforms@digital.justice.gov.uk"
+      "cloud-platform.justice.gov.uk/source-code"   = "https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/cloud-platform-components/kiam.tf"
     }
   }
 }

--- a/terraform/cloud-platform-components/kuberos.tf
+++ b/terraform/cloud-platform-components/kuberos.tf
@@ -1,6 +1,31 @@
+#############
+# Namespace #
+#############
+
+resource "kubernetes_namespace" "kuberos" {
+  metadata {
+    name = "kuberos"
+
+    labels = {
+      "name"                                           = "kuberos"
+      "component"                                      = "kuberos"
+      "cloud-platform.justice.gov.uk/environment-name" = "production"
+      "cloud-platform.justice.gov.uk/is-production"    = "true"
+    }
+
+    annotations = {
+      "cloud-platform.justice.gov.uk/application"                   = "Kubernetes kuberos component"
+      "cloud-platform.justice.gov.uk/business-unit"                 = "cloud-platform"
+      "cloud-platform.justice.gov.uk/owner"                         = "Cloud Platform: platforms@digital.justice.gov.uk"
+      "cloud-platform.justice.gov.uk/source-code"                   = "https://github.com/ministryofjustice/cloud-platform-infrastructure"
+      "cloud-platform.justice.gov.uk/can-use-loadbalancer-services" = "true"
+    }
+  }
+}
+
 resource "helm_release" "kuberos" {
   name          = "kuberos"
-  namespace     = "kuberos"
+  namespace     = kubernetes_namespace.kuberos.id
   chart         = "kuberos"
   repository    = data.helm_repository.cloud_platform.metadata[0].name
   recreate_pods = true

--- a/terraform/cloud-platform-components/kuberos.tf
+++ b/terraform/cloud-platform-components/kuberos.tf
@@ -8,17 +8,15 @@ resource "kubernetes_namespace" "kuberos" {
 
     labels = {
       "name"                                           = "kuberos"
-      "component"                                      = "kuberos"
       "cloud-platform.justice.gov.uk/environment-name" = "production"
       "cloud-platform.justice.gov.uk/is-production"    = "true"
     }
 
     annotations = {
-      "cloud-platform.justice.gov.uk/application"                   = "Kubernetes kuberos component"
-      "cloud-platform.justice.gov.uk/business-unit"                 = "cloud-platform"
-      "cloud-platform.justice.gov.uk/owner"                         = "Cloud Platform: platforms@digital.justice.gov.uk"
-      "cloud-platform.justice.gov.uk/source-code"                   = "https://github.com/ministryofjustice/cloud-platform-infrastructure"
-      "cloud-platform.justice.gov.uk/can-use-loadbalancer-services" = "true"
+      "cloud-platform.justice.gov.uk/application"   = "Kuberos"
+      "cloud-platform.justice.gov.uk/business-unit" = "cloud-platform"
+      "cloud-platform.justice.gov.uk/owner"         = "Cloud Platform: platforms@digital.justice.gov.uk"
+      "cloud-platform.justice.gov.uk/source-code"   = "https://github.com/ministryofjustice/kuberos"
     }
   }
 }

--- a/terraform/cloud-platform-components/main.tf
+++ b/terraform/cloud-platform-components/main.tf
@@ -69,6 +69,12 @@ data "helm_repository" "cloud_platform" {
   url  = "https://ministryofjustice.github.io/cloud-platform-helm-charts"
 }
 
+# Stable Helm Chart repository
+data "helm_repository" "stable" {
+  name = "stable"
+  url  = "https://kubernetes-charts.storage.googleapis.com"
+}
+
 provider "aws" {
   alias   = "dsd"
   profile = "moj-dsd"

--- a/terraform/cloud-platform-components/opa.tf
+++ b/terraform/cloud-platform-components/opa.tf
@@ -1,6 +1,7 @@
 
 module "opa" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-opa?ref=0.0.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-opa?ref=0.0.2"
+
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   # boolean expression for applying opa valid hostname for test clusters only.
   enable_invalid_hostname_policy = terraform.workspace == local.live_workspace ? false : true


### PR DESCRIPTION
Helm 3 [doesn't create namespaces](https://itnext.io/breaking-changes-in-helm-3-and-how-to-fix-them-39fea23e06ff) and helm terraform provider does [not assume stable repo anymore](https://github.com/terraform-providers/terraform-provider-helm/issues/163)

These changes are required as part of the transition to Helm 3.