### PR TITLE
Add delete node step after draining.

### DIFF
--- a/recycle-node.rb
+++ b/recycle-node.rb
@@ -42,6 +42,7 @@ def main
   sleep 30
 
   node = get_latest_node_details(node) # node status should have changed, after being drained
+  delete_node(node)
   terminate_node(node)
 
   sleep 60
@@ -158,6 +159,16 @@ end
 def get_latest_node_details(node)
   name = node_name(node)
   JSON.parse(execute("kubectl get node #{name} -o json"))
+end
+
+def delete_node(node)
+  name = node_name(node)
+
+  if cordoned?(node)
+    execute "kubectl delete node #{name}"
+  else
+    raise "worker node #{name} was not cordoned."
+  end
 end
 
 def terminate_node(node)


### PR DESCRIPTION
This will allow will remove it from the cluster entirel and as part of that process, it will remove it from ELB targetgroup for de-registering. This will ensure the existing connections are closed from ELB side.

As part of this ticket, the "Connection termination on deregistration" is enabled for the load-balancer of default ingress-controller.

Related to: https://github.com/ministryofjustice/cloud-platform/issues/2540

