### PR TITLE
Remove ECR repos

### DIFF
--- a/terraform/cloud-platform-account/main.tf
+++ b/terraform/cloud-platform-account/main.tf
@@ -39,20 +39,3 @@ module "baselines" {
     "cloud-platform-6cf3132ef8fce52bb371b1d02f40c36d"
   ]
 }
-
-# ECR repository for cloud-platform-cli
-module "ecr_cloud_platform_cli" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.1"
-
-  repo_name = "cloud-platform-cli"
-  team_name = "cloud-platform"
-}
-
-# ECR repository for cloud-platform-tools-image
-module "ecr_cloud_platform_tools_image" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.1"
-
-  repo_name = "cloud-platform-tools-image"
-  team_name = "cloud-platform"
-}
-


### PR DESCRIPTION
We got the DockerHub pro account. We don't need this ECR repos anymore.