### PR TITLE
Make `destroy-cluster.rb` non-interactive

### DIFF
--- a/destroy-cluster.rb
+++ b/destroy-cluster.rb
@@ -44,15 +44,18 @@ end
 # destroyed. So, we check for any unexpected namespaces, and abort if we find
 # any.
 def abort_if_user_namespaces_exist
-  stdout, _, _ = execute("kubectl get ns -o name | sed 's/namespace.//'")
-  namespaces = stdout.split("\n")
-  user_namespaces = namespaces - SYSTEM_NAMESPACES
   if user_namespaces.any?
     puts "\nPlease delete these namespaces, and any associated AWS resources, before destroying this cluster:"
     user_namespaces.each { |ns| puts "  * #{ns}" }
     puts
     raise
   end
+end
+
+def user_namespaces
+  stdout, _, _ = execute("kubectl get ns -o name | sed 's/namespace.//'")
+  namespaces = stdout.split("\n")
+  namespaces - SYSTEM_NAMESPACES
 end
 
 def terraform_components

--- a/destroy-cluster.rb
+++ b/destroy-cluster.rb
@@ -220,8 +220,7 @@ def parse_options
   options = {
     dry_run: true,
     cluster_name: nil,
-    vpc_name: nil,
-    destroy_vpc: true
+    destroy_vpc: true,
   }
 
   OptionParser.new { |opts|
@@ -230,7 +229,7 @@ def parse_options
     end
 
     opts.on("-v", "--vpc-name VPC-NAME", "VPC to destroy, defaults to CLUSTER-NAME") do |name|
-      options[:vpc_name] = name || options[:cluster_name]
+      options[:vpc_name] = name
     end
 
     opts.on("-d", "--dont-destroy-vpc", "Supply this flag to leave the VPC intact") do |dont_destroy_vpc|
@@ -246,6 +245,9 @@ def parse_options
       exit
     end
   }.parse!
+
+  # By default, we name our VPCs the same as the cluster
+  options[:vpc_name] ||= options[:cluster_name]
 
   options
 end

