### PR TITLE
Fixed integation tests with the latest changes

### DIFF
--- a/smoke-tests/spec/authorized_keys_spec.rb
+++ b/smoke-tests/spec/authorized_keys_spec.rb
@@ -7,14 +7,6 @@ describe "authorized_keys", "live-1": true, speed: "fast" do
     end
   end
 
-  context "expected all pods running inside authorized-keys-provider namespace" do
-    let(:pods) { get_running_app_pods("authorized-keys-provider", "authorized-keys-provider") }
-
-    it "all pods inside authorized-keys-provider are running" do
-      expect(all_containers_running?(pods)).to eq(true)
-    end
-  end
-
   context "expected authorized_keys file within the bastion repo" do
     it "authorized_keys file exists and it can be downloaded" do
       response = URI.open("https://github.com/ministryofjustice/cloud-platform-terraform-bastion/blob/main/files/authorized_keys.txt")


### PR DESCRIPTION
Removed an integration test which doesn't apply anymore because of the latest changes (moved the authorised keys to the bastion module).