### PR TITLE
Amend API version and seccomp profile used in pod security policies

### DIFF
--- a/terraform/cloud-platform-components/resources/psp/pod-security-policy.yaml
+++ b/terraform/cloud-platform-components/resources/psp/pod-security-policy.yaml
@@ -1,16 +1,19 @@
-apiVersion: extensions/v1beta1
+# Policy recommendation from the Kubernetes community page
+# https://kubernetes.io/docs/concepts/policy/pod-security-policy/
+# https://kubernetes.io/docs/concepts/security/pod-security-standards/
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: privileged
   annotations:
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: "*"
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
 spec:
   privileged: true
   allowPrivilegeEscalation: true
   allowedCapabilities:
-  - "*"
+  - '*'
   volumes:
-  - "*"
+  - '*'
   hostNetwork: true
   hostPorts:
   - min: 0
@@ -26,13 +29,13 @@ spec:
   fsGroup:
     rule: 'RunAsAny'
 ---
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: restricted
   annotations:
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
-    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'runtime/default'
 spec:
   privileged: false
   # Required to prevent escalations to root.


### PR DESCRIPTION
The API change is part of the Kubernetes 1.16 upgrade path. The old extensions api is deprecated. The docker/default seccomp was deprecated as of 1.11. Runtime/default is now used. Docker/default is still allowed in the allowedProfileNames annotation to backport legacy apps. This document describes seccomp in more detail: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#seccomp

Tests in a 1.15.11 cluster were successful.