### PR TITLE
To run fast tests on test clusters. 

### DIFF
--- a/smoke-tests/makefile
+++ b/smoke-tests/makefile
@@ -90,3 +90,14 @@ test-fast:
 		-e KUBECONFIG=/app/config \
 		$(TAGGED_IMAGE) rspec --tag speed:fast
 
+# Only run tests tagged with speed: fast and NOT tagged with "live-1": true and "eks-manager": true
+test-fast-non-live-1:
+	docker run --rm \
+		-v $(KUBE_CONFIG):/app/config \
+		-v $${PWD}/spec:/app/spec \
+		-v $${HOME}/.aws:/app/.aws \
+		-e AWS_CONFIG_FILE=/app/.aws/config \
+		-e AWS_PROFILE=$(AWS_PROFILE) \
+		-e AWS_SHARED_CREDENTIALS_FILE=/app/.aws/credentials \
+		-e KUBECONFIG=/app/config \
+		$(TAGGED_IMAGE) rspec --tag speed:fast --tag ~live-1 --tag ~eks-manager


### PR DESCRIPTION
- Useful and easy when testing upgrade on test clusters