### PR TITLE
Use v0.0.11 for default ingress controller

### DIFF
--- a/terraform/cloud-platform-components/components.tf
+++ b/terraform/cloud-platform-components/components.tf
@@ -114,7 +114,7 @@ module "modsec_ingress_controllers" {
 }
 
 module "ingress_controllers" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=0.0.10"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=0.0.11"
 
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   is_live_cluster     = terraform.workspace == local.live_workspace ? true : false


### PR DESCRIPTION
Applying the EKS version of this change, #962, did not cause any downtime to the "concourse" ingress, so I think this change should be safe to apply too.