### PR TITLE
Pin kubernetes provider version specific to 1.11.1

### DIFF
--- a/terraform/cloud-platform-eks/components/main.tf
+++ b/terraform/cloud-platform-eks/components/main.tf
@@ -20,7 +20,7 @@ provider "aws" {
 }
 
 provider "kubernetes" {
-  version = "~> 1.11"
+  version = "~> 1.11.1"
 }
 
 # Unfortunatly we are facing https://github.com/terraform-providers/terraform-provider-helm/issues/458 and


### PR DESCRIPTION
- Terraform plan and apply stuck and only works on this version.
- This fix the test EKS cluster creation.