### PR TITLE
Fix the "wait_for_job_to_start" helper method

### DIFF
--- a/smoke-tests/spec/kubernetes_helper.rb
+++ b/smoke-tests/spec/kubernetes_helper.rb
@@ -79,7 +79,7 @@ end
 
 def wait_for_job_to_start(namespace, job_name)
   controlled_by = "Job/#{job_name}"
-  command = "kubectl describe pods -n #{namespace} | grep -B 2 #{controlled_by} | grep Succeeded > /dev/null"
+  command = "kubectl describe pods -n #{namespace} | grep -B 4 #{controlled_by} | grep Succeeded > /dev/null"
   _, _, status = execute(command)
 
   10.times do


### PR DESCRIPTION
This method is used by the logging specs, which launch a job and then
check whether the logs show up in elasticsearch.

The method relies on kubectl output including the word "Succeeded",
which used to appear 2 lines above the job name in the output from
`kubectl describe pods`

It seems the format of kubectl output has changed, because "Succeeded"
now *sometimes* appears 4 lines above the job name, not 2 lines.

This caused `wait_for_job_to_start` to always fail, resulting in the
logging specs failing.

This change should make the logging specs pass more consistently.