### PR TITLE
Fixed externalDNS in manager cluster

### DIFF
--- a/terraform/cloud-platform-eks/components/main.tf
+++ b/terraform/cloud-platform-eks/components/main.tf
@@ -33,7 +33,7 @@ provider "helm" {
 ###############
 
 module "components" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-eks-components?ref=0.3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-eks-components?ref=0.3.5"
 
   alertmanager_slack_receivers = var.alertmanager_slack_receivers
   pagerduty_config             = var.pagerduty_config


### PR DESCRIPTION
More details about this change in the externalDNS repository: https://github.com/ministryofjustice/cloud-platform-terraform-external-dns/pull/4

Basically it was added the right annotations within the ServiceAccount for EKS be able to link the IAM role to the ServiceAccount