### PR TITLE
Increase sleep from 10 to 20 for a PSP test

### DIFF
--- a/smoke-tests/spec/psp_spec.rb
+++ b/smoke-tests/spec/psp_spec.rb
@@ -70,8 +70,8 @@ describe "pod security policies" do
 
       create_psp_deployment(namespace, deployment_file)
       # On occasion the expect runs before the container runs.
-      # Sleep for ten seconds to avoid this.
-      sleep 10
+      # Sleep to avoid this.
+      sleep 20
       expect(all_containers_running?(pods)).to eq(true)
     end
 


### PR DESCRIPTION
This test seems to be failing occasionally. This change is an attempt to
make it more reliable.