### PR TITLE
Remove ingress-controllers service-monitor check

### DIFF
--- a/smoke-tests/spec/servicemonitors_spec.rb
+++ b/smoke-tests/spec/servicemonitors_spec.rb
@@ -29,15 +29,6 @@ describe "servicemonitors", speed: "fast" do
     expect(names).to include(*expected)
   end
 
-  specify "expected nginx-ingress servicemonitors" do
-    names = get_servicemonitors("ingress-controllers").map { |set| set.dig("metadata", "name") }.sort
-
-    expected = [
-      "nginx-ingress-acme-controller"
-    ]
-    expect(names).to eq(expected)
-  end
-
   specify "expected ECR and CloudWatch servicemonitors", "live-1": true do
     names = get_servicemonitors("monitoring").map { |set| set.dig("metadata", "name") }.sort
 


### PR DESCRIPTION
Remove ingress-controllers service-monitor check
The ingress-controllers namespace will now have a servicemonitor added
to it every time we create a new ingress-controller. This means the test
for expected servicemonitors is going to be impossible to manage.