### PR TITLE
Updated Prometheus component to latest

### DIFF
--- a/terraform/cloud-platform-components/components.tf
+++ b/terraform/cloud-platform-components/components.tf
@@ -59,7 +59,7 @@ module "logging" {
 }
 
 module "prometheus" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=1.0.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=1.0.2"
 
   alertmanager_slack_receivers               = var.alertmanager_slack_receivers
   iam_role_nodes                             = data.aws_iam_role.nodes.arn

--- a/terraform/cloud-platform-eks/components/components.tf
+++ b/terraform/cloud-platform-eks/components/components.tf
@@ -94,7 +94,7 @@ module "logging" {
 }
 
 module "monitoring" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=1.0.2"
 
   alertmanager_slack_receivers = var.alertmanager_slack_receivers
   iam_role_nodes               = data.aws_iam_role.nodes.arn


### PR DESCRIPTION
Removed Helm provider deprecated resources. More info in https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/pull/71