### PR TITLE
Upgrade APIs versions for Deployments and Ingresses in 1.16

### DIFF
--- a/smoke-tests/spec/fixtures/helloworld-deployment.yaml.erb
+++ b/smoke-tests/spec/fixtures/helloworld-deployment.yaml.erb
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: integration-test-helloworld
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: integration-test-app
   template:
     metadata:
       labels:
@@ -29,7 +32,7 @@ spec:
   selector:
     app: integration-test-app
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: integration-test-app-ing

--- a/smoke-tests/spec/fixtures/modsec-integrationtest.yaml.erb
+++ b/smoke-tests/spec/fixtures/modsec-integrationtest.yaml.erb
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: modsec-integrationtest-app
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: modsec-integrationtest-app
   template:
     metadata:
       labels:
@@ -29,7 +32,7 @@ spec:
   selector:
     app: modsec-integrationtest-app
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: modsec-integrationtest-app-ing


### PR DESCRIPTION
Since 1.16 (as you can see [here](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/)) Kubernetes 1.16 won't support `apiVersion: extensions/v1beta1` and that is exactly what we are using in our Integration tests. I'll also upgrade ingress to use `networking.k8s.io/v1beta1`