### PR TITLE
Use new kops module and amend live-1 manifest to use CoreDNS

### DIFF
--- a/kops/live-1.yaml
+++ b/kops/live-1.yaml
@@ -170,7 +170,8 @@ spec:
         - level: Metadata
           omitStages:
             - "RequestReceived"
-
+  kubeDNS:
+    provider: CoreDNS
   api:
     loadBalancer:
       type: Public

--- a/terraform/cloud-platform/main.tf
+++ b/terraform/cloud-platform/main.tf
@@ -57,7 +57,7 @@ locals {
 ########
 
 module "kops" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-kops?ref=0.0.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-kops?ref=0.0.5"
 
   vpc_name            = local.vpc
   cluster_domain_name = trimsuffix(local.cluster_base_domain_name, ".")


### PR DESCRIPTION
Migrate from kubeDNS to CoreDNS.

As of Kubernetes v1.12, CoreDNS is the recommended DNS Server, replacing kube-dns

https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/#introduction

Use new kops module with the change 