### PR TITLE
Bump monitoring release for Manager cluster

### DIFF
--- a/terraform/cloud-platform-eks/components/components.tf
+++ b/terraform/cloud-platform-eks/components/components.tf
@@ -92,7 +92,7 @@ module "logging" {
 }
 
 module "monitoring" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=0.4.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=0.4.3"
 
   alertmanager_slack_receivers = var.alertmanager_slack_receivers
   iam_role_nodes               = data.aws_iam_role.nodes.arn


### PR DESCRIPTION
This commit connects to
https://github.com/ministryofjustice/cloud-platform/issues/2078 and will
bump the monitoring stack on the Manager cluster to version 0.4.3. This
version contains a change to the monitoring (alertmanager and
prometheus) proxies.