### PR TITLE
Upgrade ingress controller to module 0.1.0 …

### DIFF
--- a/terraform/cloud-platform-components/components.tf
+++ b/terraform/cloud-platform-components/components.tf
@@ -92,7 +92,7 @@ module "ingress_controllers_k8snginx_fallback" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-k8s-ingress-controller?ref=0.0.3"
 
   # boolean expression for applying standby ingress-controller for live-1 cluster only.
-  enable_fallback_ingress_controller = terraform.workspace == local.live_workspace ? true : false
+  enable_fallback_ingress_controller = true
   # Will be used as the ingress controller name and the class annotation
   controller_name = "k8snginx"
   replica_count   = "6"
@@ -114,7 +114,7 @@ module "modsec_ingress_controllers" {
 }
 
 module "ingress_controllers" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=0.0.12"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=0.1.0"
 
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   is_live_cluster     = terraform.workspace == local.live_workspace ? true : false


### PR DESCRIPTION
This uses chart ingress-nginx version 3.6.0. More details refer: https://github.com/ministryofjustice/cloud-platform-terraform-ingress-controller/pull/5