### PR TITLE
Fix monitoring source in EKS

### DIFF
--- a/terraform/cloud-platform-eks/components/components.tf
+++ b/terraform/cloud-platform-eks/components/components.tf
@@ -92,7 +92,7 @@ module "logging" {
 }
 
 module "monitoring" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=0.4.0
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=0.4.0"
 
   alertmanager_slack_receivers = var.alertmanager_slack_receivers
   iam_role_nodes               = data.aws_iam_role.nodes.arn


### PR DESCRIPTION
This is causing error "Error: Invalid multi-line string"