### PR TITLE
Define per-AZ instancegroups for worker nodes

### DIFF
--- a/kops/live-1.yaml
+++ b/kops/live-1.yaml
@@ -435,9 +435,9 @@ spec:
 
 ########################################################################################################################################
 #                                                                                                                                      #
-# NOTE: This InstanceGroup must always be the last entry in this file, for the node-recycler.                                          #
+# NOTE: Label 'cloud-platform-recycle-nodes: "true"' in this multiple Availability Zone InstanceGroups, used for node-recycler.        #
 #                                                                                                                                      #
-# https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/091ff8cc054fb2f87734edef8de28dd31d71b0b2/recycle-node.rb#L85 #
+# https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/091ff8cc054fb2f87734edef8de28dd31d71b0b2/recycle-node.rb#L93 #
 #                                                                                                                                      #
 ########################################################################################################################################
 
@@ -447,15 +447,16 @@ metadata:
   creationTimestamp: null
   labels:
     kops.k8s.io/cluster: live-1.cloud-platform.service.justice.gov.uk
-  name: nodes-1.16.13
+    cloud-platform-recycle-nodes: "true"
+  name: nodes-1.16.13-eu-west-2a
 spec:
   image: kope.io/k8s-1.16-debian-stretch-amd64-hvm-ebs-2020-01-17
   machineType: r5.xlarge
-  maxSize: 25
-  minSize: 25
+  maxSize: 9
+  minSize: 9
   rootVolumeSize: 256
   nodeLabels:
-    kops.k8s.io/instancegroup: nodes-1.16.13
+    kops.k8s.io/instancegroup: nodes-1.16.13-eu-west-2a
   cloudLabels:
     application: moj-cloud-platform
     business-unit: platforms
@@ -467,5 +468,63 @@ spec:
   role: Node
   subnets:
   - eu-west-2a
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: null
+  labels:
+    kops.k8s.io/cluster: live-1.cloud-platform.service.justice.gov.uk
+    cloud-platform-recycle-nodes: "true"
+  name: nodes-1.16.13-eu-west-2b
+spec:
+  image: kope.io/k8s-1.16-debian-stretch-amd64-hvm-ebs-2020-01-17
+  machineType: r5.xlarge
+  maxSize: 9
+  minSize: 9
+  rootVolumeSize: 256
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-1.16.13-eu-west-2b
+  cloudLabels:
+    application: moj-cloud-platform
+    business-unit: platforms
+    is-production: "true"
+    k8s.io/cluster/live-1.cloud-platform.service.justice.gov.uk: ""
+    role: node
+    owner: cloud-platform:platforms@digital.justice.gov.uk
+    source-code: https://github.com/ministryofjustice/cloud-platform-infrastructure
+  role: Node
+  subnets:
   - eu-west-2b
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: null
+  labels:
+    kops.k8s.io/cluster: live-1.cloud-platform.service.justice.gov.uk
+    cloud-platform-recycle-nodes: "true"
+  name: nodes-1.16.13-eu-west-2c
+spec:
+  image: kope.io/k8s-1.16-debian-stretch-amd64-hvm-ebs-2020-01-17
+  machineType: r5.xlarge
+  maxSize: 9
+  minSize: 9
+  rootVolumeSize: 256
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-1.16.13-eu-west-2c
+  cloudLabels:
+    application: moj-cloud-platform
+    business-unit: platforms
+    is-production: "true"
+    k8s.io/cluster/live-1.cloud-platform.service.justice.gov.uk: ""
+    role: node
+    owner: cloud-platform:platforms@digital.justice.gov.uk
+    source-code: https://github.com/ministryofjustice/cloud-platform-infrastructure
+  role: Node
+  subnets:
   - eu-west-2c

--- a/recycle-node.rb
+++ b/recycle-node.rb
@@ -85,7 +85,7 @@ end
 
 def worker_node?(node)
   instance_group = node.dig("metadata", "labels", "kops.k8s.io/instancegroup")
-  
+
   node.dig("metadata", "labels")["kubernetes.io/role"] == "node" \
     && recylable_instance_groups.include?(instance_group)
 end

--- a/recycle-node.rb
+++ b/recycle-node.rb
@@ -79,7 +79,7 @@ end
 
 def recylable_instance_groups
   YAML.load_stream(get_kops_config)
-    .find_all { |doc| doc.dig("metadata", "labels", "cloud-platform-recycle-nodes") == true }
+    .find_all { |doc| doc.dig("metadata", "labels", "cloud-platform-recycle-nodes") == "true" }
     .map { |doc| doc.dig("metadata", "name") }
 end
 
@@ -92,7 +92,7 @@ end
 
 def target_worker_node_count
   YAML.load_stream(get_kops_config)
-    .find_all { |doc| doc.dig("metadata", "labels", "cloud-platform-recycle-nodes") == true }
+    .find_all { |doc| doc.dig("metadata", "labels", "cloud-platform-recycle-nodes") == "true" }
     .map { |s| s.dig("spec", "minSize") }.sum
 end
 

