### PR TITLE
Add argument for adding a Docker config file to nodes

### DIFF
--- a/create-cluster.rb
+++ b/create-cluster.rb
@@ -106,7 +106,7 @@ def run_kops(cluster_name, dockerconfig)
 end
 
 def add_dockerconfig(cluster_name, path)
-  if(!File.exists?(path))
+  if !File.exist?(path)
     puts "Docker config file specified #{path} does not exist."
   else
     run_and_output "kops create secret dockerconfig -f #{path} --name #{cluster_name}.#{CLUSTER_SUFFIX}"

--- a/makefile
+++ b/makefile
@@ -11,6 +11,7 @@ tools-shell:
 		-v $$(pwd):/app \
 		-v $${HOME}/.aws:/root/.aws \
 		-v $${HOME}/.gnupg:/root/.gnupg \
+		-v $${HOME}/.docker:/root/.docker \
 		-w /app \
 		$(TOOLS_IMAGE) bash
 


### PR DESCRIPTION
Connects to https://github.com/ministryofjustice/cloud-platform/issues/2566

Due to the rate limiting on un-authenticated user accounts in Docker
hub, we need to add a docker config file to the worker and master nodes.
This is achieved by adding a kops secret, containing the base64 encoded
docker config file.

The following commit amends the `create-cluster.rb` script to allow
passing an argument to include a dockerconfig file or not. If the
argument is passed, the `add_dockerconfig` function checks the file
exists and executes the required command. I didn't want the script to
fail if the dockerfile doesn't exist so it should shield the [add secret](https://github.com/kubernetes/kops/blob/master/docs/cli/kops_create_secret_dockerconfig.md)
command to execute only if it exists.