### PR TITLE
Fixed create cluster script

### DIFF
--- a/create-cluster.rb
+++ b/create-cluster.rb
@@ -94,9 +94,6 @@ def create_cluster_kops(cluster_name, cluster_size, vpc_name)
 
   tf_apply = [
     "terraform apply",
-    "-var master_node_machine_type=#{master_node_machine_type}",
-    "-var worker_node_machine_type=#{worker_node_machine_type}",
-    "-var enable_large_nodesgroup=false",
     *("-var vpc_name=\"#{vpc_name}\"" if vpc_name),
     "-auto-approve"
   ].join(" ")

--- a/terraform/cloud-platform/variables.tf
+++ b/terraform/cloud-platform/variables.tf
@@ -62,7 +62,6 @@ variable "enable_large_nodesgroup" {
 variable "auth0_tenant_domain" {
   description = "The auth0 domain/tenant used, different for live/test clusters"
   default = {
-    live-1  = "justice-cloud-platform.eu.auth0.com"
     default = "moj-cloud-platforms-dev.eu.auth0.com"
   }
 }

--- a/terraform/cloud-platform/variables.tf
+++ b/terraform/cloud-platform/variables.tf
@@ -62,6 +62,6 @@ variable "enable_large_nodesgroup" {
 variable "auth0_tenant_domain" {
   description = "The auth0 domain/tenant used, different for live/test clusters"
   default = {
-    default = "moj-cloud-platforms-dev.eu.auth0.com"
+    default = "justice-cloud-platform.eu.auth0.com"
   }
 }


### PR DESCRIPTION
master_node_machine_type, worker_node_machine_type and enable_large_nodesgroup are by default (unless it is in live-1) as small. It doesn't need to be specified. 