### PR TITLE
Add dependency for ingress_controller_integration_test, and default ingress_controllers

### DIFF
--- a/terraform/cloud-platform-components/components.tf
+++ b/terraform/cloud-platform-components/components.tf
@@ -80,7 +80,7 @@ module "prometheus" {
 
 
 module "ingress_controller_integration_test" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-teams-ingress-controller?ref=0.1.2"
 
   namespace = "integration-test"
 }
@@ -88,7 +88,7 @@ module "ingress_controller_integration_test" {
 
 
 module "ingress_controllers" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=0.0.6"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=0.0.7"
 
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   is_live_cluster     = terraform.workspace == local.live_workspace ? true : false


### PR DESCRIPTION
Revert "Removed dependency variables, not required anymore"

This reverts commit f1e468b. We need this dependency for "ingress_controller_integration_test"

Destroy cluster fails some times as ingress-controller namespace stuck in terminating state, so added cert-manager dependency.
"reason":"ContentDeletionFailed","message":
"Failed to delete all resource types, 1 remaining: conversion webhook for acme.cert-manager.io/v1alpha2