### PR TITLE
Remove ECR check from expected prometheus rules

### DIFF
--- a/smoke-tests/spec/prometheusrules_spec.rb
+++ b/smoke-tests/spec/prometheusrules_spec.rb
@@ -37,13 +37,4 @@ describe "Prometheus Rules", speed: "fast" do
     ]
     expect(names).to include(*expected)
   end
-
-  specify "in production", "live-1": true do
-    names = get_prometheus_rules.map { |set| set.dig("metadata", "name") }.sort
-
-    expected = [
-      "prometheus-custom-alerts-ecr-exporter"
-    ]
-    expect(names).to include(*expected)
-  end
 end


### PR DESCRIPTION
We no longer send alerts to #lower-priority-alarms for ECRs with high
image counts. So this change removes the check for
`prometheus-custom-alerts-ecr-exporter` in the list of prometheus rules.