### PR TITLE
Helm 3 and migration of EKS components to infrastructure

### DIFF
--- a/terraform/cloud-platform-eks/components/components.tf
+++ b/terraform/cloud-platform-eks/components/components.tf
@@ -1,0 +1,98 @@
+
+module "cert_manager" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-certmanager?ref=0.0.3"
+
+  iam_role_nodes      = data.aws_iam_role.nodes.arn
+  cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
+  hostzone            = lookup(var.cluster_r53_resource_maps, terraform.workspace, ["arn:aws:route53:::hostedzone/${data.aws_route53_zone.selected.zone_id}"])
+
+  # This module requires helm and OPA already deployed
+  dependence_prometheus = module.monitoring.helm_prometheus_operator_status
+  dependence_deploy     = "null_resource.deploy"
+  dependence_opa        = module.opa.helm_opa_status
+
+  # This section is for EKS
+  eks                         = true
+  eks_cluster_oidc_issuer_url = data.terraform_remote_state.cluster.outputs.cluster_oidc_issuer_url
+}
+
+module "external_dns" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-external-dns?ref=1.0.3"
+
+  iam_role_nodes      = data.aws_iam_role.nodes.arn
+  cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
+  hostzone            = lookup(var.cluster_r53_resource_maps, terraform.workspace, ["arn:aws:route53:::hostedzone/${data.aws_route53_zone.selected.zone_id}"])
+
+  # EKS doesn't use KIAM but it is a requirement for the module.
+  dependence_kiam   = ""
+  dependence_deploy = "null_resource.deploy"
+
+  # This section is for EKS
+  eks                         = true
+  eks_cluster_oidc_issuer_url = data.terraform_remote_state.cluster.outputs.cluster_oidc_issuer_url
+}
+
+module "ingress_controllers" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=0.0.3"
+
+  cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
+  is_live_cluster     = false
+
+  # This module requires helm and OPA already deployed
+  dependence_prometheus  = module.monitoring.helm_prometheus_operator_status
+  dependence_deploy      = "null_resource.deploy"
+  dependence_opa         = module.opa.helm_opa_status
+  dependence_certmanager = module.cert_manager.helm_cert_manager_status
+}
+
+module "logging" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-logging?ref=0.0.3"
+
+  elasticsearch_host       = lookup(var.elasticsearch_hosts_maps, terraform.workspace, "placeholder-elasticsearch")
+  elasticsearch_audit_host = lookup(var.elasticsearch_audit_hosts_maps, terraform.workspace, "placeholder-elasticsearch")
+
+  dependence_prometheus       = module.monitoring.helm_prometheus_operator_status
+  dependence_deploy           = "null_resource.deploy"
+  dependence_priority_classes = kubernetes_priority_class.cluster_critical
+}
+
+module "monitoring" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=0.2.2"
+
+  alertmanager_slack_receivers = var.alertmanager_slack_receivers
+  iam_role_nodes               = data.aws_iam_role.nodes.arn
+  pagerduty_config             = var.pagerduty_config
+
+  cluster_domain_name           = data.terraform_remote_state.cluster.outputs.cluster_domain_name
+  oidc_components_client_id     = data.terraform_remote_state.cluster.outputs.oidc_components_client_id
+  oidc_components_client_secret = data.terraform_remote_state.cluster.outputs.oidc_components_client_secret
+  oidc_issuer_url               = data.terraform_remote_state.cluster.outputs.oidc_issuer_url
+
+  dependence_deploy = "null_resource.deploy"
+  dependence_opa    = module.opa.helm_opa_status
+
+  # This section is for EKS
+  eks                         = true
+  eks_cluster_oidc_issuer_url = data.terraform_remote_state.cluster.outputs.cluster_oidc_issuer_url
+}
+
+module "opa" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-opa?ref=0.0.2"
+
+  cluster_domain_name            = data.terraform_remote_state.cluster.outputs.cluster_domain_name
+  enable_invalid_hostname_policy = terraform.workspace == local.live_workspace ? false : true
+  dependence_deploy              = "null_resource.deploy"
+}
+
+module "velero" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-velero?ref=0.0.3"
+
+  iam_role_nodes        = data.aws_iam_role.nodes.arn
+  dependence_prometheus = module.monitoring.helm_prometheus_operator_status
+  cluster_domain_name   = data.terraform_remote_state.cluster.outputs.cluster_domain_name
+
+  # This section is for EKS
+  eks                         = true
+  eks_cluster_oidc_issuer_url = data.terraform_remote_state.cluster.outputs.cluster_oidc_issuer_url
+}
+

