### PR TITLE
Check all nodes for fluent-bit pods integration tests

### DIFF
--- a/smoke-tests/spec/daemonsets_spec.rb
+++ b/smoke-tests/spec/daemonsets_spec.rb
@@ -49,7 +49,7 @@ describe "daemonsets", speed: "fast" do
     let(:pods) { get_running_app_pods("logging", "fluent-bit") }
 
     it "runs fluent-bit" do
-      expect(non_ingress_node_ips).to eq(app_node_ips)
+      expect(all_node_ips).to eq(app_node_ips)
     end
 
     specify "all fluent-bit containers are running" do


### PR DESCRIPTION
The ingress-nodes have fluent-bit enabled and hence the fluent-bit tests has to include all_nodes.