### PR TITLE
Add sleep to fix kiam test

### DIFF
--- a/smoke-tests/spec/kiam_helper.rb
+++ b/smoke-tests/spec/kiam_helper.rb
@@ -7,13 +7,13 @@ class KiamRole
       {
         Effect: "Allow",
         Action: [
-          "sts:AssumeRole",
+          "sts:AssumeRole"
         ],
         Resource: [
-          "*",
-        ],
-      },
-    ],
+          "*"
+        ]
+      }
+    ]
   }
 
   def initialize(args)
@@ -141,16 +141,16 @@ class KiamRole
         {
           Effect: "Allow",
           Principal: {
-            AWS: [cluster_nodes_policy_principal.to_s],
+            AWS: [cluster_nodes_policy_principal.to_s]
           },
-          Action: "sts:AssumeRole",
-        },
-      ],
+          Action: "sts:AssumeRole"
+        }
+      ]
     }
 
     role = iam.create_role(
       role_name: role_name,
-      assume_role_policy_document: node_assume_role_policy_doc.to_json,
+      assume_role_policy_document: node_assume_role_policy_doc.to_json
     )
 
     client.wait_until(:role_exists, role_name: role_name)

--- a/smoke-tests/spec/kiam_helper.rb
+++ b/smoke-tests/spec/kiam_helper.rb
@@ -30,6 +30,7 @@ class KiamRole
       ensure_cluster_nodes_are_trusted(role)
     else
       role = create_role
+      sleep 90 # waiting for role to get created.
     end
 
     assume_role_policy = fetch_or_create_policy(


### PR DESCRIPTION
Kiam tests are failing with reason "Unable to locate credentials". Added sleep for create role to fix this issue.