### PR TITLE
Bump logging module which enable fluent-bit on Nodegroup ingress-nodes

### DIFF
--- a/terraform/cloud-platform-components/components.tf
+++ b/terraform/cloud-platform-components/components.tf
@@ -46,7 +46,7 @@ module "kuberos" {
 
 
 module "logging" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-logging?ref=1.0.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-logging?ref=1.0.4"
 
   # if you need to connect to the test elasticsearch cluster, replace "placeholder-elasticsearch" with "search-cloud-platform-test-zradqd7twglkaydvgwhpuypzy4.eu-west-2.es.amazonaws.com"
   # -> value = "${replace(terraform.workspace, "live", "") != terraform.workspace ? "search-cloud-platform-live-dibidbfud3uww3lpxnhj2jdws4.eu-west-2.es.amazonaws.com" : "search-cloud-platform-test-zradqd7twglkaydvgwhpuypzy4.eu-west-2.es.amazonaws.com"


### PR DESCRIPTION
Mode details on this PR: https://github.com/ministryofjustice/cloud-platform-terraform-logging/pull/28/