### PR TITLE
Fix eventrouter helm repo in EKS

### DIFF
--- a/terraform/cloud-platform-eks/components/components.tf
+++ b/terraform/cloud-platform-eks/components/components.tf
@@ -84,7 +84,7 @@ module "ingress_controllers" {
 }
 
 module "logging" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-logging?ref=1.0.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-logging?ref=1.0.3"
 
   elasticsearch_host       = lookup(var.elasticsearch_hosts_maps, terraform.workspace, "placeholder-elasticsearch")
   elasticsearch_audit_host = lookup(var.elasticsearch_audit_hosts_maps, terraform.workspace, "placeholder-elasticsearch")


### PR DESCRIPTION
Upgrading to the latest logging module, otherwise EKS clusters fail in creation with:

```
Error: failed to download "stable/eventrouter" (hint: running `helm repo update` may help)
  on .terraform/modules/logging/main.tf line 63, in resource "helm_release" "eventrouter":
  63: resource "helm_release" "eventrouter" {
```