--- a/terraform/cloud-platform-eks/components/components.tf
+++ b/terraform/cloud-platform-eks/components/components.tf
@@ -1,6 +1,6 @@
 
 module "cert_manager" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-certmanager?ref=0.0.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-certmanager?ref=0.0.5"
 
   iam_role_nodes      = data.aws_iam_role.nodes.arn
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
@@ -17,7 +17,7 @@ module "cert_manager" {
 }
 
 module "cluster_autoscaler" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-cluster-autoscaler?ref=0.0.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-cluster-autoscaler?ref=0.0.3"
 
   cluster_domain_name         = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   eks_cluster_id              = data.terraform_remote_state.cluster.outputs.cluster_id
@@ -25,7 +25,7 @@ module "cluster_autoscaler" {
 }
 
 module "external_dns" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-external-dns?ref=1.0.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-external-dns?ref=1.0.4"
 
   iam_role_nodes      = data.aws_iam_role.nodes.arn
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
@@ -65,7 +65,7 @@ module "logging" {
 }
 
 module "monitoring" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=0.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=0.3.1"
 
   alertmanager_slack_receivers = var.alertmanager_slack_receivers
   iam_role_nodes               = data.aws_iam_role.nodes.arn
@@ -93,7 +93,7 @@ module "opa" {
 }
 
 module "velero" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-velero?ref=0.0.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-velero?ref=0.0.4"
 
   iam_role_nodes        = data.aws_iam_role.nodes.arn
   dependence_prometheus = module.monitoring.helm_prometheus_operator_status

--- a/terraform/cloud-platform-eks/components/components.tf
+++ b/terraform/cloud-platform-eks/components/components.tf
@@ -17,7 +17,7 @@ module "cert_manager" {
 }
 
 module "cluster_autoscaler" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-cluster-autoscaler?ref=0.0.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-cluster-autoscaler?ref=0.0.2"
 
   cluster_domain_name         = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   eks_cluster_id              = data.terraform_remote_state.cluster.outputs.cluster_id

--- a/terraform/cloud-platform-eks/components/components.tf
+++ b/terraform/cloud-platform-eks/components/components.tf
@@ -16,6 +16,14 @@ module "cert_manager" {
   eks_cluster_oidc_issuer_url = data.terraform_remote_state.cluster.outputs.cluster_oidc_issuer_url
 }
 
+module "cluster_autoscaler" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-cluster-autoscaler?ref=0.0.1"
+
+  cluster_domain_name         = data.terraform_remote_state.cluster.outputs.cluster_domain_name
+  eks_cluster_id              = data.terraform_remote_state.cluster.outputs.cluster_id
+  eks_cluster_oidc_issuer_url = data.terraform_remote_state.cluster.outputs.cluster_oidc_issuer_url
+}
+
 module "external_dns" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-external-dns?ref=1.0.3"
 

