### PR TITLE
Add only capabilities needed for the privileged PSP

### DIFF
--- a/terraform/cloud-platform-components/resources/psp/pod-security-policy.yaml
+++ b/terraform/cloud-platform-components/resources/psp/pod-security-policy.yaml
@@ -13,7 +13,10 @@ spec:
   privileged: true
   allowPrivilegeEscalation: true
   allowedCapabilities:
-  - '*'
+    - NET_BIND_SERVICE
+    - NET_ADMIN
+  requiredDropCapabilities:
+    - NET_RAW
   volumes:
   - '*'
   hostNetwork: true


### PR DESCRIPTION
Add only capabilities needed for the privileged instead of a wildcard. This would allow to add any drop capabilities. Drop NET_RAW capability as this would allow root access to all the pod running as privileged CVE-2020-14386. NET_ADMIN is enough to run any pods with escalated permissions.

Related to: https://github.com/ministryofjustice/cloud-platform/issues/2335