--- a/terraform/cloud-platform/main.tf
+++ b/terraform/cloud-platform/main.tf
@@ -66,7 +66,9 @@ module "kops" {
   auth0_client_id         = module.auth0.oidc_kubernetes_client_id
   authorized_keys_manager = module.bastion.authorized_keys_manager
 
-  cluster_node_count       = lookup(var.cluster_node_count, terraform.workspace, var.cluster_node_count["default"])
+  cluster_node_count_a     = lookup(var.cluster_node_count_a, terraform.workspace, var.cluster_node_count_a["default"])
+  cluster_node_count_b     = lookup(var.cluster_node_count_b, terraform.workspace, var.cluster_node_count_b["default"])
+  cluster_node_count_c     = lookup(var.cluster_node_count_c, terraform.workspace, var.cluster_node_count_c["default"])
   master_node_machine_type = lookup(var.master_node_machine_type, terraform.workspace, var.master_node_machine_type["default"])
   worker_node_machine_type = lookup(var.worker_node_machine_type, terraform.workspace, var.worker_node_machine_type["default"])
   enable_large_nodesgroup  = lookup(var.enable_large_nodesgroup, terraform.workspace, var.enable_large_nodesgroup["default"])

--- a/terraform/cloud-platform/main.tf
+++ b/terraform/cloud-platform/main.tf
@@ -57,7 +57,7 @@ locals {
 ########
 
 module "kops" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-kops?ref=0.0.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-kops?ref=0.0.6"
 
   vpc_name            = local.vpc
   cluster_domain_name = trimsuffix(local.cluster_base_domain_name, ".")

--- a/terraform/cloud-platform/variables.tf
+++ b/terraform/cloud-platform/variables.tf
@@ -29,7 +29,7 @@ variable "availability_zones" {
 variable "cluster_node_count_a" {
   description = "The number of worker node in the cluster in Availability Zone eu-west-2a"
   default = {
-    live-1  = "8"
+    live-1  = "9"
     default = "1"
   }
 }
@@ -37,7 +37,7 @@ variable "cluster_node_count_a" {
 variable "cluster_node_count_b" {
   description = "The number of worker node in the cluster in Availability Zone eu-west-2b"
   default = {
-    live-1  = "8"
+    live-1  = "9"
     default = "1"
   }
 }
@@ -45,7 +45,7 @@ variable "cluster_node_count_b" {
 variable "cluster_node_count_c" {
   description = "The number of worker node in the cluster in Availability Zone eu-west-2c"
   default = {
-    live-1  = "8"
+    live-1  = "9"
     default = "1"
   }
 }

--- a/terraform/cloud-platform/variables.tf
+++ b/terraform/cloud-platform/variables.tf
@@ -26,11 +26,27 @@ variable "availability_zones" {
   default     = ["eu-west-2a", "eu-west-2b", "eu-west-2c"]
 }
 
-variable "cluster_node_count" {
-  description = "The number of worker node in the cluster"
+variable "cluster_node_count_a" {
+  description = "The number of worker node in the cluster in Availability Zone eu-west-2a"
   default = {
     live-1  = "25"
-    default = "3"
+    default = "1"
+  }
+}
+
+variable "cluster_node_count_b" {
+  description = "The number of worker node in the cluster in Availability Zone eu-west-2b"
+  default = {
+    live-1  = "25"
+    default = "1"
+  }
+}
+
+variable "cluster_node_count_c" {
+  description = "The number of worker node in the cluster in Availability Zone eu-west-2c"
+  default = {
+    live-1  = "25"
+    default = "1"
   }
 }
 

--- a/terraform/cloud-platform/variables.tf
+++ b/terraform/cloud-platform/variables.tf
@@ -29,7 +29,7 @@ variable "availability_zones" {
 variable "cluster_node_count_a" {
   description = "The number of worker node in the cluster in Availability Zone eu-west-2a"
   default = {
-    live-1  = "25"
+    live-1  = "8"
     default = "1"
   }
 }
@@ -37,7 +37,7 @@ variable "cluster_node_count_a" {
 variable "cluster_node_count_b" {
   description = "The number of worker node in the cluster in Availability Zone eu-west-2b"
   default = {
-    live-1  = "25"
+    live-1  = "8"
     default = "1"
   }
 }
@@ -45,7 +45,7 @@ variable "cluster_node_count_b" {
 variable "cluster_node_count_c" {
   description = "The number of worker node in the cluster in Availability Zone eu-west-2c"
   default = {
-    live-1  = "25"
+    live-1  = "8"
     default = "1"
   }
 }


### PR DESCRIPTION
This is related to [2272](https://github.com/ministryofjustice/cloud-platform/issues/2272)

This will help to alter our kops config to control which AZ our worker nodes are created.

Also updated the recycle node job script to handle multiple AZ ig.