### PR TITLE
Added Github SuperLinter

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,21 @@
+
+name: Lint Code Base
+
+on:
+  push:
+    branches-ignore:
+      - 'master'
+      - 'main'
+
+jobs:
+  build:
+    name: Lint Code Base
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+      - name: Lint Code Base
+        uses: docker://github/super-linter:v3.1.0
+        env:
+          VALIDATE_ALL_CODEBASE: false
+          DEFAULT_BRANCH: 'main'


### PR DESCRIPTION
We are testing the github super-linter and infrastructure repo sounds a good place to start with. Added `VALIDATE_ALL_CODEBASE: false` to avoid it scan our whole repository [1] and instead focus on PR code 

[1] It takes a lot of time to scan and we have **a lot** (more than 100...) of errors with markdownlint. 