### PR TITLE
Revert to terraform init, then select

### DIFF
--- a/destroy-cluster.rb
+++ b/destroy-cluster.rb
@@ -129,8 +129,8 @@ class ClusterDeleter
 
   def terraform_components
     dir = "terraform/cloud-platform-components"
-    tf_workspace_select(dir, cluster_name)
     tf_init dir
+    tf_workspace_select(dir, cluster_name)
     # prometheus_operator often fails to delete cleanly if anything has
     # happened to the open policy agent beforehand. Delete it first to
     # avoid any issues
@@ -151,8 +151,8 @@ class ClusterDeleter
 
   def terraform_base
     dir = "terraform/cloud-platform"
-    tf_workspace_select(dir, cluster_name)
     tf_init dir
+    tf_workspace_select(dir, cluster_name)
     execute %(cd #{dir}; terraform destroy -var vpc_name="#{vpc_name}" -auto-approve)
   end
 
@@ -164,8 +164,8 @@ class ClusterDeleter
 
   def terraform_vpc
     dir = "terraform/cloud-platform-network"
-    tf_workspace_select(dir, vpc_name)
     tf_init dir
+    tf_workspace_select(dir, vpc_name)
     tf_destroy(dir)
   end
 


### PR DESCRIPTION
We tried putting `terraform workspace select` before `terraform init` to
avoid the error where the user already has a workspace selected, and that
workspace no longer exists. But, this doesn't work, and you get the
error:

```
Error: Initialization required. Please see the error message above.
```

So this change reverts back to running `terraform init` first, and then
running `terraform workspace select ...`