### PR TITLE
Remove vpc_name input during eks cluster creation

### DIFF
--- a/create-cluster.rb
+++ b/create-cluster.rb
@@ -86,7 +86,6 @@ def create_cluster_eks(cluster_name, vpc_name)
 
   tf_apply = [
     "terraform apply",
-    *("-var vpc_name=\"#{vpc_name}\"" if vpc_name),
     "-auto-approve"
   ].join(" ")
 


### PR DESCRIPTION
The `cloud-platform-eks` module look for the var.vpc_name for a given key, if not provided will use terraform.workspace as a vpc_name. For all eks test clusters the vpc_name is same as the workspace name.