### PR TITLE
Move begin/rescue inside the 'records' loop

### DIFF
--- a/smoke-tests/spec/external_dns_helper.rb
+++ b/smoke-tests/spec/external_dns_helper.rb
@@ -54,16 +54,14 @@ def cleanup_zone(domain, namespace, ingress_name, zone_id = nil)
 
   if records.size > 2
     records.each do |record|
-      begin
-        case record[:type]
-        when "A"
-          delete_record(zone_id, record)
-        when "TXT"
-          delete_record(zone_id, record)
-        end
-      rescue Aws::Route53::Errors::InvalidChangeBatch => e
-        puts "Caught error when deleting record:\n#{record}\nContinuing..."
+      case record[:type]
+      when "A"
+        delete_record(zone_id, record)
+      when "TXT"
+        delete_record(zone_id, record)
       end
+    rescue Aws::Route53::Errors::InvalidChangeBatch => e
+      puts "Caught error when deleting record:\n#{record}\nContinuing..."
     end
   end
 end

--- a/smoke-tests/spec/external_dns_helper.rb
+++ b/smoke-tests/spec/external_dns_helper.rb
@@ -53,17 +53,17 @@ def cleanup_zone(domain, namespace, ingress_name, zone_id = nil)
   records = get_zone_records(zone_id)
 
   if records.size > 2
-    begin
-      records.each do |record|
+    records.each do |record|
+      begin
         case record[:type]
         when "A"
           delete_record(zone_id, record)
         when "TXT"
           delete_record(zone_id, record)
         end
+      rescue Aws::Route53::Errors::InvalidChangeBatch => e
+        puts "Caught error when deleting record:\n#{record}\nContinuing..."
       end
-    rescue Aws::Route53::Errors::InvalidChangeBatch => e
-      puts "Caught error when deleting record:\n#{record}\nContinuing..."
     end
   end
 end


### PR DESCRIPTION
I made a mistake in #833, whereby the rescue block is outside of the
context in which `record` exists, so an [undefined variable error gets
thrown](https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/reporting/jobs/integration-tests/builds/1297) if the rescue clause is triggered.

This change moves the begin/rescue inside the loop, where `record`
exists if an error occurs. This should have the desired effect of
allowing the tests to continue successfully, even if the A/TXT record is
not found when the cleanup code tries to delete it.