### PR TITLE
Bump EKS components version to 0.3.3

### DIFF
--- a/terraform/cloud-platform-eks/components/main.tf
+++ b/terraform/cloud-platform-eks/components/main.tf
@@ -33,7 +33,7 @@ provider "helm" {
 ###############
 
 module "components" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-eks-components?ref=0.3.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-eks-components?ref=0.3.3"
 
   alertmanager_slack_receivers = var.alertmanager_slack_receivers
   pagerduty_config             = var.pagerduty_config


### PR DESCRIPTION
This release contains the external-dns module call