### PR TITLE
Add kubeProxy stanza to kops manifest

### DIFF
--- a/kops/live-1.yaml
+++ b/kops/live-1.yaml
@@ -245,6 +245,8 @@ spec:
   kubeControllerManager:
     featureGates:
       TTLAfterFinished: "true"
+  kubeProxy:
+    metricsBindAddress: 0.0.0.0
   kubernetesApiAccess:
   - 0.0.0.0/0
   kubernetesVersion: 1.15.10

--- a/terraform/cloud-platform/templates/kops.yaml.tpl
+++ b/terraform/cloud-platform/templates/kops.yaml.tpl
@@ -245,6 +245,8 @@ spec:
   kubeControllerManager:
     featureGates:
       TTLAfterFinished: "true"
+  kubeProxy:
+    metricsBindAddress: 0.0.0.0
   kubernetesApiAccess:
   - 0.0.0.0/0
   kubernetesVersion: 1.15.10


### PR DESCRIPTION
This allows Prometheus to scrape the kubeProxy endpoint as outlined in https://github.com/ministryofjustice/cloud-platform/issues/1636