### PR TITLE
Bump version of default ingress-controller to 0.0.6

### DIFF
--- a/terraform/cloud-platform-components/components.tf
+++ b/terraform/cloud-platform-components/components.tf
@@ -88,7 +88,7 @@ module "ingress_controller_integration_test" {
 
 
 module "ingress_controllers" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=0.0.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=0.0.6"
 
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   is_live_cluster     = terraform.workspace == local.live_workspace ? true : false


### PR DESCRIPTION
Bump version of default ingress-controller to 0.0.6 which has ModSecurity disabled

