### PR TITLE
Add annotations to integration test ingress

### DIFF
--- a/smoke-tests/spec/fixtures/external-dns-ingress.yaml.erb
+++ b/smoke-tests/spec/fixtures/external-dns-ingress.yaml.erb
@@ -3,6 +3,8 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: <%= ingress_name %>
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
 spec:
   rules:
   - host: <%= domain %>

--- a/smoke-tests/spec/fixtures/helloworld-deployment.yaml.erb
+++ b/smoke-tests/spec/fixtures/helloworld-deployment.yaml.erb
@@ -36,6 +36,8 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: integration-test-app-ing
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
 spec:
   tls:
   - hosts:

--- a/smoke-tests/spec/fixtures/invalid-nginx-syntax.yaml.erb
+++ b/smoke-tests/spec/fixtures/invalid-nginx-syntax.yaml.erb
@@ -4,6 +4,7 @@ metadata:
   name: integration-test-nginx-ing
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /$1
+    kubernetes.io/ingress.class: "nginx"
 spec:
   tls:
   - hosts:

--- a/terraform/cloud-platform-components/docker-registry-cache.tf
+++ b/terraform/cloud-platform-components/docker-registry-cache.tf
@@ -200,6 +200,7 @@ resource "kubernetes_ingress" "docker-registry-cache-ingress" {
     name      = "docker-registry-cache-ingress"
     namespace = kubernetes_namespace.docker-registry-cache.id
     annotations = {
+      "kubernetes.io/ingress.class"                        = "nginx"
       "nginx.ingress.kubernetes.io/whitelist-source-range" = join(",", [for ip in data.terraform_remote_state.network.outputs.nat_gateway_ips : "${ip}/32"])
     }
   }


### PR DESCRIPTION
PR connects to https://github.com/ministryofjustice/cloud-platform/issues/2243

Due to the split of ingress controllers we will need to define which
ingress controller our traffic should traverse. It has been decided that
we will keep a generic controller but will need to be specified via an
annotation.