### PR TITLE
Remove fluentd from list of expected daemonsets

### DIFF
--- a/smoke-tests/spec/daemonsets_spec.rb
+++ b/smoke-tests/spec/daemonsets_spec.rb
@@ -21,7 +21,6 @@ describe "daemonsets", speed: "fast" do
     expected = [
       "calico-node",
       "fluent-bit",
-      "fluentd-es",
       "kiam-agent",
       "kiam-server",
       "kops-controller",


### PR DESCRIPTION
Now that we have switched completely to fluentbit, this test needs to be
updated.