--- a/terraform/cloud-platform-eks/components/k8s-resources.tf
+++ b/terraform/cloud-platform-eks/components/k8s-resources.tf
@@ -1,0 +1,86 @@
+###################
+# Storage Classes #
+###################
+
+resource "kubernetes_storage_class" "storageclass" {
+
+  metadata {
+    name = "gp2-expand"
+  }
+
+  storage_provisioner    = "kubernetes.io/aws-ebs"
+  reclaim_policy         = "Delete"
+  allow_volume_expansion = "true"
+
+  parameters = {
+    type      = "gp2"
+    encrypted = "true"
+  }
+}
+
+#########################
+# Pod Security Policies #
+#########################
+
+resource "null_resource" "pod_security_policy" {
+  provisioner "local-exec" {
+    command = "kubectl create -f ${path.module}/resources/psp/pod-security-policy.yaml"
+  }
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = "kubectl delete --ignore-not-found -f ${path.module}/resources/psp/pod-security-policy.yaml"
+  }
+
+  triggers = {
+    content = filesha1("${path.module}/resources/psp/pod-security-policy.yaml")
+  }
+}
+
+####################
+# Priority Classes #
+####################
+
+resource "kubernetes_priority_class" "cluster_critical" {
+  metadata {
+    name = "cluster-critical"
+  }
+
+  value          = 999999000
+  description    = "This priority class is meant to be used as the system-cluster-critical class, outside of the kube-system namespace."
+  global_default = false
+}
+
+resource "kubernetes_priority_class" "node_critical" {
+  metadata {
+    name = "node-critical"
+  }
+
+  value          = 1000000000
+  description    = "This priority class is meant to be used as the system-node-critical class, outside of the kube-system namespace."
+  global_default = false
+}
+
+########
+# RBAC #
+########
+
+resource "kubernetes_cluster_role_binding" "webops" {
+  metadata {
+    name = "webops-cluster-admin"
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = "cluster-admin"
+  }
+
+  subject {
+    kind      = "Group"
+    name      = "github:webops"
+    api_group = "rbac.authorization.k8s.io"
+  }
+}
+
+

--- a/terraform/cloud-platform-eks/components/main.tf
+++ b/terraform/cloud-platform-eks/components/main.tf
@@ -19,23 +19,75 @@ provider "aws" {
 }
 
 provider "kubernetes" {
-  version = "~> 1.10.0"
+  version = "~> 1.11"
 }
 
+# Unfortunatly we are facing https://github.com/terraform-providers/terraform-provider-helm/issues/458 and
+# https://github.com/terraform-providers/terraform-provider-helm/issues/498 so we can't go to to higher version
 provider "helm" {
-  version         = "0.10.4"
-  service_account = "tiller"
+  version = "1.0.0"
   kubernetes {}
 }
 
-###############
-# Definitions #
-###############
+#################
+# Remote States #
+#################
 
-module "components" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-eks-components?ref=0.3.7"
+data "terraform_remote_state" "cluster" {
+  backend = "s3"
 
-  alertmanager_slack_receivers = var.alertmanager_slack_receivers
-  pagerduty_config             = var.pagerduty_config
-  cloud_platform_slack_webhook = var.cloud_platform_slack_webhook
+  config = {
+    bucket  = "cloud-platform-terraform-state"
+    region  = "eu-west-1"
+    key     = "cloud-platform-eks/${terraform.workspace}/terraform.tfstate"
+    profile = "moj-cp"
+  }
+}
+
+data "terraform_remote_state" "global" {
+  backend = "s3"
+
+  config = {
+    bucket  = "cloud-platform-terraform-state"
+    region  = "eu-west-1"
+    key     = "global-resources/terraform.tfstate"
+    profile = "moj-cp"
+  }
+}
+
+##################
+# Data Resources #
+##################
+
+data "aws_iam_role" "nodes" {
+  name = data.terraform_remote_state.cluster.outputs.eks_worker_iam_role_name
+}
+
+data "aws_route53_zone" "selected" {
+  name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
+}
+
+##########
+# Locals #
+##########
+
+locals {
+  live_workspace = "manager"
+  live_domain    = "cloud-platform.service.justice.gov.uk"
+}
+
+##########
+# Calico #
+##########
+
+resource "null_resource" "calico_deploy" {
+
+  provisioner "local-exec" {
+    command = "kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/release-1.5/config/v1.5/calico.yaml"
+  }
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = "kubectl delete -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/release-1.5/config/v1.5/calico.yaml"
+  }
 }

