### PR TITLE
 Increase instance type for EKS cluster.

### DIFF
--- a/terraform/cloud-platform-eks/variables.tf
+++ b/terraform/cloud-platform-eks/variables.tf
@@ -10,6 +10,6 @@ variable "cluster_node_count" {
 
 variable "worker_node_machine_type" {
   description = "The AWS EC2 instance types to use for worker nodes"
-  default     = "m4.large"
+  default     = "m4.xlarge"
 }
 


### PR DESCRIPTION
 This is to fix CPU-High Alerts

Alert: This device's CPU usage has exceeded the threshold with a value of 95.53333333324797. Instance XXXXXX CPU usage is dangerously high