### PR TITLE
WIP Add initial e2e kuttl tests for Prometheus, CertManager and psp

### DIFF
--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -1,0 +1,8 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestSuite
+testDirs:
+- ./tests/e2e/
+startKIND: false
+startControlPlane: false
+parallel: 8
+timeout: 120

--- a/tests/e2e/deploy/00-assert.yaml
+++ b/tests/e2e/deploy/00-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: integration-test-helloworld
+status:
+  readyReplicas: 1

--- a/tests/e2e/deploy/00-nginx.yaml
+++ b/tests/e2e/deploy/00-nginx.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: integration-test-helloworld
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: integration-test-app
+  template:
+    metadata:
+      labels:
+        app: integration-test-app
+    spec:
+      containers:
+      - name: nginx
+        image: bitnami/nginx
+        ports:
+        - containerPort: 8080

--- a/tests/e2e/prometheus/00-assert.yaml
+++ b/tests/e2e/prometheus/00-assert.yaml
@@ -1,0 +1,7 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: integration-test-helloworld
+spec:
+  groups:
+  - name: application-rules

--- a/tests/e2e/prometheus/00-rules.yaml
+++ b/tests/e2e/prometheus/00-rules.yaml
@@ -1,0 +1,18 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: kuttl-prometheus-rule-test
+  labels:
+    role: kuttl-prometheus-rule-test
+spec:
+  groups:
+  - name: application-rules
+    rules:
+    - alert: KubePodCrashLooping
+      annotations:
+        message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting {{ printf "%.2f" $value }} times / 5 minutes.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodcrashlooping
+      expr: rate(kube_pod_container_status_restarts_total{job="kube-state-metrics", namespace="hmpps-book-secure-move-api-staging"}[15m]) * 60 * 5 > 0
+      for: 1h
+      labels:
+        severity: test

--- a/tests/e2e/psp/00-assert.yaml
+++ b/tests/e2e/psp/00-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: unprivileged-integration-test
+status:
+  readyReplicas: 1

--- a/tests/e2e/psp/00-unpriv.yaml
+++ b/tests/e2e/psp/00-unpriv.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: unprivileged-integration-test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: unprivileged-integration-test
+  template:
+    metadata:
+      labels:
+        app: unprivileged-integration-test
+    spec:
+      containers:
+        - name: nginx
+          image: bitnami/nginx
+          imagePullPolicy: "IfNotPresent"
+          ports:
+            - containerPort: 5432

--- a/tests/e2e/psp/01-errors.yaml
+++ b/tests/e2e/psp/01-errors.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: privileged-integration-test
+status:
+  phase: Failed

--- a/tests/e2e/psp/01-priv.yaml
+++ b/tests/e2e/psp/01-priv.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: privileged-integration-test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: privileged-integration-test
+  template:
+    metadata:
+      labels:
+        app: privileged-integration-test
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:10.4
+          imagePullPolicy: "IfNotPresent"
+          ports:
+            - containerPort: 5432


### PR DESCRIPTION
Overview
---
This draft PR connects to https://github.com/ministryofjustice/cloud-platform/issues/2515 and relates to the firebreak research into the Kubernetes test framework kuttl. 