### PR TITLE
Increase wait after creating ingress

### DIFF
--- a/smoke-tests/spec/ingress_spec.rb
+++ b/smoke-tests/spec/ingress_spec.rb
@@ -37,7 +37,7 @@ describe "nginx ingress" do
       )
 
       wait_for(namespace, "ingress", ingress_name)
-      sleep 60 # Without this, the test fails
+      sleep 90 # Without this, the test fails
     end
 
     it "returns 200 for http get" do


### PR DESCRIPTION
This ingress spec is consistently failing. I think that may be because
it's taking longer to create/modify ingresses than it was when the test
was first written.

This change increases the delay from 60 to 90 seconds, after creating
the test ingress, before trying to use it.
