### PR TITLE
Bump logging module which has the eventrouter parsed as seperate json…

### DIFF
--- a/terraform/cloud-platform-components/components.tf
+++ b/terraform/cloud-platform-components/components.tf
@@ -45,7 +45,7 @@ module "kuberos" {
 
 
 module "logging" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-logging?ref=0.1.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-logging?ref=0.1.3"
 
   # if you need to connect to the test elasticsearch cluster, replace "placeholder-elasticsearch" with "search-cloud-platform-test-zradqd7twglkaydvgwhpuypzy4.eu-west-2.es.amazonaws.com"
   # -> value = "${replace(terraform.workspace, "live", "") != terraform.workspace ? "search-cloud-platform-live-dibidbfud3uww3lpxnhj2jdws4.eu-west-2.es.amazonaws.com" : "search-cloud-platform-test-zradqd7twglkaydvgwhpuypzy4.eu-west-2.es.amazonaws.com"


### PR DESCRIPTION
… indexed wiht eventrouter* in ES. More details in this PR: https://github.com/ministryofjustice/cloud-platform-terraform-logging/pull/14

Related to: https://github.com/ministryofjustice/cloud-platform/issues/2252

