### PR TITLE
Fixing linter

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,5 +2,4 @@
 iplist.txt filter=git-crypt diff=git-crypt
 
 # The EKS kubeconfig files
-terraform/cloud-platform-eks/files/* filter=git-crypt diff=git-crypt
 terraform/cloud-platform-eks/cluster.tf filter=git-crypt diff=git-crypt

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -14,6 +14,10 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
+      - name: Remove files before linting
+        run: | 
+          find . -iname *.tfvars -exec rm -rf {} \;
+          rm -rf terraform/cloud-platform-eks/cluster.tf 
       - name: Lint Code Base
         uses: docker://github/super-linter:v3.1.0
         env:


### PR DESCRIPTION
Added exclusions to Github Super Linter:

- Files that are encrypted (`*.tfvars`)
- `cluster.tf`
