### PR TITLE
Add fluentd-es back to daemonset integration test

### DIFF
--- a/smoke-tests/spec/daemonsets_spec.rb
+++ b/smoke-tests/spec/daemonsets_spec.rb
@@ -13,7 +13,7 @@ describe "daemonsets", speed: "fast" do
     expected = [
       "calico-node",
       "fluent-bit",
-      "fluent-es",
+      "fluentd-es",
       "kiam-agent",
       "kiam-server",
       "kops-controller",

--- a/smoke-tests/spec/daemonsets_spec.rb
+++ b/smoke-tests/spec/daemonsets_spec.rb
@@ -13,6 +13,7 @@ describe "daemonsets", speed: "fast" do
     expected = [
       "calico-node",
       "fluent-bit",
+      "fluent-es",
       "kiam-agent",
       "kiam-server",
       "kops-controller",


### PR DESCRIPTION
As fluentd still exists in the cluster it's easier to add this daemonset
check back in.