### PR TITLE
Remove-ECR-alerts-smoke-tests

### DIFF
--- a/smoke-tests/spec/prometheusrules_spec.rb
+++ b/smoke-tests/spec/prometheusrules_spec.rb
@@ -38,12 +38,4 @@ describe "Prometheus Rules", speed: "fast" do
     expect(names).to include(*expected)
   end
 
-  specify "in production", "live-1": true do
-    names = get_prometheus_rules.map { |set| set.dig("metadata", "name") }.sort
-
-    expected = [
-      "prometheus-custom-alerts-ecr-exporter"
-    ]
-    expect(names).to include(*expected)
-  end
 end

--- a/smoke-tests/spec/prometheusrules_spec.rb
+++ b/smoke-tests/spec/prometheusrules_spec.rb
@@ -37,5 +37,4 @@ describe "Prometheus Rules", speed: "fast" do
     ]
     expect(names).to include(*expected)
   end
-
 end


### PR DESCRIPTION
Why:
[Remove ECR alerts routed to low-priority-alerts](https://app.zenhub.com/workspaces/cloud-platform-team-5ccb0b8a81f66118c983c189/issues/ministryofjustice/cloud-platform/2112)