### PR TITLE
Continue if zone deletion throws an error

### DIFF
--- a/smoke-tests/spec/external_dns_helper.rb
+++ b/smoke-tests/spec/external_dns_helper.rb
@@ -53,13 +53,17 @@ def cleanup_zone(domain, namespace, ingress_name, zone_id = nil)
   records = get_zone_records(zone_id)
 
   if records.size > 2
-    records.each do |record|
-      case record[:type]
+    begin
+      records.each do |record|
+        case record[:type]
         when "A"
           delete_record(zone_id, record)
         when "TXT"
           delete_record(zone_id, record)
+        end
       end
+    rescue Aws::Route53::Errors::InvalidChangeBatch => e
+      puts "Caught error when deleting record:\n#{record}\nContinuing..."
     end
   end
 end


### PR DESCRIPTION
We sometimes see this failure:

```
Failures:

  1) external DNS when zone matches ingress domain and an ingress is deleted it deletes an A record
     Failure/Error:
       client.change_resource_record_sets({
         hosted_zone_id: zone_id,
         change_batch: {
           changes: [record_change]
         }
       })

     Aws::Route53::Errors::InvalidChangeBatch:
       [Tried to delete resource record set [name='integrationtest.service.justice.gov.uk.', type='A'] but it was not found]
```

I'm not entirely sure how this happens. It may be that someone is running the
external dns tests manually at the same time as the pipeline, so a race
condition arises.

Either way, this particular error should not cause the test to fail. The only
thing that matters is that the zone does not exist before the test runs - how
that happens doesn't matter. So, we can catch that particular error and
continue.

I was not able to replicate the error during testing, because it's
intermittent, but the external dns tests still pass, with this change in place.