### PR TITLE
Remove grafana datasource from EKS

### DIFF
--- a/terraform/cloud-platform-eks/components/components.tf
+++ b/terraform/cloud-platform-eks/components/components.tf
@@ -65,7 +65,7 @@ module "logging" {
 }
 
 module "monitoring" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=0.3.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=0.3.2"
 
   alertmanager_slack_receivers = var.alertmanager_slack_receivers
   iam_role_nodes               = data.aws_iam_role.nodes.arn


### PR DESCRIPTION
We are using grafana datasource in EKS, it actually is causing problems with the role length. For the time being, it was removed