### PR TITLE
Create pod security policy integration tests

### DIFF
--- a/smoke-tests/spec/fixtures/privileged-deployment.yaml.erb
+++ b/smoke-tests/spec/fixtures/privileged-deployment.yaml.erb
@@ -16,3 +16,4 @@ spec:
           imagePullPolicy: "IfNotPresent"
           ports:
             - containerPort: 5432
+

--- a/smoke-tests/spec/fixtures/privileged-deployment.yaml.erb
+++ b/smoke-tests/spec/fixtures/privileged-deployment.yaml.erb
@@ -1,10 +1,13 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: privileged-integration-test
   namespace: <%= namespace %>
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: privileged-integration-test
   template:
     metadata:
       labels:

--- a/smoke-tests/spec/fixtures/privileged-deployment.yaml.erb
+++ b/smoke-tests/spec/fixtures/privileged-deployment.yaml.erb
@@ -1,0 +1,18 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: privileged-integration-test
+  namespace: <%= namespace %>
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: privileged-integration-test
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:10.4
+          imagePullPolicy: "IfNotPresent"
+          ports:
+            - containerPort: 5432

--- a/smoke-tests/spec/fixtures/unprivileged-deployment.yaml.erb
+++ b/smoke-tests/spec/fixtures/unprivileged-deployment.yaml.erb
@@ -16,3 +16,4 @@ spec:
           imagePullPolicy: "IfNotPresent"
           ports:
             - containerPort: 5432
+

--- a/smoke-tests/spec/fixtures/unprivileged-deployment.yaml.erb
+++ b/smoke-tests/spec/fixtures/unprivileged-deployment.yaml.erb
@@ -1,0 +1,18 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: unprivileged-integration-test
+  namespace: <%= namespace %>
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: unprivileged-integration-test
+    spec:
+      containers:
+        - name: nginx
+          image: bitnami/nginx
+          imagePullPolicy: "IfNotPresent"
+          ports:
+            - containerPort: 5432

--- a/smoke-tests/spec/fixtures/unprivileged-deployment.yaml.erb
+++ b/smoke-tests/spec/fixtures/unprivileged-deployment.yaml.erb
@@ -1,10 +1,13 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: unprivileged-integration-test
   namespace: <%= namespace %>
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: unprivileged-integration-test
   template:
     metadata:
       labels:

--- a/smoke-tests/spec/kubernetes_helper.rb
+++ b/smoke-tests/spec/kubernetes_helper.rb
@@ -196,6 +196,11 @@ def get_certificates
   get_from_all_namespaces "certificate"
 end
 
+# Pod Security Policies
+def get_psp
+  get_from_all_namespaces "psp"
+end
+
 # CRD issuers.certmanager.k8s.io
 def get_issuers
   get_from_all_namespaces "issuers"

--- a/smoke-tests/spec/kubernetes_helper.rb
+++ b/smoke-tests/spec/kubernetes_helper.rb
@@ -69,24 +69,6 @@ def object_exists?(namespace, type, name)
   status.success?
 end
 
-# Creates a deplyoment using the postgres image with a privileged container.
-def create_privileged_deploy(namespace)
-  apply_template_file(
-    namespace: namespace,
-    file: "spec/fixtures/privileged-deployment.yaml.erb",
-    binding: binding
-  )
-end
-
-# Creates a deployment using the bitnami/nginx image with a unprivileged container.
-def create_unprivileged_deploy(namespace)
-  apply_template_file(
-    namespace: namespace,
-    file: "spec/fixtures/unprivileged-deployment.yaml.erb",
-    binding: binding
-  )
-end
-
 def create_job(namespace, yaml_file, args)
   job_name = args.fetch(:job_name)
   search_url = args[:search_url] # This line is necessary to make 'search_url' available via 'binding'

--- a/smoke-tests/spec/kubernetes_helper.rb
+++ b/smoke-tests/spec/kubernetes_helper.rb
@@ -69,6 +69,24 @@ def object_exists?(namespace, type, name)
   status.success?
 end
 
+# Creates a deplyoment using the postgres image with a privileged container.
+def create_privileged_deploy(namespace)
+  apply_template_file(
+    namespace: namespace,
+    file: "spec/fixtures/privileged-deployment.yaml.erb",
+    binding: binding
+  )
+end
+
+# Creates a deployment using the bitnami/nginx image with a unprivileged container.
+def create_unprivileged_deploy(namespace)
+  apply_template_file(
+    namespace: namespace,
+    file: "spec/fixtures/unprivileged-deployment.yaml.erb",
+    binding: binding
+  )
+end
+
 def create_job(namespace, yaml_file, args)
   job_name = args.fetch(:job_name)
   search_url = args[:search_url] # This line is necessary to make 'search_url' available via 'binding'
@@ -240,6 +258,10 @@ def get_servicemonitors(namespace)
   kubectl_items "get servicemonitors -n #{namespace}"
 end
 
+def delete_clusterrolebinding(name)
+  kubectl_delete "clusterrolebinding #{name}"
+end
+
 def kubectl_items(cmd)
   kubectl_get(cmd).fetch("items")
 end
