### PR TITLE
Remove default_cert for monitoring namespace

### DIFF
--- a/terraform/cloud-platform-components/components.tf
+++ b/terraform/cloud-platform-components/components.tf
@@ -81,7 +81,8 @@ module "prometheus" {
 module "ingress_controller_monitoring" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
 
-  namespace    = "monitoring"
+  namespace     = "monitoring"
+  is_production = true
 }
 
 module "ingress_controllers" {

--- a/terraform/cloud-platform-components/components.tf
+++ b/terraform/cloud-platform-components/components.tf
@@ -79,10 +79,9 @@ module "prometheus" {
 }
 
 module "ingress_controller_monitoring" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
 
   namespace    = "monitoring"
-  default_cert = "monitoring/default-certificate"
 }
 
 module "ingress_controllers" {


### PR DESCRIPTION
As the latest cloud-platform-terraform-teams-ingress-controller changes, will use the ingress-controller default certificate