### PR TITLE
Update concourse to use the latest version 1.2.4

### DIFF
--- a/terraform/cloud-platform-eks/components/components.tf
+++ b/terraform/cloud-platform-eks/components/components.tf
@@ -1,6 +1,6 @@
 
 module "concourse" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-concourse?ref=1.2.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-concourse?ref=1.2.4"
 
   vpc_id                                      = data.terraform_remote_state.cluster.outputs.vpc_id
   internal_subnets                            = data.terraform_remote_state.cluster.outputs.internal_subnets


### PR DESCRIPTION
This version got additional permissions for concourse to create EKS components