### PR TITLE
Updated components to the latest module versions

### DIFF
--- a/terraform/cloud-platform-components/cert-manager.tf
+++ b/terraform/cloud-platform-components/cert-manager.tf
@@ -1,6 +1,6 @@
 
 module "cert_manager" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-certmanager?ref=0.0.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-certmanager?ref=0.0.5"
 
   iam_role_nodes      = data.aws_iam_role.nodes.arn
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name

--- a/terraform/cloud-platform-components/external-dns.tf
+++ b/terraform/cloud-platform-components/external-dns.tf
@@ -1,5 +1,5 @@
 module "external_dns" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-external-dns?ref=1.0.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-external-dns?ref=1.0.4"
 
   iam_role_nodes      = data.aws_iam_role.nodes.arn
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name

--- a/terraform/cloud-platform-components/monitoring.tf
+++ b/terraform/cloud-platform-components/monitoring.tf
@@ -1,6 +1,6 @@
 
 module "prometheus" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=0.3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=0.3.1"
 
   alertmanager_slack_receivers               = var.alertmanager_slack_receivers
   iam_role_nodes                             = data.aws_iam_role.nodes.arn

--- a/terraform/cloud-platform-components/monitoring.tf
+++ b/terraform/cloud-platform-components/monitoring.tf
@@ -1,6 +1,6 @@
 
 module "prometheus" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=0.3.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=0.3.2"
 
   alertmanager_slack_receivers               = var.alertmanager_slack_receivers
   iam_role_nodes                             = data.aws_iam_role.nodes.arn

--- a/terraform/cloud-platform-components/velero.tf
+++ b/terraform/cloud-platform-components/velero.tf
@@ -1,5 +1,5 @@
 module "velero" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-velero?ref=0.0.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-velero?ref=0.0.4"
 
   iam_role_nodes        = data.aws_iam_role.nodes.arn
   dependence_prometheus = module.prometheus.helm_prometheus_operator_status


### PR DESCRIPTION
Updated components to the latest module versions. 

The only change affecting live-1 is the rename of the externalDNS serviceAccount from `default` to `externalDNS`