### PR TITLE
Added new fixture for mod-sec integration tests

### DIFF
--- a/smoke-tests/spec/fixtures/helloworld-deployment-modsec.yaml.erb
+++ b/smoke-tests/spec/fixtures/helloworld-deployment-modsec.yaml.erb
@@ -37,7 +37,11 @@ kind: Ingress
 metadata:
   name: integration-test-app-ing
   annotations:
-    kubernetes.io/ingress.class: <%= ingress_class %>
+    kubernetes.io/ingress.class: <%= ingress_class %> 
+    nginx.ingress.kubernetes.io/enable-modsecurity: "false"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      Include /etc/nginx/owasp-modsecurity-crs/nginx-modsecurity.conf
+      SecRuleEngine On
 spec:
   tls:
   - hosts:

--- a/smoke-tests/spec/modsec_spec.rb
+++ b/smoke-tests/spec/modsec_spec.rb
@@ -21,7 +21,7 @@ xdescribe "Testing modsec on ingress class: 'integration-test'", kops: true do
       namespace: namespace,
       host: host,
       ingress_class: ingress_class,
-      file: "spec/fixtures/helloworld-deployment.yaml.erb",
+      file: "spec/fixtures/helloworld-deployment-modsec.yaml.erb",
       binding: binding
     )
     wait_for(namespace, "ingress", ingress_name)


### PR DESCRIPTION
As we have a new OPA policy which will block mod-sec config on ingress, created a separate file for mod-sec tests