### PR TITLE
Upgrade ingress controller of EKS to module 0.1.0

### DIFF
--- a/terraform/cloud-platform-eks/components/components.tf
+++ b/terraform/cloud-platform-eks/components/components.tf
@@ -73,7 +73,7 @@ module "external_dns" {
 }
 
 module "ingress_controllers" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=0.0.12"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=0.1.0"
 
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   is_live_cluster     = false


### PR DESCRIPTION
The module 0.1.0 uses latest chart ingress-nginx version 3.6.0