### PR TITLE
Disable tests which creates ingress

### DIFF
--- a/smoke-tests/spec/cert_manager_spec.rb
+++ b/smoke-tests/spec/cert_manager_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe "cert-manager" do
+xdescribe "cert-manager" do
   let(:namespace) { "cert-manager-test-#{readable_timestamp}" }
 
   before do

--- a/smoke-tests/spec/external_dns_spec.rb
+++ b/smoke-tests/spec/external_dns_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 ZONE_ID = "Z02429076QQMAO8KXV68" # integrationtest.service.justice.gov.uk zone_id
 
 # This test can only be ran against live-1. Test clusters do not have enough privileges.
-describe "external DNS", "live-1": true do
+xdescribe "external DNS", "live-1": true do
   let(:domain) { "integrationtest.service.justice.gov.uk" } # That zone already exists
   namespace = "integrationtest-dns-#{readable_timestamp}"
   let(:ingress_domain) { domain }

--- a/smoke-tests/spec/ingress_spec.rb
+++ b/smoke-tests/spec/ingress_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe "nginx ingress" do
+xdescribe "nginx ingress" do
   namespace = "smoketest-ingress-#{readable_timestamp}"
   host = "#{namespace}.apps.#{current_cluster}"
   let(:url) { "https://#{host}" }
@@ -24,7 +24,7 @@ describe "nginx ingress" do
   # TODO: This test is failing a lot of the time due to performance problems with our shared ingress.
   # So, I'm disabling it for now. When we have fixed the underlying problem, this should be
   # reinstated.
-  xcontext "when ingress is deployed" do
+  context "when ingress is deployed" do
     before do
       apply_template_file(
         namespace: namespace,

--- a/smoke-tests/spec/modsec_spec.rb
+++ b/smoke-tests/spec/modsec_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe "Testing modsec" do
+xdescribe "Testing modsec" do
   namespace = "integrationtest-modsec-#{readable_timestamp}"
   host = "#{namespace}.apps.#{current_cluster}"
   ingress_name = "modsec-integrationtest-app-ing"


### PR DESCRIPTION
This is to avoid load on ingress-controller, as we are having Nginx config issues.