### PR TITLE
Remove mixed instance policies within monitoring nodes

### DIFF
--- a/kops/live-1.yaml
+++ b/kops/live-1.yaml
@@ -411,6 +411,11 @@ metadata:
 spec:
   image: kope.io/k8s-1.17-debian-stretch-amd64-hvm-ebs-2020-07-20
   machineType: r5.2xlarge
+  mixedInstancesPolicy:
+    instances:
+    - r5.xlarge
+    - c5.xlarge
+    - r4.xlarge
   maxSize: 2
   minSize: 2
   rootVolumeSize: 256
@@ -550,6 +555,11 @@ metadata:
 spec:
   image: kope.io/k8s-1.17-debian-stretch-amd64-hvm-ebs-2020-07-20
   machineType: r5.xlarge
+  mixedInstancesPolicy:
+    instances:
+    - r5.xlarge
+    - c5.xlarge
+    - r4.xlarge
   maxSize: 9
   minSize: 9
   rootVolumeSize: 256
@@ -580,6 +590,11 @@ metadata:
 spec:
   image: kope.io/k8s-1.17-debian-stretch-amd64-hvm-ebs-2020-07-20
   machineType: r5.xlarge
+  mixedInstancesPolicy:
+    instances:
+    - r5.xlarge
+    - c5.xlarge
+    - r4.xlarge
   maxSize: 9
   minSize: 9
   rootVolumeSize: 256
@@ -610,6 +625,11 @@ metadata:
 spec:
   image: kope.io/k8s-1.17-debian-stretch-amd64-hvm-ebs-2020-07-20
   machineType: r5.xlarge
+  mixedInstancesPolicy:
+    instances:
+    - r5.xlarge
+    - c5.xlarge
+    - r4.xlarge
   maxSize: 9
   minSize: 9
   rootVolumeSize: 256

--- a/kops/live-1.yaml
+++ b/kops/live-1.yaml
@@ -411,11 +411,6 @@ metadata:
 spec:
   image: kope.io/k8s-1.17-debian-stretch-amd64-hvm-ebs-2020-07-20
   machineType: r5.2xlarge
-  mixedInstancesPolicy:
-    instances:
-    - r5.xlarge
-    - c5.xlarge
-    - r4.xlarge
   maxSize: 2
   minSize: 2
   rootVolumeSize: 256

--- a/terraform/cloud-platform/main.tf
+++ b/terraform/cloud-platform/main.tf
@@ -59,7 +59,7 @@ locals {
 ########
 
 module "kops" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-kops?ref=0.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-kops?ref=0.1.1"
 
   vpc_name            = local.vpc
   cluster_domain_name = trimsuffix(local.cluster_base_domain_name, ".")


### PR DESCRIPTION
This aligns the code with the manual changes we did during the incident at the beginning of the week. This should also fix the kops divergence pipeline.