### PR TITLE
Add custom Prometheus labels for CertManager

### DIFF
--- a/terraform/cloud-platform-components/components.tf
+++ b/terraform/cloud-platform-components/components.tf
@@ -1,5 +1,5 @@
 module "cert_manager" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-certmanager?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-certmanager?ref=0.0.8"
 
   iam_role_nodes      = data.aws_iam_role.nodes.arn
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name


### PR DESCRIPTION
More details about the change here: https://github.com/ministryofjustice/cloud-platform-terraform-certmanager/pull/10