### PR TITLE
Remove fallback ingress controller

### DIFF
--- a/terraform/cloud-platform-components/components.tf
+++ b/terraform/cloud-platform-components/components.tf
@@ -88,20 +88,6 @@ module "ingress_controller_integration_test" {
   dependence_certmanager = module.cert_manager.helm_cert_manager_status
 }
 
-module "ingress_controllers_k8snginx_fallback" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-k8s-ingress-controller?ref=0.0.3"
-
-  # boolean expression for applying standby ingress-controller for live-1 cluster only.
-  enable_fallback_ingress_controller = true
-  # Will be used as the ingress controller name and the class annotation
-  controller_name = "k8snginx"
-  replica_count   = "6"
-
-  # This module requires prometheus and certmanager
-  dependence_prometheus  = module.prometheus.helm_prometheus_operator_status
-  dependence_certmanager = module.cert_manager.helm_cert_manager_status
-}
-
 
 module "modsec_ingress_controllers" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-modsec-ingress-controller?ref=0.0.6"


### PR DESCRIPTION
The Ingress controller upgrade is completed for live-1 so this is no longer required