### PR TITLE
Use v1.2.7 of the concourse module

### DIFF
--- a/terraform/cloud-platform-eks/components/components.tf
+++ b/terraform/cloud-platform-eks/components/components.tf
@@ -1,6 +1,6 @@
 
 module "concourse" {
-  source                                      = "github.com/ministryofjustice/cloud-platform-terraform-concourse?ref=1.2.6"
+  source                                      = "github.com/ministryofjustice/cloud-platform-terraform-concourse?ref=1.2.7"
   vpc_id                                      = data.terraform_remote_state.cluster.outputs.vpc_id
   internal_subnets                            = data.terraform_remote_state.cluster.outputs.internal_subnets
   internal_subnets_ids                        = data.terraform_remote_state.cluster.outputs.internal_subnets_ids


### PR DESCRIPTION
This version provides the HOODAW API key secret.

related to
https://github.com/ministryofjustice/cloud-platform-terraform-concourse/pull/9
