### PR TITLE
Prevent destroy script running outside container

### DIFF
--- a/destroy-cluster.rb
+++ b/destroy-cluster.rb
@@ -59,11 +59,26 @@ class ClusterDeleter
   end
 
   def check_prerequisites
+    running_in_docker
     check_options
     check_env_vars
     check_software_installed
     check_aws_profiles
     check_name_length
+  end
+
+  def running_in_docker
+    unless running_in_docker?
+      raise "This script may only be run inside a docker container"
+    end
+  end
+
+  # https://stackoverflow.com/questions/20010199/how-to-determine-if-a-process-runs-inside-lxc-docker
+  def running_in_docker?
+    FileTest.exists?("/.dockerenv") || (
+      FileTest.exists?("/proc/self/cgroup") &&
+      File.read("/proc/self/cgroup").split("\n").any?
+    )
   end
 
   def check_options

--- a/destroy-cluster.rb
+++ b/destroy-cluster.rb
@@ -214,7 +214,7 @@ def parse_options
   options = {
     dry_run: true,
     cluster_name: nil,
-    destroy_vpc: true
+    destroy_vpc: true,
   }
 
   OptionParser.new { |opts|

--- a/destroy-cluster.rb
+++ b/destroy-cluster.rb
@@ -229,7 +229,7 @@ def parse_options
   options = {
     dry_run: true,
     cluster_name: nil,
-    destroy_vpc: true,
+    destroy_vpc: true
   }
 
   OptionParser.new { |opts|


### PR DESCRIPTION
Prevent script executing outside docker container

We only want this script to run in a docker
container (usually started via `make tools-shell`)
so that we have complete control over its
environment.

This function tests whether the script is running
inside a docker container, and fails if it isn't.
