### PR TITLE
Add sleep between deployment and expect psp tests

### DIFF
--- a/smoke-tests/spec/psp_spec.rb
+++ b/smoke-tests/spec/psp_spec.rb
@@ -67,15 +67,20 @@ describe "pod security policies", kops: true do
 
     it "runs in a privileged namespace" do
       make_namespace_privileged(namespace)
-      create_psp_deployment(namespace, deployment_file)
 
+      create_psp_deployment(namespace, deployment_file)
+      # On occasion the expect runs before the container runs.
+      # Sleep for ten seconds to avoid this.
+      sleep 10
       expect(all_containers_running?(pods)).to eq(true)
       delete_clusterrolebinding(namespace)
     end
 
     it "runs in a unprivileged namespace" do
       create_psp_deployment(namespace, deployment_file)
-
+      # On occasion the expect runs before the container runs.
+      # Sleep for ten seconds to avoid this.
+      sleep 10
       expect(all_containers_running?(pods)).to eq(true)
     end
   end


### PR DESCRIPTION
PSP integration tests fails sometimes as the expect checks before the deployment creates container and the container is ready.