### PR TITLE
Adding network policies inside terraform monitoring module

### DIFF
--- a/terraform/cloud-platform-components/components.tf
+++ b/terraform/cloud-platform-components/components.tf
@@ -60,7 +60,7 @@ module "logging" {
 }
 
 module "prometheus" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=0.5.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=0.5.3"
 
   alertmanager_slack_receivers               = var.alertmanager_slack_receivers
   iam_role_nodes                             = data.aws_iam_role.nodes.arn


### PR DESCRIPTION
In order to have a test cluster similar to live-1, we should also include network policies. This PR calls the latest version of the terraform monitoring module which includes network policies