### PR TITLE
Bump the live-1 monitoring module to 0.4.3

### DIFF
--- a/terraform/cloud-platform-components/components.tf
+++ b/terraform/cloud-platform-components/components.tf
@@ -60,7 +60,7 @@ module "logging" {
 }
 
 module "prometheus" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=0.4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=0.4.3"
 
   alertmanager_slack_receivers               = var.alertmanager_slack_receivers
   iam_role_nodes                             = data.aws_iam_role.nodes.arn

--- a/terraform/cloud-platform-eks/components/components.tf
+++ b/terraform/cloud-platform-eks/components/components.tf
@@ -92,7 +92,7 @@ module "logging" {
 }
 
 module "monitoring" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=0.4.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=0.4.3"
 
   alertmanager_slack_receivers = var.alertmanager_slack_receivers
   iam_role_nodes               = data.aws_iam_role.nodes.arn


### PR DESCRIPTION
This PR connects to
ministryofjustice/cloud-platform#2078 and
relates to the chart version upgrade of the alertmanager and prometheus
proxies.