### PR TITLE
Disable all specs which create ingresses

### DIFF
--- a/smoke-tests/spec/cert_manager_spec.rb
+++ b/smoke-tests/spec/cert_manager_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe "cert-manager" do
+xdescribe "cert-manager" do
   let(:namespace) { "cert-manager-test-#{readable_timestamp}" }
   ingress_class = "nginx"
 

--- a/smoke-tests/spec/ingress_spec.rb
+++ b/smoke-tests/spec/ingress_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe "nginx ingress", speed: "slow" do
+xdescribe "nginx ingress", speed: "slow" do
   namespace = "smoketest-ingress-#{readable_timestamp}"
   host = "#{namespace}-nginx.apps.#{current_cluster}"
   let(:url) { "https://#{host}" }

--- a/smoke-tests/spec/modsec_spec.rb
+++ b/smoke-tests/spec/modsec_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 # Integration tests has the dedicated ingress controller with ingress class - integration-test
 # The below spec uses the ingress_class = "integration-test" in its ingress annotation
 
-describe "Testing modsec on ingress class: 'integration-test'", kops: true do
+xdescribe "Testing modsec on ingress class: 'integration-test'", kops: true do
   namespace = "integrationtest-modsec-#{readable_timestamp}"
   host = "#{namespace}.apps.#{current_cluster}"
   let(:url) { "https://#{host}" }


### PR DESCRIPTION
This reduces the integration tests until they do virtually nothing :(

This is (hopefully) a temporary measure until we are confident our default ingress controller is stable.