@@ -247,6 +269,10 @@ end
 def kubectl_get(cmd)
   json, _, _ = execute("kubectl #{cmd} -o json")
   JSON.parse(json)
+end
+
+def kubectl_delete(cmd)
+  execute("kubectl delete #{cmd}")
 end
 
 # Set the enable-modsecurity flag to false on the ingress annotation

--- a/smoke-tests/spec/psp_spec.rb
+++ b/smoke-tests/spec/psp_spec.rb
@@ -1,13 +1,9 @@
 require "spec_helper"
 
-describe "pod security policies" do
-  PRIVILEGED_POLICY = "PodSecurityPolicy/privileged"
-  RESTRICTED_POLICY = "PodSecurityPolicy/restricted"
-
-  # let(:namespace) { "integrationtest-psp-#{random_string}-#{readable_timestamp}" }
+describe "pod security policies:" do
   # TODO: create a test to ensure priv and rest psp's exist
   # TODO: how do you create a priv namespace
-  it "has expected policies" do
+  specify "has the expected policies" do
     names = get_psp.map { |set| set.dig("metadata", "name") }.sort
 
     expected = [
@@ -17,20 +13,58 @@ describe "pod security policies" do
     ]
     expect(names).to include(*expected)
   end
-end
-  # before do
-  #   create_namespace(namespace)
-  #   create_test_psp()
-  # end
 
-  # after do
-  #   delete_namespace(namespace)
-  #   delete_test_psp()
-  # end
+    let(:namespace) { "integrationtest-psp-#{random_string}-#{readable_timestamp}" }
 
-  # context "privilege pod" do
-  #   it "cannot run inside non-privileged namespaces"
-  #   it "can run inside privileged namespaces"
+    before do
+      create_namespace(namespace)
+    end
+
+    after do
+      delete_namespace(namespace)
+    end
+
+  context "a privilege pod" do
+
+    # it "cannot run inside non-privileged namespaces"
+    it "can run inside privileged namespaces" do
+      make_namespace_privileged(namespace)
+    end
+  end
+
   # context "restricted pod" do
   #   it "can run inside privileged namespaces"
   #   it "can run inside non-privileged namespaces"
