### PR TITLE
Amend Pod Security Policy manifest API

### DIFF
--- a/smoke-tests/spec/psp_spec.rb
+++ b/smoke-tests/spec/psp_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 # controls security sensitive aspects of the pod specification.
 # This spec confirms the Cloud Platform psp's are operational
 # within its cluster.
-describe "pod security policies" do
+describe "pod security policies", kops: true do
   let(:namespace) { "integrationtest-psp-#{readable_timestamp}" }
   let(:pods) { get_running_pods(namespace)}
 

--- a/terraform/cloud-platform-components/resources/psp/pod-security-policy.yaml
+++ b/terraform/cloud-platform-components/resources/psp/pod-security-policy.yaml
@@ -1,3 +1,6 @@
+# Policy recommendation from the Kubernetes community page
+# https://kubernetes.io/docs/concepts/policy/pod-security-policy/
+# https://kubernetes.io/docs/concepts/security/pod-security-standards/
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -31,8 +34,8 @@ kind: PodSecurityPolicy
 metadata:
   name: restricted
   annotations:
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
-    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'runtime/default'
 spec:
   privileged: false
   # Required to prevent escalations to root.

--- a/terraform/cloud-platform-components/resources/psp/pod-security-policy.yaml
+++ b/terraform/cloud-platform-components/resources/psp/pod-security-policy.yaml
@@ -1,16 +1,16 @@
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: privileged
   annotations:
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: "*"
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
 spec:
   privileged: true
   allowPrivilegeEscalation: true
   allowedCapabilities:
-  - "*"
+  - '*'
   volumes:
-  - "*"
+  - '*'
   hostNetwork: true
   hostPorts:
   - min: 0
@@ -26,7 +26,7 @@ spec:
   fsGroup:
     rule: 'RunAsAny'
 ---
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: restricted


### PR DESCRIPTION
This is required for the 1.16 upgrade in the coming weeks. The PR simply changes the API versions along with some formatting and removing a deprecated annotation.