### PR TITLE
Increase sleep delay for PSP test

### DIFF
--- a/smoke-tests/spec/psp_spec.rb
+++ b/smoke-tests/spec/psp_spec.rb
@@ -39,7 +39,7 @@ describe "pod security policies" do
       create_psp_deployment(namespace, deployment_file)
       # On occasion the expect runs before the container runs.
       # Sleep for ten seconds to avoid this.
-      sleep 10
+      sleep 20
 
       expect(all_containers_running?(pods)).to eq(true)
     end


### PR DESCRIPTION
Similar to #06898b34, this change is an attempt to make this particular
test more reliable. It doesn't fail often, but this specific test has
failed multiple times over the past few days.
