### PR TITLE
Update external-dns to chartv3.1.0

### DIFF
--- a/terraform/cloud-platform-components/external-dns.tf
+++ b/terraform/cloud-platform-components/external-dns.tf
@@ -5,7 +5,7 @@ module "external_dns" {
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   hostzone            = lookup(var.cluster_r53_resource_maps, terraform.workspace, ["arn:aws:route53:::hostedzone/${data.terraform_remote_state.cluster.outputs.hosted_zone_id}"])
 
-  dependence_kiam   = helm_release.kiam
+  dependence_kiam = helm_release.kiam
 
   # This section is for EKS
   eks = false

--- a/terraform/cloud-platform-components/external-dns.tf
+++ b/terraform/cloud-platform-components/external-dns.tf
@@ -1,11 +1,10 @@
 module "external_dns" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-external-dns?ref=1.0.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-external-dns?ref=1.1.0"
 
   iam_role_nodes      = data.aws_iam_role.nodes.arn
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   hostzone            = lookup(var.cluster_r53_resource_maps, terraform.workspace, ["arn:aws:route53:::hostedzone/${data.terraform_remote_state.cluster.outputs.hosted_zone_id}"])
 
-  dependence_deploy = "null_resource.deploy"
   dependence_kiam   = helm_release.kiam
 
   # This section is for EKS

--- a/terraform/cloud-platform-eks/components/components.tf
+++ b/terraform/cloud-platform-eks/components/components.tf
@@ -32,7 +32,7 @@ module "external_dns" {
   hostzone            = lookup(var.cluster_r53_resource_maps, terraform.workspace, ["arn:aws:route53:::hostedzone/${data.aws_route53_zone.selected.zone_id}"])
 
   # EKS doesn't use KIAM but it is a requirement for the module.
-  dependence_kiam   = ""
+  dependence_kiam = ""
 
   # This section is for EKS
   eks                         = true

--- a/terraform/cloud-platform-eks/components/components.tf
+++ b/terraform/cloud-platform-eks/components/components.tf
@@ -25,7 +25,7 @@ module "cluster_autoscaler" {
 }
 
 module "external_dns" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-external-dns?ref=1.0.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-external-dns?ref=1.1.0"
 
   iam_role_nodes      = data.aws_iam_role.nodes.arn
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
@@ -33,7 +33,6 @@ module "external_dns" {
 
   # EKS doesn't use KIAM but it is a requirement for the module.
   dependence_kiam   = ""
-  dependence_deploy = "null_resource.deploy"
 
   # This section is for EKS
   eks                         = true


### PR DESCRIPTION
external-dns stable chart is depreciated, we used Bitnami maintained ExternalDNS Helm chart.

bitnami-external-dns :
https://github.com/bitnami/charts/tree/master/bitnami/external-dns

As part of the upgrade, use policy: sync.