### PR TITLE
Use the latest logging module

### DIFF
--- a/terraform/cloud-platform-components/logging.tf
+++ b/terraform/cloud-platform-components/logging.tf
@@ -1,6 +1,6 @@
 
 module "logging" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-logging?ref=0.0.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-logging?ref=0.0.3"
 
   # if you need to connect to the test elasticsearch cluster, replace "placeholder-elasticsearch" with "search-cloud-platform-test-zradqd7twglkaydvgwhpuypzy4.eu-west-2.es.amazonaws.com"
   # -> value = "${replace(terraform.workspace, "live", "") != terraform.workspace ? "search-cloud-platform-live-dibidbfud3uww3lpxnhj2jdws4.eu-west-2.es.amazonaws.com" : "search-cloud-platform-test-zradqd7twglkaydvgwhpuypzy4.eu-west-2.es.amazonaws.com"


### PR DESCRIPTION
In the new release of the logging module, the _fluentd_ pods are given more CPU resource. 

This should prevent the pods from running out of CPU, on the master nodes.