### PR TITLE
Update es version

### DIFF
--- a/smoke-tests/spec/logging_spec.rb
+++ b/smoke-tests/spec/logging_spec.rb
@@ -23,7 +23,7 @@ describe "Log collection", "live-1": true do
     # is no easy way to figure out when this has/hasn't happened. This sleep seems to work
     # consistently, but it's possible it may break unexpectedly, at some point.
 
-    sleep 120 # TODO: this is an experimental change (from 60), to see if a longer sleep fixes
+    sleep 180 # TODO: this is an experimental change (from 60), to see if a longer sleep fixes
     #       intermittent pipeline failures
 
     date = Date.today.strftime("%Y.%m.%d")

--- a/terraform/global-resources/elasticsearch.tf
+++ b/terraform/global-resources/elasticsearch.tf
@@ -79,7 +79,7 @@ data "aws_iam_policy_document" "live_1" {
 resource "aws_elasticsearch_domain" "live_1" {
   domain_name           = local.live_domain
   provider              = aws.cloud-platform
-  elasticsearch_version = "6.8"
+  elasticsearch_version = "7.4"
 
   cluster_config {
     instance_type            = "m4.2xlarge.elasticsearch"

--- a/terraform/global-resources/elasticsearch.tf
+++ b/terraform/global-resources/elasticsearch.tf
@@ -252,3 +252,24 @@ data "aws_iam_policy_document" "test" {
 #   }
 # }
 
+# This is to for manual snapshort before ES 7.4 upgrade, we will leave it for couple of weeks.
+# https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-managedomains-snapshots.html
+
+resource "aws_s3_bucket" "cp-elasticsearch" {
+  bucket   = "cloud-platform-live-elasticsearch-snapshot"
+  acl      = "private"
+  provider = aws.cloud-platform
+
+  versioning {
+    enabled = true
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
Update cloud-platform live ES version to 7.4

Created s3 bucket for snapshot before upgrading it to 7.4
https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-managedomains-snapshots.html

Also increased sleep time for ES integration test, as test is failing.