### PR TITLE
new release 3.6  to cloud-platform-terraform-monitoring

### DIFF
--- a/terraform/cloud-platform-components/components.tf
+++ b/terraform/cloud-platform-components/components.tf
@@ -62,7 +62,7 @@ module "logging" {
 }
 
 module "prometheus" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=0.3.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=0.3.6"
 
   alertmanager_slack_receivers               = var.alertmanager_slack_receivers
   iam_role_nodes                             = data.aws_iam_role.nodes.arn

--- a/terraform/cloud-platform-components/components.tf
+++ b/terraform/cloud-platform-components/components.tf
@@ -62,7 +62,7 @@ module "logging" {
 }
 
 module "prometheus" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=0.3.6"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=0.3.7"
 
   alertmanager_slack_receivers               = var.alertmanager_slack_receivers
   iam_role_nodes                             = data.aws_iam_role.nodes.arn


### PR DESCRIPTION
Why [Amend nginx alarm to show which pod has failed#2188](https://app.zenhub.com/workspaces/cloud-platform-team-5ccb0b8a81f66118c983c189/issues/ministryofjustice/cloud-platform/2188) >
https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/releases/tag/0.3.6