### PR TITLE
Default to encrypt *.tfstate rather than ignoring it

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 *.tfvars filter=git-crypt diff=git-crypt
-*.tfstate filter=git-crypt diff=git-crypt
+*.bootstrap_state filter=git-crypt diff=git-crypt
 iplist.txt filter=git-crypt diff=git-crypt
 
 # The EKS kubeconfig files

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 *.tfvars filter=git-crypt diff=git-crypt
+*.tfstate filter=git-crypt diff=git-crypt
 iplist.txt filter=git-crypt diff=git-crypt
 
 # The EKS kubeconfig files

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .terraform
-ssh/*id_rsa
 *.tfstate*
+ssh/*id_rsa
 generated/*
 .bundle
 .key

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .terraform
 ssh/*id_rsa
+*.tfstate*
 generated/*
 .bundle
 .key

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .terraform
-*.tfstate*
 ssh/*id_rsa
 generated/*
 .bundle


### PR DESCRIPTION
Because we need to find the way how to store the seed state (the one used to create the initial S3/DybamoDB table), it feels a good idea to store it encrypted within the repo instead of ignoring them. 