### PR TITLE
Adding new Prometheus URL

### DIFF
--- a/terraform/cloud-platform/main.tf
+++ b/terraform/cloud-platform/main.tf
@@ -99,7 +99,7 @@ module "bastion" {
 #########
 
 module "auth0" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-auth0?ref=1.1.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-auth0?ref=1.1.3"
 
   cluster_name         = local.cluster_name
   services_base_domain = local.services_base_domain


### PR DESCRIPTION
The new Prometheus URL also needs a CallbackURL registration in Auth0. This PR includes it.