### PR TITLE
Fix cluster creation dependences

### DIFF
--- a/terraform/cloud-platform-components/components.tf
+++ b/terraform/cloud-platform-components/components.tf
@@ -79,11 +79,12 @@ module "prometheus" {
 }
 
 module "ingress_controller_monitoring" {
-  # source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
-  source = "/home/mogaal/workspace/github/ministryofjustice/cloud-platform-terraform-teams-ingress-controller"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.9"
 
-  namespace     = "monitoring"
-  is_production = true
+  namespace              = "monitoring"
+  is_production          = true
+  dependence_prometheus  = module.prometheus.helm_prometheus_operator_status
+  dependence_certmanager = module.cert_manager.helm_cert_manager_status
 }
 
 module "ingress_controllers" {

--- a/terraform/cloud-platform-components/components.tf
+++ b/terraform/cloud-platform-components/components.tf
@@ -79,7 +79,8 @@ module "prometheus" {
 }
 
 module "ingress_controller_monitoring" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  # source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.7"
+  source = "/home/mogaal/workspace/github/ministryofjustice/cloud-platform-terraform-teams-ingress-controller"
 
   namespace     = "monitoring"
   is_production = true


### PR DESCRIPTION
Add explicitly dependencies between ingress controller for monitoring namespace and Prometheus/CertManager