### PR TITLE
Accept long cluster name, for destroy

### DIFF
--- a/destroy-cluster.rb
+++ b/destroy-cluster.rb
@@ -233,7 +233,7 @@ def parse_options
 
   OptionParser.new { |opts|
     opts.on("-n", "--name CLUSTER-NAME", "Cluster name (max. #{MAX_CLUSTER_NAME_LENGTH} chars)") do |name|
-      options[:cluster_name] = name
+      options[:cluster_name] = name.sub(".cloud-platform.service.justice.gov.uk", "")
     end
 
     opts.on("-v", "--vpc-name VPC-NAME", "VPC to destroy, defaults to CLUSTER-NAME") do |name|


### PR DESCRIPTION
This change allows the name of the cluster to be supplied as **either**
of:

* foobar
* foobar.cloud-platform.service.justice.gov.uk

This makes it easier to copy and paste the cluster name from the
output of `kops get clusters`
