### PR TITLE
Change master nodes from c4.4xlarge to c5.4xlarge

### DIFF
--- a/kops/live-1.yaml
+++ b/kops/live-1.yaml
@@ -326,7 +326,7 @@ metadata:
   name: master-eu-west-2a
 spec:
   image: kope.io/k8s-1.16-debian-stretch-amd64-hvm-ebs-2020-01-17
-  machineType: c4.4xlarge
+  machineType: c5.4xlarge
   maxSize: 1
   minSize: 1
   nodeLabels:
@@ -353,7 +353,7 @@ metadata:
   name: master-eu-west-2b
 spec:
   image: kope.io/k8s-1.16-debian-stretch-amd64-hvm-ebs-2020-01-17
-  machineType: c4.4xlarge
+  machineType: c5.4xlarge
   maxSize: 1
   minSize: 1
   nodeLabels:
@@ -380,7 +380,7 @@ metadata:
   name: master-eu-west-2c
 spec:
   image: kope.io/k8s-1.16-debian-stretch-amd64-hvm-ebs-2020-01-17
-  machineType: c4.4xlarge
+  machineType: c5.4xlarge
   maxSize: 1
   minSize: 1
   nodeLabels:

--- a/terraform/cloud-platform/variables.tf
+++ b/terraform/cloud-platform/variables.tf
@@ -37,8 +37,8 @@ variable "cluster_node_count" {
 variable "master_node_machine_type" {
   description = "The AWS EC2 instance types to use for master nodes"
   default = {
-    live-1  = "c4.4xlarge"
-    default = "c4.large"
+    live-1  = "c5.4xlarge"
+    default = "c5.large"
   }
 }
 


### PR DESCRIPTION
This is because the c4 instance family is nearing its end of life, and
we ran into availability problems the last time we tried to replace a c4
master node.

This change should help to mitigate such issues, because c5 has
generally better availability. We are talking to AWS about a more robust
way to prevent such problems in future.
