### PR TITLE
New monitoring release with kibana proxies

### DIFF
--- a/terraform/cloud-platform-components/components.tf
+++ b/terraform/cloud-platform-components/components.tf
@@ -59,7 +59,7 @@ module "logging" {
 }
 
 module "prometheus" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=1.2.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=1.3.0"
 
   alertmanager_slack_receivers               = var.alertmanager_slack_receivers
   iam_role_nodes                             = data.aws_iam_role.nodes.arn
@@ -69,6 +69,8 @@ module "prometheus" {
   enable_thanos_helm_chart                   = terraform.workspace == local.live_workspace ? true : false
   enable_thanos_sidecar                      = terraform.workspace == local.live_workspace ? true : false
   enable_prometheus_affinity_and_tolerations = terraform.workspace == local.live_workspace ? true : false
+  enable_kibana_audit_proxy                  = terraform.workspace == local.live_workspace ? true : false
+  enable_kibana_proxy                        = terraform.workspace == local.live_workspace ? true : false
 
   cluster_domain_name           = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   oidc_components_client_id     = data.terraform_remote_state.cluster.outputs.oidc_components_client_id


### PR DESCRIPTION
WHAT
New version of the monitoring module with kibana proxies
WHY
Proxies use to be in env repo as yaml code, now in managed TF code. (Applies in live-1 only) 