### PR TITLE
Increase ingress sleep_delay to 400s

### DIFF
--- a/smoke-tests/spec/ingress_spec.rb
+++ b/smoke-tests/spec/ingress_spec.rb
@@ -1,13 +1,15 @@
 require "spec_helper"
 
-describe "nginx ingress" do
+describe "nginx ingress", speed: "slow" do
   namespace = "smoketest-ingress-#{readable_timestamp}"
   host = "#{namespace}-nginx.apps.#{current_cluster}"
   let(:url) { "https://#{host}" }
   ingress_name = "integration-test-app-ing"
   ingress_class = "nginx"
 
-  let(:sleep_delay) { 120 } # How long to wait after creating/modifying an ingress
+  # Delay of 300 or lower consistently results in at least one test failure
+  # Delay of 360 fails 50/50
+  let(:sleep_delay) { 400 } # How long to wait after creating/modifying an ingress
 
   before(:all) do
     create_namespace(namespace)


### PR DESCRIPTION
I dug into the consistently failing test (line 47), and it does pass,
when running locally, with a sufficiently long delay. By repeatedly
testing with different sleep delays, 400s looks like a valid choice to
get tests which pass consistently.

This is a ridiculously long time to wait for a test to run, so I've
added a `speed: "slow"` tag, so that people can bypass this test when
they need faster feedback.
