### PR TITLE
Replace kube-dns with corends service monitor test

### DIFF
--- a/smoke-tests/spec/servicemonitors_spec.rb
+++ b/smoke-tests/spec/servicemonitors_spec.rb
@@ -22,7 +22,7 @@ describe "servicemonitors", speed: "fast" do
 
     expected = [
       "prometheus-operator-kube-controller-manager",
-      "prometheus-operator-kube-dns",
+      "prometheus-operator-coredns",
       "prometheus-operator-kube-etcd",
       "prometheus-operator-kube-scheduler"
     ]


### PR DESCRIPTION
This will fix the integration test 

servicemonitors expected prometheus servicemonitors in kops clusters
     Failure/Error: expect(names).to include(*expected)
expected ["cloudwatch-exporter-prometheus-cloudwatch-exporter", "ecr-exporter-prometheus-ecr-exporter", "prome...rometheus-operator-node-exporter", "prometheus-operator-operator", "prometheus-operator-prometheus"] to include "prometheus-operator-kube-dns"