### PR TITLE
Ignore starter-pack namespaces

### DIFF
--- a/destroy-cluster.rb
+++ b/destroy-cluster.rb
@@ -14,10 +14,9 @@ SYSTEM_NAMESPACES = %w[
   kuberos
   logging
   monitoring
-  starter-pack
   opa
   velero
-]
+] + (0..9).map { |i| "starter-pack-#{i}" }
 
 MAX_CLUSTER_NAME_LENGTH = 12
 REQUIRED_ENV_VARS = %w[AWS_PROFILE AUTH0_DOMAIN AUTH0_CLIENT_ID AUTH0_CLIENT_SECRET KOPS_STATE_STORE]


### PR DESCRIPTION
The starter-pack was recently changed, so that the namespace which
exists by default is `starter-pack-0` rather than `starter-pack`

This caused the cluster delete pipeline job to fail.

This change will ignore any namespaces called `starter-pack-0` to
`starter-pack-9`, when deciding if it is safe to delete a cluster.
