### PR TITLE
Increase es nodes live1 to 15

### DIFF
--- a/terraform/global-resources/elasticsearch.tf
+++ b/terraform/global-resources/elasticsearch.tf
@@ -83,7 +83,7 @@ resource "aws_elasticsearch_domain" "live_1" {
 
   cluster_config {
     instance_type            = "m4.4xlarge.elasticsearch"
-    instance_count           = "12"
+    instance_count           = "15"
     dedicated_master_enabled = true
     dedicated_master_type    = "m4.large.elasticsearch"
     dedicated_master_count   = "3"


### PR DESCRIPTION
WHAT
Increase number of nodes on live1 es cluster to 15

WHY
The minimum free space on a node was below the threshold of 20GB