### PR TITLE
Disable installing fallback ingress controller on test cluster 

### DIFF
--- a/terraform/cloud-platform-components/components.tf
+++ b/terraform/cloud-platform-components/components.tf
@@ -115,11 +115,11 @@ module "ingress_controllers_k8snginx_fallback" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-k8s-ingress-controller?ref=0.0.4"
 
   # boolean expression for applying standby ingress-controller for live-1 cluster only.
-  enable_fallback_ingress_controller = true
+  enable_fallback_ingress_controller = terraform.workspace == local.live_workspace ? true : false
   # Will be used as the ingress controller name and the class annotation
   controller_name                                    = "k8snginx"
   replica_count                                      = "6"
-  enable_ingress_controller_affinity_and_tolerations = true
+  enable_ingress_controller_affinity_and_tolerations = terraform.workspace == local.live_workspace ? true : false
 
   # This module requires prometheus and certmanager
   dependence_prometheus  = module.prometheus.helm_prometheus_operator_status


### PR DESCRIPTION
Also, disable affinity flag as this is specific to scheduling the ingress pods to ingress-nodes nodegroup which is not available in test clusters