--- a/destroy-cluster.rb
+++ b/destroy-cluster.rb
@@ -26,8 +26,6 @@ SYSTEM_NAMESPACES = %w[
 require "open3"
 
 def main
-  raise "Please check the code carefully before executing this script."
-
   target_cluster
   abort_if_user_namespaces_exist
   terraform_components

--- a/destroy-cluster.rb
+++ b/destroy-cluster.rb
@@ -220,7 +220,7 @@ def parse_options
   options = {
     dry_run: true,
     cluster_name: nil,
-    destroy_vpc: true,
+    destroy_vpc: true
   }
 
   OptionParser.new { |opts|

--- a/destroy-cluster.rb
+++ b/destroy-cluster.rb
@@ -51,11 +51,11 @@ class ClusterDeleter
   private
 
   def dry_run?
-    !!(options[:dry_run])
+    !!options[:dry_run]
   end
 
   def destroy_vpc?
-    !!(options[:destroy_vpc])
+    !!options[:destroy_vpc]
   end
 
   def check_prerequisites
@@ -95,7 +95,7 @@ class ClusterDeleter
     REQUIRED_AWS_PROFILES.each do |profile|
       raise "ERROR Required AWS Profile #{profile} not found." \
         unless creds.grep(/\[#{profile}\]/).any?
-      end
+    end
   end
 
   def check_name_length
@@ -211,14 +211,13 @@ class ClusterDeleter
   end
 end
 
-
 def parse_options
   # set defaults
   options = {
     dry_run: true,
     cluster_name: nil,
     vpc_name: nil,
-    destroy_vpc: true,
+    destroy_vpc: true
   }
 
   OptionParser.new { |opts|

--- a/destroy-cluster.rb
+++ b/destroy-cluster.rb
@@ -30,169 +30,197 @@ REQUIRED_AWS_PROFILES = %w[moj-cp]
 # copied from create-cluster.rb
 MAX_CLUSTER_NAME_LENGTH = 12
 
+LIVE_CLUSTER_NAME_REXP = /live/
+
 require "open3"
 require "optparse"
+require "pry-byebug"
 
-def main(options)
-  check_prerequisites
+class ClusterDeleter
+  attr_reader :options
 
-  target_cluster
-  abort_if_user_namespaces_exist
-  terraform_components
-  kops_cluster(options)
-  terraform_base
-  terraform_workspaces
-  terraform_vpc # Un comment to destroy the VPC
-end
+  def initialize(options)
+    @options = options
+  end
 
-def check_prerequisites(options)
-  check_options(options)
-  check_env_vars
-  check_software_installed
-  check_aws_profiles
-  check_name_length(options[:cluster_name])
-end
+  def run
+    if dry_run?
+      puts "DRY-RUN: No changes will be made to the cluster"
+    end
 
-def check_options(options)
-  abort_if_live_cluster(options)
-  abort_if_vpc_name_but_no_destroy(options)
-end
+    check_prerequisites
 
-def check_prerequisites(cluster_name)
-  # TODO: check helm version is >= 2.11
-end
+    cluster_name = options.fetch(:cluster_name)
+    target_cluster(cluster_long_name(cluster_name))
 
-def check_env_vars
-  REQUIRED_ENV_VARS.each do |var|
-    value = ENV.fetch(var, "")
-    raise "ERROR Required environment variable #{var} is not set." if value.empty?
+    # TODO abort_if_user_namespaces_exist
+
+    terraform_components
+
+    kops_cluster
+    terraform_base
+    terraform_workspaces
+    # terraform_vpc if destroy_vpc? # Un comment to destroy the VPC
+  end
+
+  private
+
+  def dry_run?
+    !!(options[:dry_run])
+  end
+
+  def check_prerequisites
+    check_options
+    check_env_vars
+    check_software_installed
+    check_aws_profiles
+    check_name_length
+  end
+
+  def check_options
+    cluster_name = options[:cluster_name]
+    raise "No cluster name supplied" if cluster_name.nil?
+    raise "You may not destroy production clusters" if LIVE_CLUSTER_NAME_REXP.match(cluster_name)
+  end
+
+  def check_env_vars
+    REQUIRED_ENV_VARS.each do |var|
+      value = ENV.fetch(var, "")
+      raise "ERROR Required environment variable #{var} is not set." if value.empty?
+    end
+  end
+
+  def check_software_installed
+    REQUIRED_EXECUTABLES.each do |exe|
+      raise "ERROR Required executable #{exe} not found." unless system("which #{exe}")
+    end
+    check_terraform_auth0
+  end
+
+  def check_terraform_auth0
+    raise "ERROR Terraform auth0 provider plugin not found." \
+      unless Dir["#{ENV.fetch("HOME")}/.terraform.d/plugins/**/**"].grep(/auth0/).any?
+  end
+
+  def check_aws_profiles
+    creds = File.read("#{ENV.fetch("HOME")}/.aws/credentials").split("\n")
+    REQUIRED_AWS_PROFILES.each do |profile|
+      raise "ERROR Required AWS Profile #{profile} not found." \
+        unless creds.grep(/\[#{profile}\]/).any?
+      end
+  end
+
+  def check_name_length
+    cluster_name = options[:cluster_name]
+    l = cluster_name.length
+    raise "ERROR Cluster name #{cluster_name} too long (#{l} chars). Max. is #{MAX_CLUSTER_NAME_LENGTH}." \
+      unless l <= MAX_CLUSTER_NAME_LENGTH
+  end
+
+  def target_cluster(cluster)
+    execute("kops export kubecfg #{cluster}", true)
+  end
+
+  # If someone has deployed something into this cluster, there might be
+  # associated AWS resources which would be left orphaned if the cluster were
+  # destroyed. So, we check for any unexpected namespaces, and abort if we find
+  # any.
+  def abort_if_user_namespaces_exist
+    if user_namespaces.any?
+      puts "\nPlease delete these namespaces, and any associated AWS resources, before destroying this cluster:"
+      user_namespaces.each { |ns| puts "  * #{ns}" }
+      puts
+      raise
+    end
+  end
+
+  def user_namespaces
+    stdout, _, _ = execute("kubectl get ns -o name | sed 's/namespace.//'", true)
+    namespaces = stdout.split("\n")
+    namespaces - SYSTEM_NAMESPACES
+  end
+
+  def terraform_components
+    dir = "terraform/cloud-platform-components"
+    tf_init dir
+    tf_workspace_select(dir, CLUSTER)
+    # prometheus_operator often fails to delete cleanly if anything has
+    # happened to the open policy agent beforehand. Delete it first to
+    # avoid any issues
+    begin
+      retries ||= 0
+      puts "Retry ##{retries} to destroy prometheus due to CRDs missing and deleting prometheus resources"
+      tf_destroy(dir, "module.prometheus")
+      raise
+    rescue
+      retry if (retries += 1) < 2
+    end
+    tf_destroy(dir)
+  end
+
+  def kops_cluster
+    name = options.fetch(:cluster_name)
+    execute "kops delete cluster --name #{cluster_long_name(name)} --yes"
+  end
+
+  def terraform_base
+    dir = "terraform/cloud-platform"
+    tf_init dir
+    tf_workspace_select(dir, CLUSTER)
+    execute %(cd #{dir}; terraform destroy -var vpc_name="#{VPC_NAME}" -auto-approve)
+  end
+
+  def terraform_workspaces
+    ["terraform/cloud-platform", "terraform/cloud-platform-components"].each do |dir|
+      execute "cd #{dir}; terraform workspace select default; terraform workspace delete #{CLUSTER}"
+    end
+  end
+
+  def terraform_vpc
+    dir = "terraform/cloud-platform-network"
+    tf_init dir
+    tf_workspace_select(dir, VPC_NAME)
+    tf_destroy(dir)
+  end
+
+  def tf_init(dir)
+    execute "cd #{dir}; terraform init"
+  end
+
+  def tf_workspace_select(dir, workspace)
+    execute "cd #{dir}; terraform workspace select #{workspace}"
+  end
+
+  def tf_destroy(dir, target = nil)
+    tgt = target.nil? ? "" : "-target #{target}"
+    execute "cd #{dir}; terraform destroy #{tgt} -auto-approve"
+  end
+
+  def cluster_long_name(name)
+    "#{name}.cloud-platform.service.justice.gov.uk"
+  end
+
+  def execute(cmd, execute_in_dry_run = false)
+    if dry_run? && !execute_in_dry_run
+      puts "DRY-RUN: #{cmd}"
+      nil
+    else
+      puts "executing: #{cmd}"
+      stdout, stderr, status = Open3.capture3(cmd)
+
+      unless status.success?
+        puts "Command: #{cmd} failed."
+        puts stderr
+        raise
+      end
+
+      puts stdout
+
+      [stdout, stderr, status]
+    end
   end
 end
 
-def check_software_installed
-  REQUIRED_EXECUTABLES.each do |exe|
-    raise "ERROR Required executable #{exe} not found." unless system("which #{exe}")
-  end
-  check_terraform_auth0
-end
-
-def check_terraform_auth0
-  raise "ERROR Terraform auth0 provider plugin not found." \
-    unless Dir["#{ENV.fetch("HOME")}/.terraform.d/plugins/**/**"].grep(/auth0/).any?
-end
-
-def check_aws_profiles
-  creds = File.read("#{ENV.fetch("HOME")}/.aws/credentials").split("\n")
-  REQUIRED_AWS_PROFILES.each do |profile|
-    raise "ERROR Required AWS Profile #{profile} not found." \
-      unless creds.grep(/\[#{profile}\]/).any?
-  end
-end
-
-def check_name_length(cluster_name)
-  l = cluster_name.length
-  raise "ERROR Cluster name #{cluster_name} too long (#{l} chars). Max. is #{MAX_CLUSTER_NAME_LENGTH}." \
-    unless l <= MAX_CLUSTER_NAME_LENGTH
-end
-
-def target_cluster(cluster)
-  execute "kops export kubecfg #{cluster}"
-end
-
-# If someone has deployed something into this cluster, there might be
-# associated AWS resources which would be left orphaned if the cluster were
-# destroyed. So, we check for any unexpected namespaces, and abort if we find
-# any.
-def abort_if_user_namespaces_exist
-  if user_namespaces.any?
-    puts "\nPlease delete these namespaces, and any associated AWS resources, before destroying this cluster:"
-    user_namespaces.each { |ns| puts "  * #{ns}" }
-    puts
-    raise
-  end
-end
-
-def user_namespaces
-  stdout, _, _ = execute("kubectl get ns -o name | sed 's/namespace.//'")
-  namespaces = stdout.split("\n")
-  namespaces - SYSTEM_NAMESPACES
-end
-
-def terraform_components
-  dir = "terraform/cloud-platform-components"
-  tf_init dir
-  tf_workspace_select(dir, CLUSTER)
-  # prometheus_operator often fails to delete cleanly if anything has
-  # happened to the open policy agent beforehand. Delete it first to
-  # avoid any issues
-  begin
-    retries ||= 0
-    puts "Retry ##{retries} to destroy prometheus due to CRDs missing and deleting prometheus resources"
-    tf_destroy(dir, "module.prometheus")
-    raise
-  rescue
-    retry if (retries += 1) < 2
-  end
-  tf_destroy(dir)
-end
-
-def kops_cluster(options)
-  name = options.fetch(:cluster_name)
-  execute "kops delete cluster --name #{cluster_long_name(name)} --yes"
-end
-
-def terraform_base
-  dir = "terraform/cloud-platform"
-  tf_init dir
-  tf_workspace_select(dir, CLUSTER)
-  execute %(cd #{dir}; terraform destroy -var vpc_name="#{VPC_NAME}" -auto-approve)
-end
-
-def terraform_workspaces
-  ["terraform/cloud-platform", "terraform/cloud-platform-components"].each do |dir|
-    execute "cd #{dir}; terraform workspace select default; terraform workspace delete #{CLUSTER}"
-  end
-end
-
-def terraform_vpc
-  dir = "terraform/cloud-platform-network"
-  tf_init dir
-  tf_workspace_select(dir, VPC_NAME)
-  tf_destroy(dir)
-end
-
-def tf_init(dir)
-  execute "cd #{dir}; terraform init"
-end
-
-def tf_workspace_select(dir, workspace)
-  execute "cd #{dir}; terraform workspace select #{workspace}"
-end
-
-def tf_destroy(dir, target = nil)
-  tgt = target.nil? ? "" : "-target #{target}"
-  execute "cd #{dir}; terraform destroy #{tgt} -auto-approve"
-end
-
-def cluster_long_name(name)
-  "#{name}.cloud-platform.service.justice.gov.uk"
-end
-
-def execute(cmd)
-  puts "executing: #{cmd}"
-
-  stdout, stderr, status = Open3.capture3(cmd)
-
-  unless status.success?
-    puts "Command: #{cmd} failed."
-    puts stderr
-    raise
-  end
-
-  puts stdout
-
-  [stdout, stderr, status]
-end
 
 def parse_options
   # set defaults
@@ -216,6 +244,10 @@ def parse_options
       options[:destroy_vpc] = destroy_vpc
     end
 
+    opts.on("-y", "--yes", "Actually destroy the cluster") do |yes|
+      options[:dry_run] = !yes
+    end
+
     opts.on_tail("-h", "--help", "Show help message") do
       puts opts
       exit
@@ -228,4 +260,4 @@ end
 ############################################################
 
 options = parse_options
-main(options)
+ClusterDeleter.new(options).run


### PR DESCRIPTION
related to https://github.com/ministryofjustice/cloud-platform/issues/1926

Add command-line options for the required variables, so that the script can be invoked non-interactively, by a concourse pipeline.