### PR TITLE
AWS Ephemeral account credentials required by Github actions

### DIFF
--- a/terraform/aws-accounts/cloud-platform-ephemeral-test/cloud-platform-account/main.tf
+++ b/terraform/aws-accounts/cloud-platform-ephemeral-test/cloud-platform-account/main.tf
@@ -61,6 +61,13 @@ resource "aws_route53_zone" "aws_account_hostzone_id" {
 # Automated tests #
 ###################
 
+# This module creates an AWS user and injest AWS_* keys within the specified 
+# GH repos in order to be used by the GH actions to execute unit-tests
 module "terratest" {
   source = "./modules/automated-tests"
+
+  github_repositories = [
+    "cloud-platform-terraform-ecr-credentials",
+    "cloud-platform-terraform-sqs",
+  ]
 }

--- a/terraform/aws-accounts/cloud-platform-ephemeral-test/cloud-platform-account/modules/automated-tests/main.tf
+++ b/terraform/aws-accounts/cloud-platform-ephemeral-test/cloud-platform-account/modules/automated-tests/main.tf
@@ -487,18 +487,16 @@ resource "aws_iam_policy_attachment" "attach_policy" {
 # Github #
 ##########
 
-data "github_actions_public_key" "cp_terraform_ecr_credentials" {
-  repository = "cloud-platform-terraform-ecr-credentials"
-}
-
-resource "github_actions_secret" "cp_terraform_ecr_aws_access_key" {
-  repository      = "cloud-platform-terraform-ecr-credentials"
+resource "github_actions_secret" "access_key" {
+  for_each        = toset(var.github_repositories)
+  repository      = each.key
   secret_name     = "AWS_ACCESS_KEY_ID"
   plaintext_value = aws_iam_access_key.terratest.id
 }
 
-resource "github_actions_secret" "cp_terraform_ecr_aws_secret_key" {
-  repository      = "cloud-platform-terraform-ecr-credentials"
+resource "github_actions_secret" "secret_key" {
+  for_each        = toset(var.github_repositories)
+  repository      = each.key
   secret_name     = "AWS_SECRET_ACCESS_KEY"
   plaintext_value = aws_iam_access_key.terratest.secret
 }

--- a/terraform/aws-accounts/cloud-platform-ephemeral-test/cloud-platform-account/modules/automated-tests/variables.tf
+++ b/terraform/aws-accounts/cloud-platform-ephemeral-test/cloud-platform-account/modules/automated-tests/variables.tf
@@ -1,0 +1,5 @@
+variable "github_repositories" {
+  description = "GitHub repos to create the secrets"
+  default     = []
+}
+


### PR DESCRIPTION
Some AWS_* creds are required by Github actions in order to execute unit tests against terraform modules. 