### PR TITLE
Added back outputs because they are required by the apply pipeline

### DIFF
--- a/terraform/cloud-platform/main.tf
+++ b/terraform/cloud-platform/main.tf
@@ -55,7 +55,7 @@ locals {
 ########
 
 module "kops" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-kops?ref=0.0.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-kops?ref=0.0.3"
 
   vpc_name            = local.vpc
   cluster_domain_name = trimsuffix(local.cluster_base_domain_name, ".")

--- a/terraform/cloud-platform/outputs.tf
+++ b/terraform/cloud-platform/outputs.tf
@@ -48,3 +48,23 @@ output "oidc_components_client_secret" {
   sensitive = true
 }
 
+# This outputs are used by cloud-platform-environment repo
+output "vpc_id" {
+  value = module.kops.vpc_id
+}
+
+output "internal_subnets_ids" {
+  value = module.kops.internal_subnets_ids
+}
+
+output "external_subnets_ids" {
+  value = module.kops.external_subnets_ids
+}
+
+output "network_id" {
+  value = module.kops.network_id
+}
+
+output "network_cidr_block" {
+  value = module.kops.network_cidr_block
+}


### PR DESCRIPTION
Before I deleted some outputs thinking they were not used, later on @vijay-veeranki realised they were being used in the [concourse apply pipeline](https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/environments-terraform/jobs/apply-live-1/builds/338) so I'm adding them back.