+
+
+  # Creates a clusterrolebinding between the privileged pod
+  # security policy and the namespaces default service account
+  def make_namespace_privileged(namespace)
+    json = <<~EOF
+      {
+        "apiVersion": "rbac.authorization.k8s.io/v1",
+        "kind": "ClusterRoleBinding",
+        "metadata": {
+            "name": "integration-test:#{namespace}"
+        },
+        "roleRef": {
+            "apiGroup": "rbac.authorization.k8s.io",
+            "kind": "ClusterRole",
+            "name": "psp:privileged"
+        },
+        "subjects": [
+            {
+                "apiGroup": "rbac.authorization.k8s.io",
+                "kind": "Group",
+                "name": "system:serviceaccounts:#{namespace}"
+            }
+        ]
+      }
+    EOF
+
+    jsn = JSON.parse(json).to_json
+
+    cmd = %(echo '#{jsn}' | kubectl -n #{namespace} apply -f -)
+    execute(cmd)
+  end
+end

--- a/smoke-tests/spec/psp_spec.rb
+++ b/smoke-tests/spec/psp_spec.rb
@@ -1,8 +1,14 @@
 require "spec_helper"
 
-describe "pod security policies:" do
-  # TODO: create a test to ensure priv and rest psp's exist
-  # TODO: how do you create a priv namespace
+# Pod security policies (PSP) is a cluster-level resource that
+# controls security sensitive aspects of the pod specification.
+# This spec confirms the Cloud Platform psp's are operational
+# within its cluster.
+describe "pod security policies" do
+  let(:namespace) { "integrationtest-psp-#{readable_timestamp}" }
+  let(:pods) { get_running_pods(namespace)}
+
+  # Confirms the main psp's currently exist
   specify "has the expected policies" do
     names = get_psp.map { |set| set.dig("metadata", "name") }.sort
 
@@ -14,57 +20,79 @@ describe "pod security policies:" do
     expect(names).to include(*expected)
   end
 
-    let(:namespace) { "integrationtest-psp-#{random_string}-#{readable_timestamp}" }
+
+  # Checks a privileged container i.e. something that can either run
+  # as root or esculate its privilege in someway, can only run
+  # inside select namespaces.
+  context "a privileged container" do
 
     before do
       create_namespace(namespace)
     end
 
-    after do
-      delete_namespace(namespace)
+    # after do
+    #   # delete_namespace(namespace)
+    # end
+
+    it "cannot run inside non-privileged namespaces" do
+      create_privileged_deploy(namespace)
+      expect(all_containers_running?(pods)).to eq(false)
     end
 
-  context "a privilege pod" do
-
-    # it "cannot run inside non-privileged namespaces"
     it "can run inside privileged namespaces" do
       make_namespace_privileged(namespace)
+      create_privileged_deploy(namespace)
+
+      expect(all_containers_running?(pods)).to eq(true)
+      delete_clusterrolebinding(namespace)
     end
   end
 
-  # context "restricted pod" do
-  #   it "can run inside privileged namespaces"
-  #   it "can run inside non-privileged namespaces"
+  # Checks unprivileged containers i.e. non-root user, can run
+  # anywhere.
+  context "restricted containers" do
+    it "can run inside non-privileged namespaces" do
+      create_unprivileged_deploy(namespace)
+      expect(all_containers_running?(pods)).to eq(true)
+    end
 
+    it "can run inside privileged namespaces" do
+      make_namespace_privileged(namespace)
+      create_unprivileged_deploy(namespace)
 
-  # Creates a clusterrolebinding between the privileged pod
-  # security policy and the namespaces default service account
-  def make_namespace_privileged(namespace)
-    json = <<~EOF
-      {
-        "apiVersion": "rbac.authorization.k8s.io/v1",
-        "kind": "ClusterRoleBinding",
-        "metadata": {
-            "name": "integration-test:#{namespace}"
-        },
-        "roleRef": {
-            "apiGroup": "rbac.authorization.k8s.io",
-            "kind": "ClusterRole",
-            "name": "psp:privileged"
-        },
-        "subjects": [
-            {
-                "apiGroup": "rbac.authorization.k8s.io",
-                "kind": "Group",
-                "name": "system:serviceaccounts:#{namespace}"
-            }
-        ]
-      }
-    EOF
-
-    jsn = JSON.parse(json).to_json
-
-    cmd = %(echo '#{jsn}' | kubectl -n #{namespace} apply -f -)
-    execute(cmd)
+      expect(all_containers_running?(pods)).to eq(true)
+      delete_clusterrolebinding(namespace)
+    end
   end
+end
+
+# Creates a clusterrolebinding between the privileged psp
+# and the namespaces default service account.
+def make_namespace_privileged(namespace)
+  json = <<~EOF
+    {
+      "apiVersion": "rbac.authorization.k8s.io/v1",
+      "kind": "ClusterRoleBinding",
+      "metadata": {
+          "name": "#{namespace}"
+      },
+      "roleRef": {
+          "apiGroup": "rbac.authorization.k8s.io",
+          "kind": "ClusterRole",
+          "name": "psp:privileged"
+      },
+      "subjects": [
+          {
+              "apiGroup": "rbac.authorization.k8s.io",
+              "kind": "Group",
+              "name": "system:serviceaccounts:#{namespace}"
+          }
+      ]
+    }
+  EOF
+
+  jsn = JSON.parse(json).to_json
+
+  cmd = %(echo '#{jsn}' | kubectl -n #{namespace} apply -f -)
+  execute(cmd)
 end

--- a/smoke-tests/spec/psp_spec.rb
+++ b/smoke-tests/spec/psp_spec.rb
@@ -54,7 +54,7 @@ describe "pod security policies" do
 
   # Creates an unprivileged container in a privileged and unprivileged namespace.
   # Expected behaviour, the container is able to run in both namespaces.
-  context "when a container doesn't requires privileges" do
+  context "when a container doesn't require privileges" do
     let(:deployment_file) { "spec/fixtures/unprivileged-deployment.yaml.erb" }
 
     before do

--- a/smoke-tests/spec/psp_spec.rb
+++ b/smoke-tests/spec/psp_spec.rb
@@ -1,0 +1,36 @@
+require "spec_helper"
+
+describe "pod security policies" do
+  PRIVILEGED_POLICY = "PodSecurityPolicy/privileged"
+  RESTRICTED_POLICY = "PodSecurityPolicy/restricted"
+
+  # let(:namespace) { "integrationtest-psp-#{random_string}-#{readable_timestamp}" }
+  # TODO: create a test to ensure priv and rest psp's exist
+  # TODO: how do you create a priv namespace
+  it "has expected policies" do
+    names = get_psp.map { |set| set.dig("metadata", "name") }.sort
+
+    expected = [
+      "privileged",
+      "restricted",
+      "kube-system"
+    ]
+    expect(names).to include(*expected)
+  end
+end
+  # before do
+  #   create_namespace(namespace)
+  #   create_test_psp()
+  # end
+
+  # after do
+  #   delete_namespace(namespace)
+  #   delete_test_psp()
+  # end
+
+  # context "privilege pod" do
+  #   it "cannot run inside non-privileged namespaces"
+  #   it "can run inside privileged namespaces"
+  # context "restricted pod" do
+  #   it "can run inside privileged namespaces"
+  #   it "can run inside non-privileged namespaces"


### PR DESCRIPTION
Overview
---
This PR connects to https://github.com/ministryofjustice/cloud-platform/issues/1908 and relates to the creation of integration tests for the pod security policies in a Cloud Platform cluster. The tests check the following:
- Whether the three important pod security policies exist in the cluster
- Whether a privileged and unprivileged container can run inside and privileged namespace.
- Whether a privileged container fails to run inside an unprivileged namespace.
- Whether an unprivileged container can run inside an unprivileged namespace.