### PR TITLE
Add three ingress instance groups

### DIFF
--- a/kops/live-1.yaml
+++ b/kops/live-1.yaml
@@ -442,7 +442,7 @@ metadata:
   name: ingress-nodes-1.17.12-eu-west-2a
 spec:
   image: kope.io/k8s-1.17-debian-stretch-amd64-hvm-ebs-2020-07-20
-  machineType: r5.xlarge
+  machineType: c4.xlarge
   maxSize: 1
   minSize: 1
   rootVolumeSize: 256
@@ -473,7 +473,7 @@ metadata:
   name: ingress-nodes-1.17.12-eu-west-2b
 spec:
   image: kope.io/k8s-1.17-debian-stretch-amd64-hvm-ebs-2020-07-20
-  machineType: r5.xlarge
+  machineType: c4.xlarge
   maxSize: 1
   minSize: 1
   rootVolumeSize: 256
@@ -504,7 +504,7 @@ metadata:
   name: ingress-nodes-1.17.12-eu-west-2c
 spec:
   image: kope.io/k8s-1.17-debian-stretch-amd64-hvm-ebs-2020-07-20
-  machineType: r5.xlarge
+  machineType: c4.xlarge
   maxSize: 1
   minSize: 1
   rootVolumeSize: 256
@@ -531,6 +531,8 @@ spec:
 # https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/091ff8cc054fb2f87734edef8de28dd31d71b0b2/recycle-node.rb#L93 #
 #                                                                                                                                      #
 ########################################################################################################################################
+
+---
 
 apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup

--- a/kops/live-1.yaml
+++ b/kops/live-1.yaml
@@ -433,6 +433,97 @@ spec:
 
 ---
 
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: null
+  labels:
+    kops.k8s.io/cluster: live-1.cloud-platform.service.justice.gov.uk
+  name: ingress-nodes-1.17.12-eu-west-2a
+spec:
+  image: kope.io/k8s-1.17-debian-stretch-amd64-hvm-ebs-2020-07-20
+  machineType: r5.xlarge
+  maxSize: 1
+  minSize: 1
+  rootVolumeSize: 256
+  nodeLabels:
+    kops.k8s.io/instancegroup: ingress-nodes-1.17.12-eu-west-2a
+  cloudLabels:
+    application: moj-cloud-platform
+    business-unit: platforms
+    is-production: "true"
+    k8s.io/cluster/live-1.cloud-platform.service.justice.gov.uk: ""
+    role: node
+    owner: cloud-platform:platforms@digital.justice.gov.uk
+    source-code: https://github.com/ministryofjustice/cloud-platform-infrastructure
+  role: Node
+  taints:
+  - ingress-node=true:NoSchedule
+  subnets:
+  - eu-west-2a
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: null
+  labels:
+    kops.k8s.io/cluster: live-1.cloud-platform.service.justice.gov.uk
+  name: ingress-nodes-1.17.12-eu-west-2b
+spec:
+  image: kope.io/k8s-1.17-debian-stretch-amd64-hvm-ebs-2020-07-20
+  machineType: r5.xlarge
+  maxSize: 1
+  minSize: 1
+  rootVolumeSize: 256
+  nodeLabels:
+    kops.k8s.io/instancegroup: ingress-nodes-1.17.12-eu-west-2b
+  cloudLabels:
+    application: moj-cloud-platform
+    business-unit: platforms
+    is-production: "true"
+    k8s.io/cluster/live-1.cloud-platform.service.justice.gov.uk: ""
+    role: node
+    owner: cloud-platform:platforms@digital.justice.gov.uk
+    source-code: https://github.com/ministryofjustice/cloud-platform-infrastructure
+  role: Node
+  taints:
+  - ingress-node=true:NoSchedule
+  subnets:
+  - eu-west-2b
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: null
+  labels:
+    kops.k8s.io/cluster: live-1.cloud-platform.service.justice.gov.uk
+  name: ingress-nodes-1.17.12-eu-west-2c
+spec:
+  image: kope.io/k8s-1.17-debian-stretch-amd64-hvm-ebs-2020-07-20
+  machineType: r5.xlarge
+  maxSize: 1
+  minSize: 1
+  rootVolumeSize: 256
+  nodeLabels:
+    kops.k8s.io/instancegroup: ingress-nodes-1.17.12-eu-west-2c
+  cloudLabels:
+    application: moj-cloud-platform
+    business-unit: platforms
+    is-production: "true"
+    k8s.io/cluster/live-1.cloud-platform.service.justice.gov.uk: ""
+    role: node
+    owner: cloud-platform:platforms@digital.justice.gov.uk
+    source-code: https://github.com/ministryofjustice/cloud-platform-infrastructure
+  role: Node
+  taints:
+  - ingress-node=true:NoSchedule
+  subnets:
+  - eu-west-2c
+
 ########################################################################################################################################
 #                                                                                                                                      #
 # NOTE: Label 'cloud-platform-recycle-nodes: "true"' in this multiple Availability Zone InstanceGroups, used for node-recycler.        #

--- a/kops/live-1.yaml
+++ b/kops/live-1.yaml
@@ -442,7 +442,7 @@ metadata:
   name: ingress-nodes-1.17.12-eu-west-2a
 spec:
   image: kope.io/k8s-1.17-debian-stretch-amd64-hvm-ebs-2020-07-20
-  machineType: c4.xlarge
+  machineType: c5.xlarge
   maxSize: 1
   minSize: 1
   rootVolumeSize: 256
@@ -473,7 +473,7 @@ metadata:
   name: ingress-nodes-1.17.12-eu-west-2b
 spec:
   image: kope.io/k8s-1.17-debian-stretch-amd64-hvm-ebs-2020-07-20
-  machineType: c4.xlarge
+  machineType: c5.xlarge
   maxSize: 1
   minSize: 1
   rootVolumeSize: 256
@@ -504,7 +504,7 @@ metadata:
   name: ingress-nodes-1.17.12-eu-west-2c
 spec:
   image: kope.io/k8s-1.17-debian-stretch-amd64-hvm-ebs-2020-07-20
-  machineType: c4.xlarge
+  machineType: c5.xlarge
   maxSize: 1
   minSize: 1
   rootVolumeSize: 256


### PR DESCRIPTION
This commit adds three additional instance groups to the Kops manifest.
These groups contain a single instance in each eu-west-2 az to allow
for fine grained failure and scale.

The idea behind these instance groups is to dedicate a resource pool to
a critical component in a production cluster.

This PR connects to https://github.com/ministryofjustice/cloud-platform/issues/2416