### PR TITLE
Use tools-image 1.27 in `make tools-shell`

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-TOOLS_IMAGE := ministryofjustice/cloud-platform-tools:1.26
+TOOLS_IMAGE := ministryofjustice/cloud-platform-tools:1.27
 
 tools-shell:
 	docker pull $(TOOLS_IMAGE)


### PR DESCRIPTION
Several of our runbooks include running `make tools-shell`, so this needs to be kept up to date with the latest release.

We could also do something like this:
```
curl https://api.github.com/repos/ministryofjustice/cloud-platform-tools-image/releases/latest | grep tag_name | sed 's/.*: "\(.*\)".*/\1/'
```
But building that into a make target would lead to a file that was difficult to read, so it's probably simplest to keep bumping the version manually