### PR TITLE
Update Helm Terraform provider to 1.3.2

### DIFF
--- a/terraform/cloud-platform-components/main.tf
+++ b/terraform/cloud-platform-components/main.tf
@@ -20,7 +20,7 @@ provider "kubernetes" {
 }
 
 provider "helm" {
-  version = "1.1.0"
+  version = "1.3.2"
   kubernetes {
   }
 }

--- a/terraform/cloud-platform-eks/components/main.tf
+++ b/terraform/cloud-platform-eks/components/main.tf
@@ -23,10 +23,8 @@ provider "kubernetes" {
   version = "~> 1.11.1"
 }
 
-# Unfortunatly we are facing https://github.com/terraform-providers/terraform-provider-helm/issues/458 and
-# https://github.com/terraform-providers/terraform-provider-helm/issues/498 so we can't go to to higher version
 provider "helm" {
-  version = "1.0.0"
+  version = "1.3.2"
   kubernetes {}
 }
 

--- a/terraform/cross-account-IAM/main.tf
+++ b/terraform/cross-account-IAM/main.tf
@@ -22,7 +22,7 @@ provider "kubernetes" {
 }
 
 provider "helm" {
-  version = "0.10.4"
+  version = "1.3.2"
   kubernetes {
   }
 }


### PR DESCRIPTION
Overview
---

This PR links to https://github.com/ministryofjustice/cloud-platform/issues/2132 and relates to the Helm Terraform provider upgrade work across all cloud-platform-* repositories.

To see the comparison between versions, please see [here](https://github.com/hashicorp/terraform-provider-helm/compare/v1.1.1...v1.3.2)

Testing
---

I have completed an init and plan in all three Terraform states and they came up clean.