### PR TITLE
Removing monitoring ingress controller

### DIFF
--- a/terraform/cloud-platform-components/components.tf
+++ b/terraform/cloud-platform-components/components.tf
@@ -60,7 +60,7 @@ module "logging" {
 }
 
 module "prometheus" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=0.4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=0.4.2"
 
   alertmanager_slack_receivers               = var.alertmanager_slack_receivers
   iam_role_nodes                             = data.aws_iam_role.nodes.arn
@@ -76,15 +76,6 @@ module "prometheus" {
   oidc_issuer_url               = data.terraform_remote_state.cluster.outputs.oidc_issuer_url
 
   dependence_opa = module.opa.helm_opa_status
-}
-
-module "ingress_controller_monitoring" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.0.9"
-
-  namespace              = "monitoring"
-  is_production          = true
-  dependence_prometheus  = module.prometheus.helm_prometheus_operator_status
-  dependence_certmanager = module.cert_manager.helm_cert_manager_status
 }
 
 module "ingress_controllers" {


### PR DESCRIPTION
From now on monitoring traffic is going through the default ingress controller.