### PR TITLE
Bump concourse version to 1.3.3

### DIFF
--- a/smoke-tests/spec/concourse_spec.rb
+++ b/smoke-tests/spec/concourse_spec.rb
@@ -10,7 +10,7 @@ describe "concourse-test", "eks-manager": true do
   end
 
   it "runs postgresql pods" do
-    pods = get_running_app_pods("concourse", "postgresql")
+    pods = get_running_app_pods("concourse", "postgresql", "app.kubernetes.io/name")
     expect(all_containers_running?(pods)).to eq(true)
   end
 

--- a/terraform/cloud-platform-eks/components/components.tf
+++ b/terraform/cloud-platform-eks/components/components.tf
@@ -1,6 +1,6 @@
 
 module "concourse" {
-  source                                      = "github.com/ministryofjustice/cloud-platform-terraform-concourse?ref=1.3.1"
+  source                                      = "github.com/ministryofjustice/cloud-platform-terraform-concourse?ref=1.3.3"
   vpc_id                                      = data.terraform_remote_state.cluster.outputs.vpc_id
   internal_subnets                            = data.terraform_remote_state.cluster.outputs.internal_subnets
   internal_subnets_ids                        = data.terraform_remote_state.cluster.outputs.internal_subnets_ids


### PR DESCRIPTION
1.3.2 - Remove minor version upgrade for postgres
 1.3.3 - Upgrade helm chart 13.0.0 and concourse version 6.6.0