### PR TITLE
Update ES instance_type to m4.4xlarge.elasticsearch

### DIFF
--- a/terraform/global-resources/elasticsearch.tf
+++ b/terraform/global-resources/elasticsearch.tf
@@ -82,7 +82,7 @@ resource "aws_elasticsearch_domain" "live_1" {
   elasticsearch_version = "7.4"
 
   cluster_config {
-    instance_type            = "m4.2xlarge.elasticsearch"
+    instance_type            = "m4.4xlarge.elasticsearch"
     instance_count           = "6"
     dedicated_master_enabled = true
     dedicated_master_type    = "m4.large.elasticsearch"


### PR DESCRIPTION
Update ES instance_type to m4.4xlarge.elasticsearch

This is related to: https://github.com/ministryofjustice/cloud-platform/issues/1939