### PR TITLE
AWS EKS Pod Security Policies

### DIFF
--- a/smoke-tests/spec/psp_spec.rb
+++ b/smoke-tests/spec/psp_spec.rb
@@ -14,8 +14,7 @@ describe "pod security policies", kops: true do
 
     expected = [
       "privileged",
-      "restricted",
-      "kube-system"
+      "restricted"
     ]
     expect(names).to include(*expected)
   end

--- a/smoke-tests/spec/psp_spec.rb
+++ b/smoke-tests/spec/psp_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 # controls security sensitive aspects of the pod specification.
 # This spec confirms the Cloud Platform psp's are operational
 # within its cluster.
-describe "pod security policies", kops: true do
+describe "pod security policies" do
   let(:namespace) { "integrationtest-psp-#{readable_timestamp}" }
   let(:pods) { get_running_pods(namespace) }
 

--- a/terraform/cloud-platform-components/resources/psp/pod-security-policy.yaml
+++ b/terraform/cloud-platform-components/resources/psp/pod-security-policy.yaml
@@ -7,6 +7,9 @@ metadata:
   name: privileged
   annotations:
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+  labels:
+    kubernetes.io/cluster-service: "true"
+    eks.amazonaws.com/component: pod-security-policy
 spec:
   privileged: true
   allowPrivilegeEscalation: true
@@ -81,7 +84,7 @@ kind: ClusterRole
 metadata:
   name: psp:privileged
 rules:
-- apiGroups: ['extensions']
+- apiGroups: ['policy']
   resources: ['podsecuritypolicies']
   verbs:     ['use']
   resourceNames:
@@ -92,7 +95,7 @@ kind: ClusterRole
 metadata:
   name: psp:restricted
 rules:
-- apiGroups: ['extensions']
+- apiGroups: ['policy']
   resources: ['podsecuritypolicies']
   verbs:     ['use']
   resourceNames:
@@ -120,6 +123,12 @@ roleRef:
   kind: ClusterRole
   name: psp:privileged
 subjects:
+- kind: ServiceAccount
+  name: cluster-autoscaler-aws-cluster-autoscaler
+  namespace: kube-system
+- kind: ServiceAccount
+  name: typha-cpha
+  namespace: kube-system
 - kind: Group
   name: system:serviceaccounts:cert-manager
   apiGroup: rbac.authorization.k8s.io

--- a/terraform/cloud-platform-components/resources/psp/pod-security-policy.yaml
+++ b/terraform/cloud-platform-components/resources/psp/pod-security-policy.yaml
@@ -9,7 +9,6 @@ metadata:
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
   labels:
     kubernetes.io/cluster-service: "true"
-    eks.amazonaws.com/component: pod-security-policy
 spec:
   privileged: true
   allowPrivilegeEscalation: true

--- a/terraform/cloud-platform-components/resources/psp/pod-security-policy.yaml
+++ b/terraform/cloud-platform-components/resources/psp/pod-security-policy.yaml
@@ -124,6 +124,24 @@ roleRef:
   name: psp:privileged
 subjects:
 - kind: ServiceAccount
+  name: metrics-server
+  namespace: kube-system
+- kind: ServiceAccount
+  name: coredns
+  namespace: kube-system
+- kind: ServiceAccount
+  name: kube-proxy
+  namespace: kube-system
+- kind: ServiceAccount
+  name: aws-node
+  namespace: kube-system
+- kind: ServiceAccount
+  name: sonarqube-sonarqube
+  namespace: sonarqube
+- kind: ServiceAccount
+  name: calico-node
+  namespace: kube-system
+- kind: ServiceAccount
   name: cluster-autoscaler-aws-cluster-autoscaler
   namespace: kube-system
 - kind: ServiceAccount


### PR DESCRIPTION
This PR amends the Cloud Platform pod security policies, allowing them to work on an AWS EKS cluster (specifically the live manager cluster). It also includes the removal of the "kops only" flag in our integration tests, meaning it'll be run against both EKS 
and kops clusters in the future. 

The API groups had to be changed as the extensions API has been deprecated. In addition to this a number of service accounts were added to allow numerous kube-system pods access to the privileged PSP.

When merged we will need to perform a `terraform apply` to the components of both live-1 and manager. EKS comes with a default PSP, this will need to be removed in all future clusters. An issue has been raised to approach this work [here](https://github.com/ministryofjustice/cloud-platform/issues/2106)

This PR closes https://github.com/ministryofjustice/cloud-platform/issues/2066. 



