### PR TITLE
Lambda to block public access for S3 buckets

### DIFF
--- a/terraform/cloud-platform-account/main.tf
+++ b/terraform/cloud-platform-account/main.tf
@@ -33,7 +33,6 @@ module "baselines" {
   slack_channel = "lower-priority-alarms"
 
   s3_bucket_block_publicaccess_exceptions = [
-    "cloud-platform-ab9d0cbde59c3b3112de9d117068515d",
     "cloud-platform-9025c5a1a81bca7eaefd78a38df7d7de",
     "cloud-platform-fdc5e4b70a599d8ea84b4ffd31a832b3",
     "cloud-platform-6cf3132ef8fce52bb371b1d02f40c36d"

--- a/terraform/cloud-platform-account/main.tf
+++ b/terraform/cloud-platform-account/main.tf
@@ -23,7 +23,7 @@ module "iam" {
 
 # Baselines: cloudtrail, cloudwatch, lambda. Everything that our accounts should have
 module "baselines" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-awsaccounts-baselines?ref=0.0.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-awsaccounts-baselines?ref=0.0.3"
 
   enable_logging           = true
   enable_slack_integration = true
@@ -31,5 +31,12 @@ module "baselines" {
   region        = var.aws_region
   slack_webhook = var.slack_config_cloudwatch_lp
   slack_channel = "lower-priority-alarms"
+
+  s3_bucket_block_publicaccess_exceptions = [
+    "cloud-platform-ab9d0cbde59c3b3112de9d117068515d",
+    "cloud-platform-9025c5a1a81bca7eaefd78a38df7d7de",
+    "cloud-platform-fdc5e4b70a599d8ea84b4ffd31a832b3",
+    "cloud-platform-6cf3132ef8fce52bb371b1d02f40c36d"
+  ]
 }
 


### PR DESCRIPTION
It was also included the exceptions and it was already tested against our CP account.

More details about the change within the module are [here](https://github.com/ministryofjustice/cloud-platform-terraform-awsaccounts-baselines/pull/3)