### PR TITLE
Migrated PSP to policy/v1beta1 for EKS

### DIFF
--- a/terraform/cloud-platform-eks/components/resources/psp/pod-security-policy.yaml
+++ b/terraform/cloud-platform-eks/components/resources/psp/pod-security-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: privileged
@@ -26,7 +26,7 @@ spec:
   fsGroup:
     rule: 'RunAsAny'
 ---
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: restricted


### PR DESCRIPTION
In EKS we are using already 1.16 and `extensions/v1beta1` was already removed deprecated.

This PR upgrades de PSP to `policy/v1beta1`, already tested in EKS against _ale1_ cluster.
