### PR TITLE
Increase EBS volume for ES clusters

### DIFF
--- a/terraform/global-resources/elasticsearch.tf
+++ b/terraform/global-resources/elasticsearch.tf
@@ -97,7 +97,7 @@ resource "aws_elasticsearch_domain" "live_1" {
   ebs_options {
     ebs_enabled = "true"
     volume_type = "gp2"
-    volume_size = "1024"
+    volume_size = "2048"
   }
 
   advanced_options = {
@@ -175,7 +175,7 @@ resource "aws_elasticsearch_domain" "audit_1" {
   ebs_options {
     ebs_enabled = "true"
     volume_type = "gp2"
-    volume_size = "1024"
+    volume_size = "2048"
   }
 
   advanced_options = {

--- a/terraform/global-resources/guardduty.tf
+++ b/terraform/global-resources/guardduty.tf
@@ -33,7 +33,7 @@ resource "aws_s3_bucket" "security" {
   provider      = aws.cloud-platform-ireland
   bucket_prefix = var.bucket_prefix
   acl           = "private"
-  region        = var.aws_region
+  # region        = var.aws_region
 
   lifecycle {
     prevent_destroy = true


### PR DESCRIPTION
Both the main and the audit cluster are showing
"ClusterIndexWritesBlocked", and not recording any data.

This change should double the disk space for all cluster nodes.

This is not sufficient to fix the problem. After the disk space is
available, we also need to take the clusters out of read-only mode as
described in this blog post:

https://engineeernitesh.blogspot.com/2019/12/elasticsearch-error-clusterblockexcepti.html
