### PR TITLE
components pointing to the latest monitoring tf module

### DIFF
--- a/terraform/cloud-platform-components/monitoring.tf
+++ b/terraform/cloud-platform-components/monitoring.tf
@@ -1,6 +1,6 @@
 
 module "prometheus" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=0.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=0.2.3"
 
   alertmanager_slack_receivers               = var.alertmanager_slack_receivers
   iam_role_nodes                             = data.aws_iam_role.nodes.arn


### PR DESCRIPTION
This module update silence aggregateAPI alarm. More information in https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/pull/27