### PR TITLE
Removed dependence_deploy IN EKS and nginx upgrade to latest module

### DIFF
--- a/terraform/cloud-platform-eks/components/components.tf
+++ b/terraform/cloud-platform-eks/components/components.tf
@@ -72,7 +72,7 @@ module "monitoring" {
   oidc_components_client_secret = data.terraform_remote_state.cluster.outputs.oidc_components_client_secret
   oidc_issuer_url               = data.terraform_remote_state.cluster.outputs.oidc_issuer_url
 
-  dependence_opa    = module.opa.helm_opa_status
+  dependence_opa = module.opa.helm_opa_status
 
   # This section is for EKS
   eks                         = true


### PR DESCRIPTION
Nginx is not in the latest terraform module, which includes changes related with shared memory issues we faced in live-1. More information [here](https://github.com/ministryofjustice/cloud-platform-terraform-ingress-controller/pull/3)

`dependence_deploy` variable was needed when we were using Helm 2, it was the way to tell Helm Chart inside our terraform modules to wait for tiller before getting installed.

Now we are using Helm 3 and there is not tiller in the clusters.