### PR TITLE
Bump cluster-autoscaler to version 0.0.4

### DIFF
--- a/terraform/cloud-platform-eks/components/components.tf
+++ b/terraform/cloud-platform-eks/components/components.tf
@@ -47,7 +47,7 @@ module "cert_manager" {
 }
 
 module "cluster_autoscaler" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-cluster-autoscaler?ref=0.0.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-cluster-autoscaler?ref=0.0.4"
 
   cluster_domain_name         = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   eks_cluster_id              = data.terraform_remote_state.cluster.outputs.cluster_id


### PR DESCRIPTION
This PR is to bump cluster-autoscaler to version 0.0.4 which uses the latest chart 1.0.3 and image 1.16.6
Related to: https://github.com/ministryofjustice/cloud-platform-terraform-cluster-autoscaler/pull/1