### PR TITLE
Add default annotations and labels for ks ns

### DIFF
--- a/terraform/cloud-platform-components/main.tf
+++ b/terraform/cloud-platform-components/main.tf
@@ -69,4 +69,13 @@ locals {
   live_workspace = "live-1"
   live_domain    = "cloud-platform.service.justice.gov.uk"
 }
-
+resource "null_resource" "kube_system_default_annotations" {
+  provisioner "local-exec" {
+    command = "kubectl annotate --overwrite namespace kube-system 'cloud-platform.justice.gov.uk/business-unit=Platforms', 'cloud-platform.justice.gov.uk/application=Cloud Platform', 'cloud-platform.justice.gov.uk/owner=Cloud Platform: platforms@digital.justice.gov.uk', 'cloud-platform.justice.gov.uk/source-code= https://github.com/ministryofjustice/cloud-platform-infrastructure', 'cloud-platform.justice.gov.uk/slack-channel=cloud-platform' 'cloud-platform-out-of-hours-alert=true'"
+  }
+}
+resource "null_resource" "kube_system_default_labels" {
+  provisioner "local-exec" {
+    command = "kubectl label --overwrite namespace kube-system 'component=kube-system' 'cloud-platform.justice.gov.uk/slack-channel=cloud-platform' 'cloud-platform.justice.gov.uk/is-production=true' 'cloud-platform.justice.gov.uk/environment-name=production'"
+  }
+}


### PR DESCRIPTION
This PR will add two null resources in TF to add the Cloud Platform default NS annotations and Labels to the kube-system namespace.

