### PR TITLE
Update destroy-cluster.rb

### DIFF
--- a/destroy-cluster.rb
+++ b/destroy-cluster.rb
@@ -157,7 +157,7 @@ class ClusterDeleter
   end
 
   def terraform_workspaces
-    ["terraform/cloud-platform", "terraform/cloud-platform-components"].each do |dir|
+    ["terraform/cloud-platform", "terraform/cloud-platform-components", "terraform/cloud-platform-network"].each do |dir|
       execute "cd #{dir}; terraform workspace select default; terraform workspace delete #{cluster_name}"
     end
   end


### PR DESCRIPTION
Add cloud-platform-network to "def terraform_workspaces"

Work spaces are not getting deleted in terraform/cloud-platform-network. Added that in "def terraform_workspaces". This will let destroy-cluster.rb to remove workspaces under "terraform/cloud-platform-network" when it finish removing the resources. 