### PR TITLE
Disable the ingress spec which is failing

### DIFF
--- a/smoke-tests/spec/ingress_spec.rb
+++ b/smoke-tests/spec/ingress_spec.rb
@@ -21,7 +21,10 @@ describe "nginx ingress" do
     end
   end
 
-  context "when ingress is deployed" do
+  # TODO: This test is failing a lot of the time due to performance problems with our shared ingress.
+  # So, I'm disabling it for now. When we have fixed the underlying problem, this should be
+  # reinstated.
+  xcontext "when ingress is deployed" do
     before do
       apply_template_file(
         namespace: namespace,


### PR DESCRIPTION
This test is intermittently failing because of performance
problems with our shared ingress.

It's not telling us anything useful right now, and is encouraging
us to ignore integration test failures, so I'm disabling it until
we can fix the underlying problem.