### PR TITLE
Fix duplicate secret in terraform/cross-account-iam

### DIFF
--- a/terraform/cross-account-IAM/pathfinder-to-analytical-platform-prod.tf
+++ b/terraform/cross-account-IAM/pathfinder-to-analytical-platform-prod.tf
@@ -28,7 +28,7 @@ resource "aws_iam_role" "pathfinder-prod-ap" {
   assume_role_policy = data.aws_iam_policy_document.pathfinder-prod-kiam-trust-chain.json
 }
 
-resource "kubernetes_secret" "analytical_platform_landing_bucket" {
+resource "kubernetes_secret" "analytical_platform_landing_bucket_prod" {
   metadata {
     name      = "analytical-platform-landing-bucket"
     namespace = "pathfinder-prod"


### PR DESCRIPTION
This fixes the validation error:
```
Error: Duplicate resource "kubernetes_secret" configuration

  on pathfinder-to-analytical-platform-prod.tf line 31:
  31: resource "kubernetes_secret" "analytical_platform_landing_bucket" {

A kubernetes_secret resource named "analytical_platform_landing_bucket" was
already declared at pathfinder-to-analytical-platform-preprod.tf:31,1-66.
Resource names must be unique per type in each module.

```