### PR TITLE
Added fluent-bit repository

### DIFF
--- a/terraform/cloud-platform-account/main.tf
+++ b/terraform/cloud-platform-account/main.tf
@@ -39,3 +39,10 @@ module "baselines" {
     "cloud-platform-6cf3132ef8fce52bb371b1d02f40c36d"
   ]
 }
+
+module "ecr_fluentbit" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.1"
+
+  repo_name = "fluent-bit"
+  team_name = "cloud-platform"
+}


### PR DESCRIPTION
In order to solve our issue with Dockerhub API rate limits (ONLY IN EKS SIDE), we are testing the possibility of mirroring the public repositories. This is a start with fluentbit 