### PR TITLE
Add tests for different ingress controllers

### DIFF
--- a/smoke-tests/spec/ingress_controller_spec.rb
+++ b/smoke-tests/spec/ingress_controller_spec.rb
@@ -1,0 +1,37 @@
+require "spec_helper"
+
+describe "ingress controllers", speed: "fast" do
+  context "default" do
+    # This needs to be any url of an ingress on the default controller,
+    let(:url) { "https://how-out-of-date-are-we.apps.live-1.cloud-platform.service.justice.gov.uk/dashboard" }
+
+    it "returns 200 for http get" do
+      result = Net::HTTP.get_response(URI(url))
+      expect(result.code).to eq("200")
+      expect(result.message.strip).to eq("OK")
+    end
+
+    it "does not return a server header" do
+      # The `Server` response header should be suppressed by the ingress-controller configuration
+      result = Net::HTTP.get_response(URI(url))
+      headers = result.each_header.to_h
+      expect(headers).to_not have_key("server")
+    end
+  end
+
+  context "modsec01" do
+    # This needs to be any hostname of an ingress on the modsec01 controller,
+    let(:url) { "https://manage-hmpps-auth-accounts-dev.prison.service.justice.gov.uk/" }
+
+    it "returns 302 for http get" do
+      result = Net::HTTP.get_response(URI(url))
+      expect(result.code).to eq("302")
+    end
+
+    it "does not return a server header" do
+      result = Net::HTTP.get_response(URI(url))
+      headers = result.each_header.to_h
+      expect(headers).to_not have_key("server")
+    end
+  end
+end

--- a/smoke-tests/spec/spec_helper.rb
+++ b/smoke-tests/spec/spec_helper.rb
@@ -99,6 +99,7 @@ end
 
 require "aws-sdk-route53"
 require "aws-sdk-iam"
+require "net/http"
 require "open-uri"
 require "pry-byebug"
 require "erb"


### PR DESCRIPTION
These specs check that known ingresses on each of
the "nginx" and "modsec01" ingress controllers
respond as expected.

In particular, the specs confirm that the "Server"
header is not returned in the HTTP response.

As of now, this is true for the "modsec01" 
controller, but not for the "nginx" controller,
which needs a small configuration change to 
suppress that header. So, this test will fail
until that change is made.

These tests are quite brittle, because they depend
on an ingress which we don't control. 