### PR TITLE
Remove fluentd integration tests

### DIFF
--- a/smoke-tests/spec/daemonsets_spec.rb
+++ b/smoke-tests/spec/daemonsets_spec.rb
@@ -13,7 +13,6 @@ describe "daemonsets", speed: "fast" do
     expected = [
       "calico-node",
       "fluent-bit",
-      "fluentd-es",
       "kiam-agent",
       "kiam-server",
       "kops-controller",
@@ -36,18 +35,6 @@ describe "daemonsets", speed: "fast" do
     ]
 
     expect(names).to eq(expected)
-  end
-
-  context "fluentd" do
-    let(:pods) { get_running_app_pods("logging", "fluentd-es") }
-
-    it "runs fluentd" do
-      expect(all_node_ips).to eq(app_node_ips)
-    end
-
-    specify "all fluentd containers are running" do
-      expect(all_containers_running?(pods)).to eq(true)
-    end
   end
 
   context "fluent-bit", kops: true do

--- a/smoke-tests/spec/master_nodes_spec.rb
+++ b/smoke-tests/spec/master_nodes_spec.rb
@@ -21,7 +21,7 @@ describe "master nodes", speed: "fast", kops: true do
         p.dig("metadata", "namespace"),
         shorten_pod_name(p.dig("metadata", "name"), node_name)
       ]
-    } .sort
+    }.sort
   end
 
   let(:masters) {

--- a/smoke-tests/spec/master_nodes_spec.rb
+++ b/smoke-tests/spec/master_nodes_spec.rb
@@ -46,7 +46,6 @@ describe "master nodes", speed: "fast", kops: true do
       ["kube-system", "kube-controller-manager"],
       ["kube-system", "kube-proxy"],
       ["kube-system", "kube-scheduler"],
-      ["logging", "fluentd-es"],
       ["monitoring", "prometheus-operator-prometheus-node-exporter"]
     ]
 


### PR DESCRIPTION
Please note, this will not remove fluentd from our cluster, just the
ability to test it. We are aware of issues related to this integration
test and a decision has been made to remove fluentd altogether. The
removal will be undertaken in another ticket.

Fluentd still exists in the manager cluster so all tests that take place
there are untouched.