### PR TITLE
Pin auth0 provider version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Cloud Platform Infrastructure
 
-[![CircleCI](https://circleci.com/gh/ministryofjustice/cloud-platform-infrastructure.svg?style=svg)](https://circleci.com/gh/ministryofjustice/cloud-platform-infrastructure)
-
 ## Introduction
 This repository will contain all that's required to create a Cloud Platform Kubernetes cluster. The majority of this repo is made up of Terraform scripts that will be actioned by a pipeline.
 

--- a/create-cluster.rb
+++ b/create-cluster.rb
@@ -234,12 +234,6 @@ def check_software_installed
   REQUIRED_EXECUTABLES.each do |exe|
     raise "ERROR Required executable #{exe} not found." unless system("which #{exe}")
   end
-  check_terraform_auth0
-end
-
-def check_terraform_auth0
-  raise "ERROR Terraform auth0 provider plugin not found." \
-    unless Dir["#{ENV.fetch("HOME")}/.terraform.d/plugins/**/**"].grep(/auth0/).any?
 end
 
 def check_aws_profiles

--- a/destroy-cluster.rb
+++ b/destroy-cluster.rb
@@ -82,12 +82,6 @@ class ClusterDeleter
     REQUIRED_EXECUTABLES.each do |exe|
       raise "ERROR Required executable #{exe} not found." unless system("which #{exe}")
     end
-    check_terraform_auth0
-  end
-
-  def check_terraform_auth0
-    raise "ERROR Terraform auth0 provider plugin not found." \
-      unless Dir["#{ENV.fetch("HOME")}/.terraform.d/plugins/**/**"].grep(/auth0/).any?
   end
 
   def check_aws_profiles

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-TOOLS_IMAGE := ministryofjustice/cloud-platform-tools:1.17
+TOOLS_IMAGE := ministryofjustice/cloud-platform-tools:1.19
 
 tools-shell:
 	docker pull $(TOOLS_IMAGE)

--- a/terraform/cloud-platform-eks/main.tf
+++ b/terraform/cloud-platform-eks/main.tf
@@ -20,7 +20,7 @@ provider "aws" {
 }
 
 provider "auth0" {
-  version = ">= 0.2.0"
+  version = "= 0.12.2"
   domain  = local.auth0_tenant_domain
 }
 

--- a/terraform/cloud-platform/main.tf
+++ b/terraform/cloud-platform/main.tf
@@ -14,16 +14,12 @@ provider "aws" {
   profile = "moj-cp"
 }
 
-#
-# See instructions here: https://github.com/ministryofjustice/kubernetes-investigations/tree/master/auth0
-#              and here: https://github.com/yieldr/terraform-provider-auth0
-#
 # The empty configuration assumes that you have the appropriate environment
 # variables exported as explained in the upstream repo and is similar to the way
 # the AWS providr credentials are handled.
 #
 provider "auth0" {
-  version = ">= 0.2.1"
+  version = "= 0.12.2"
   domain  = local.auth0_tenant_domain
 }
 


### PR DESCRIPTION
This PR connects to https://github.com/ministryofjustice/cloud-platform/issues/1990 and relates to the change in Auth0 Terraform provider. The third party provider alexkappa/terraform-provider-auth0 has recently been accepted in the Terraform Provider Developer Program. This means we can now let `terraform init` pull the provider on each run. 

It has been decided that we should pin the tested version `0.12.2` to the provider call. This PR contains the pinning of said provider along with the removal of a check method in the create/destroy cluster scripts. 

I noticed we're still referencing circleci in our README, so I decided to remove this also. 