--- a/terraform/cloud-platform-eks/components/resources/psp/pod-security-policy.yaml
+++ b/terraform/cloud-platform-eks/components/resources/psp/pod-security-policy.yaml
@@ -1,0 +1,143 @@
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: privileged
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: "*"
+spec:
+  privileged: true
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - "*"
+  volumes:
+  - "*"
+  hostNetwork: true
+  hostPorts:
+  - min: 0
+    max: 65535
+  hostIPC: true
+  hostPID: true
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'
+---
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: restricted
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
+spec:
+  privileged: false
+  # Required to prevent escalations to root.
+  allowPrivilegeEscalation: false
+  # This is redundant with non-root + disallow privilege escalation,
+  # but we can provide it for defense in depth.
+  requiredDropCapabilities:
+    - ALL
+  # Allow core volume types.
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    # Assume that persistentVolumes set up by the cluster admin are safe to use.
+    - 'persistentVolumeClaim'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    # Require the container to run without root privileges.
+    rule: 'MustRunAsNonRoot'
+  seLinux:
+    # This policy assumes the nodes are using AppArmor rather than SELinux.
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: psp:privileged
+rules:
+- apiGroups: ['extensions']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - privileged
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: psp:restricted
+rules:
+- apiGroups: ['extensions']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - restricted
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: default:restricted
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: psp:restricted
+subjects:
+- kind: Group
+  name: system:authenticated
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: default:privileged
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: psp:privileged
+subjects:
+- kind: Group
+  name: system:serviceaccounts:cert-manager
+  apiGroup: rbac.authorization.k8s.io
+- kind: Group
+  name: system:serviceaccounts:concourse
+  apiGroup: rbac.authorization.k8s.io
+- kind: Group
+  name: system:serviceaccounts:ingress-controllers
+  apiGroup: rbac.authorization.k8s.io
+- kind: Group
+  name: system:serviceaccounts:kuberos
+  apiGroup: rbac.authorization.k8s.io
+- kind: Group
+  name: system:serviceaccounts:logging
+  apiGroup: rbac.authorization.k8s.io
+- kind: Group
+  name: system:serviceaccounts:monitoring
+  apiGroup: rbac.authorization.k8s.io
+- kind: Group
+  name: system:serviceaccounts:kiam
+  apiGroup: rbac.authorization.k8s.io
+- kind: Group
+  name: system:serviceaccounts:opa
+  apiGroup: rbac.authorization.k8s.io

--- a/terraform/cloud-platform-eks/components/variables.tf
+++ b/terraform/cloud-platform-eks/components/variables.tf
@@ -11,3 +11,27 @@ variable "cloud_platform_slack_webhook" {
   description = "Slack webhook to pass it to  script to send alerts"
 }
 
+variable "cluster_r53_resource_maps" {
+  default = {
+    manager = ["arn:aws:route53:::hostedzone/Z1OWR28V4Q2RTU", "arn:aws:route53:::hostedzone/Z5C82RHBFD2NI"]
+  }
+}
+
+variable "elasticsearch_hosts_maps" {
+  default = {
+    manager = "search-cloud-platform-live-dibidbfud3uww3lpxnhj2jdws4.eu-west-2.es.amazonaws.com"
+  }
+}
+
+variable "elasticsearch_audit_hosts_maps" {
+  default = {
+    manager = "search-cloud-platform-audit-dq5bdnjokj4yt7qozshmifug6e.eu-west-2.es.amazonaws.com"
+  }
+}
+
+variable "cluster_r53_domainfilters" {
+  default = {
+    live-1  = ["*"]
+    manager = ["manager.cloud-platform.service.justice.gov.uk.", "cloud-platform.service.justice.gov.uk."]
+  }
+}


### PR DESCRIPTION
- Migrated components from cloud-platform-terraform-eks-components to infrastructure.
- Pinned helm provider 1.0.0, which basically means Helm3