### PR TITLE
remove references to the module cluster_ssl

### DIFF
--- a/terraform/cloud-platform/main.tf
+++ b/terraform/cloud-platform/main.tf
@@ -145,12 +145,6 @@ module "cluster_dns" {
   parent_zone_id           = data.terraform_remote_state.global.outputs.cp_zone_id
 }
 
-module "cluster_ssl" {
-  source                   = "../modules/cluster_ssl"
-  cluster_base_domain_name = local.cluster_base_domain_name
-  dns_zone_id              = module.cluster_dns.cluster_dns_zone_id
-}
-
 resource "tls_private_key" "cluster" {
   algorithm = "RSA"
   rsa_bits  = "2048"

--- a/terraform/cloud-platform/outputs.tf
+++ b/terraform/cloud-platform/outputs.tf
@@ -72,7 +72,3 @@ output "oidc_components_client_secret" {
   sensitive = true
 }
 
-output "certificate_arn" {
-  value = module.cluster_ssl.apps_acm_arn
-}
-


### PR DESCRIPTION
Why:
[Delete Expired SSL Certificates#1909](https://app.zenhub.com/workspaces/cloud-platform-team-5ccb0b8a81f66118c983c189/issues/ministryofjustice/cloud-platform/1909)
Whilst investigating 2 expired ssl certificates - it was found that they had been created as AWS ACM's in the Ireland region dashboard and cli. I then found 29 in the London region - that were not in use (including 1 that had expired).
The conclusion was that these were being created in redundant code for cluster creation.



