### PR TITLE
Change github-actions repo to pull from main instead of master

### DIFF
--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - uses: ministryofjustice/github-actions/code-formatter@master
+      - uses: ministryofjustice/github-actions/code-formatter@main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/malformed-yaml.yml
+++ b/.github/workflows/malformed-yaml.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - uses: ministryofjustice/github-actions/malformed-yaml@master
+      - uses: ministryofjustice/github-actions/malformed-yaml@main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- ministryofjustice/github-actions has changed the default branch to main, hence use the main branch of that repo