### PR TITLE
Upgrade bastion module to latest version

### DIFF
--- a/terraform/cloud-platform/main.tf
+++ b/terraform/cloud-platform/main.tf
@@ -146,7 +146,7 @@ module "cluster_dns" {
 ###########
 
 module "bastion" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-bastion?ref=1.2.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-bastion?ref=1.3.0"
 
   vpc_name            = local.vpc
   route53_zone        = module.cluster_dns.cluster_dns_zone_name


### PR DESCRIPTION
The latest version includes authorized-keys inside the module rather than pointing to S3 bucket. 