### PR TITLE
Wildcard Certificate in manager cluster

### DIFF
--- a/terraform/cloud-platform-eks/components/components.tf
+++ b/terraform/cloud-platform-eks/components/components.tf
@@ -70,7 +70,7 @@ module "ingress_controllers" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=0.0.5"
 
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
-  is_live_cluster     = false
+  is_live_cluster     = terraform.workspace == local.live_workspace ? false : true
 
   # This module requires helm and OPA already deployed
   dependence_prometheus  = module.monitoring.helm_prometheus_operator_status


### PR DESCRIPTION
During the concourse migration as terraform module we realised the nginx default certificate in manager cluster does not include the wildcard certificate for `*.cloud-platform.service.justice.gov.uk`. So we had to add it manually in order to get a valid certificate for `concourse.cloud-platform.service.justice.gov.uk`.

This PR makes the change permanent.