### PR TITLE
Add modsec ingress controller

### DIFF
--- a/terraform/cloud-platform-components/components.tf
+++ b/terraform/cloud-platform-components/components.tf
@@ -94,7 +94,7 @@ module "modsec_ingress_controllers" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-modsec-ingress-controller?ref=0.0.2"
 
   controller_name = "modsec01"
-  replica_count = "3"
+  replica_count   = "3"
 
   dependence_prometheus  = module.prometheus.helm_prometheus_operator_status
   dependence_certmanager = module.cert_manager.helm_cert_manager_status

--- a/terraform/cloud-platform-components/components.tf
+++ b/terraform/cloud-platform-components/components.tf
@@ -90,7 +90,15 @@ module "ingress_controller_integration_test" {
   dependence_certmanager = module.cert_manager.helm_cert_manager_status
 }
 
+module "modsec_ingress_controllers" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-modsec-ingress-controller?ref=0.0.2"
 
+  controller_name = "modsec01"
+  replica_count = "3"
+
+  dependence_prometheus  = module.prometheus.helm_prometheus_operator_status
+  dependence_certmanager = module.cert_manager.helm_cert_manager_status
+}
 
 module "ingress_controllers" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=0.0.7"


### PR DESCRIPTION
This commit connects to
https://github.com/ministryofjustice/cloud-platform/issues/2406 and
relates to the requirement of an ingress controller with modsec turned
on.