### PR TITLE
fluentbit depends on prometheus for deployment

### DIFF
--- a/terraform/cloud-platform-components/components.tf
+++ b/terraform/cloud-platform-components/components.tf
@@ -47,7 +47,7 @@ module "kuberos" {
 
 
 module "logging" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-logging?ref=0.0.9"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-logging?ref=0.1.1"
 
   # if you need to connect to the test elasticsearch cluster, replace "placeholder-elasticsearch" with "search-cloud-platform-test-zradqd7twglkaydvgwhpuypzy4.eu-west-2.es.amazonaws.com"
   # -> value = "${replace(terraform.workspace, "live", "") != terraform.workspace ? "search-cloud-platform-live-dibidbfud3uww3lpxnhj2jdws4.eu-west-2.es.amazonaws.com" : "search-cloud-platform-test-zradqd7twglkaydvgwhpuypzy4.eu-west-2.es.amazonaws.com"


### PR DESCRIPTION
Due fluent-bit adds serviceMonitor resource (CRD components of Prometheus) it was needed to create an explicit dependency. Please check https://github.com/ministryofjustice/cloud-platform-terraform-logging/pull/11