### PR TITLE
New version of the monitoring's terraform module

### DIFF
--- a/terraform/cloud-platform-components/components.tf
+++ b/terraform/cloud-platform-components/components.tf
@@ -62,7 +62,7 @@ module "logging" {
 }
 
 module "prometheus" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=0.3.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=0.3.8"
 
   alertmanager_slack_receivers               = var.alertmanager_slack_receivers
   iam_role_nodes                             = data.aws_iam_role.nodes.arn


### PR DESCRIPTION
More details please visit [this PR](https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/pull/40/files)