### PR TITLE
Update components.tf

### DIFF
--- a/terraform/cloud-platform-components/components.tf
+++ b/terraform/cloud-platform-components/components.tf
@@ -59,7 +59,7 @@ module "logging" {
 }
 
 module "prometheus" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=0.6.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=0.6.2"
 
   alertmanager_slack_receivers               = var.alertmanager_slack_receivers
   iam_role_nodes                             = data.aws_iam_role.nodes.arn

--- a/terraform/cloud-platform-eks/components/components.tf
+++ b/terraform/cloud-platform-eks/components/components.tf
@@ -93,7 +93,7 @@ module "logging" {
 }
 
 module "monitoring" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=0.6.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=0.6.2"
 
   alertmanager_slack_receivers = var.alertmanager_slack_receivers
   iam_role_nodes               = data.aws_iam_role.nodes.arn


### PR DESCRIPTION
With the latest release of monitoring terraform module we avoid destroying CRDs when Prometheus Operator is uninstalled. This will be particularly useful for the Prometheus Operator upgrade.