### PR TITLE
Remove kiam from list of group which uses 'psp:privileged' clusterRol…

### DIFF
--- a/terraform/cloud-platform-components/components.tf
+++ b/terraform/cloud-platform-components/components.tf
@@ -26,7 +26,7 @@ module "external_dns" {
 }
 
 module "kiam" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-kiam?ref=0.0.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-kiam?ref=0.0.3"
 
   # This module requires prometheus and OPA already deployed
   dependence_prometheus = module.prometheus.helm_prometheus_operator_status

--- a/terraform/cloud-platform-components/resources/psp/pod-security-policy.yaml
+++ b/terraform/cloud-platform-components/resources/psp/pod-security-policy.yaml
@@ -165,8 +165,5 @@ subjects:
   name: system:serviceaccounts:monitoring
   apiGroup: rbac.authorization.k8s.io
 - kind: Group
-  name: system:serviceaccounts:kiam
-  apiGroup: rbac.authorization.k8s.io
-- kind: Group
   name: system:serviceaccounts:opa
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
…e. Kiam uses its own cluster role and psp

Related to: https://github.com/ministryofjustice/cloud-platform-terraform-kiam/pull/2
and https://github.com/ministryofjustice/cloud-platform/issues/2335