### PR TITLE
Only test for fluent-bit on kops clusters

### DIFF
--- a/smoke-tests/spec/daemonsets_spec.rb
+++ b/smoke-tests/spec/daemonsets_spec.rb
@@ -50,7 +50,7 @@ describe "daemonsets", speed: "fast" do
     end
   end
 
-  context "fluent-bit" do
+  context "fluent-bit", kops: true do
     let(:pods) { get_running_app_pods("logging", "fluent-bit") }
 
     it "runs fluent-bit" do


### PR DESCRIPTION
fluent-bit is not running in the EKS manager cluster yet.