### PR TITLE
Enable write access to AP S3 bucket

### DIFF
--- a/terraform/cross-account-IAM/data-eng-rds-dev.tf
+++ b/terraform/cross-account-IAM/data-eng-rds-dev.tf
@@ -52,9 +52,7 @@ data "aws_iam_policy_document" "data-eng-rds-dev-ap" {
   # Provide list of permissions and target AWS account resources to allow access from
   statement {
     actions = [
-      "s3:PutObject",
-      "s3:upload",
-      "s3:listObjectsV2",
+      "s3:*"
     ]
     resources = [
       "arn:aws:s3:::mojap-land/hmpps/data-eng-rds-dev/dev/*",

--- a/terraform/cross-account-IAM/data-eng-rds-dev.tf
+++ b/terraform/cross-account-IAM/data-eng-rds-dev.tf
@@ -1,0 +1,73 @@
+data "aws_iam_policy_document" "data-eng-rds-dev-kiam-trust-chain" {
+  # KIAM trust chain to allow pods to assume roles defined below
+  statement {
+    principals {
+      type        = "AWS"
+      identifiers = [data.aws_iam_role.nodes.arn]
+    }
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+variable "data-eng-rds-dev-tags" {
+  type = map(string)
+  default = {
+    business-unit          = "HMPPS"
+    application            = "data-eng-rds-dev"
+    is-production          = "false"
+    environment-name       = "dev"
+    owner                  = "Probation data engineering"
+    infrastructure-support = "platforms@digital.justice.gov.uk"
+  }
+}
+
+resource "aws_iam_role" "data-eng-rds-dev-ap" {
+  name               = "data-eng-rds-dev-ap"
+  description        = "IAM role for data-eng-rds-dev to access AP s3 bucket - mojap-land"
+  tags               = var.data-eng-rds-dev-tags
+  assume_role_policy = data.aws_iam_policy_document.data-eng-rds-dev-kiam-trust-chain.json
+}
+
+resource "kubernetes_secret" "analytical_platform_landing_bucket_prod" {
+  metadata {
+    name      = "analytical-platform-landing-bucket"
+    namespace = "data-eng-rds-dev"
+  }
+
+  data = {
+    arn       = aws_iam_role.data-eng-rds-dev-ap.arn
+    name      = aws_iam_role.data-eng-rds-dev-ap.name
+    unique_id = aws_iam_role.data-eng-rds-dev-ap.unique_id
+  }
+}
+
+data "aws_iam_policy_document" "data-eng-rds-dev-ap" {
+
+  # allow pods to assume this role
+  statement {
+    actions   = ["sts:AssumeRole"]
+    resources = [aws_iam_role.data-eng-rds-dev-ap.arn]
+  }
+
+  # Provide list of permissions and target AWS account resources to allow access from
+  statement {
+    actions = [
+      "s3:PutObject",
+      "s3:upload",
+      "s3:listObjectsV2",
+    ]
+    resources = [
+      "arn:aws:s3:::mojap-land/hmpps/data-eng-rds-dev/dev/*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "data-eng-rds-dev-ap-policy" {
+  name   = "data-eng-rds-dev-ap-policy"
+  policy = data.aws_iam_policy_document.data-eng-rds-dev-ap.json
+}
+
+resource "aws_iam_role_policy_attachment" "data-eng-rds-dev-ap-policy" {
+  role       = aws_iam_role.data-eng-rds-dev-ap.name
+  policy_arn = aws_iam_policy.data-eng-rds-dev-ap-policy.arn
+}

--- a/terraform/cross-account-IAM/data-eng-rds-dev.tf
+++ b/terraform/cross-account-IAM/data-eng-rds-dev.tf
@@ -28,7 +28,7 @@ resource "aws_iam_role" "data-eng-rds-dev-ap" {
   assume_role_policy = data.aws_iam_policy_document.data-eng-rds-dev-kiam-trust-chain.json
 }
 
-resource "kubernetes_secret" "analytical_platform_landing_bucket_prod" {
+resource "kubernetes_secret" "ap_landing_bucket_prod" {
   metadata {
     name      = "analytical-platform-landing-bucket"
     namespace = "data-eng-rds-dev"


### PR DESCRIPTION
This PR is to enable probation microservices to write data dumps into an Analytical Platform (AP) S3 bucket.

Raised on behalf of Jacob Browning (a data engineer working on probation within the AP).




