### PR TITLE
bump version of flowlogs module, added condition on is_enabled

### DIFF
--- a/terraform/cloud-platform-network/main.tf
+++ b/terraform/cloud-platform-network/main.tf
@@ -71,3 +71,10 @@ module "vpc" {
     Domain    = local.vpc_base_domain_name
   }
 }
+
+### 
+module "flowlogs" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-flow-logs?ref=1.3"
+  is_enabled= terraform.workspace == "live-1" ? true : false
+  vpc_id= module.vpc.vpc_id
+}

--- a/terraform/cloud-platform-network/main.tf
+++ b/terraform/cloud-platform-network/main.tf
@@ -74,7 +74,7 @@ module "vpc" {
 
 ### 
 module "flowlogs" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-flow-logs?ref=1.3"
-  is_enabled= terraform.workspace == "live-1" ? true : false
-  vpc_id= module.vpc.vpc_id
+  source     = "github.com/ministryofjustice/cloud-platform-terraform-flow-logs?ref=1.3"
+  is_enabled = terraform.workspace == "live-1" ? true : false
+  vpc_id     = module.vpc.vpc_id
 }


### PR DESCRIPTION
Bump current version of the flow log module to the latest. 

https://github.com/ministryofjustice/cloud-platform-terraform-flow-logs/releases/tag/1.3