### PR TITLE
Upgrade grafana to 7.0.2

### DIFF
--- a/terraform/cloud-platform-components/monitoring.tf
+++ b/terraform/cloud-platform-components/monitoring.tf
@@ -1,6 +1,6 @@
 
 module "prometheus" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=0.3.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=0.3.4"
 
   alertmanager_slack_receivers               = var.alertmanager_slack_receivers
   iam_role_nodes                             = data.aws_iam_role.nodes.arn

--- a/terraform/cloud-platform-eks/components/components.tf
+++ b/terraform/cloud-platform-eks/components/components.tf
@@ -61,7 +61,7 @@ module "logging" {
 }
 
 module "monitoring" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=0.3.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=0.3.4"
 
   alertmanager_slack_receivers = var.alertmanager_slack_receivers
   iam_role_nodes               = data.aws_iam_role.nodes.arn


### PR DESCRIPTION
This is due to Grafana 7.0.2 released with important security fix

https://grafana.com/blog/2020/06/03/grafana-6.7.4-and-7.0.2-released-with-important-security-fix/?utm_source=grafana_news&utm_medium=rss