### PR TITLE
Add slack SNS topic fix to Elasticsearch and accounts modules

### DIFF
--- a/terraform/cloud-platform-account/main.tf
+++ b/terraform/cloud-platform-account/main.tf
@@ -24,7 +24,7 @@ module "iam" {
 
 # Baselines: cloudtrail, cloudwatch, lambda. Everything that our accounts should have
 module "baselines" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-awsaccounts-baselines?ref=0.0.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-awsaccounts-baselines?ref=0.0.5"
 
   enable_logging           = true
   enable_slack_integration = true

--- a/terraform/cloud-platform-account/outputs.tf
+++ b/terraform/cloud-platform-account/outputs.tf
@@ -1,0 +1,4 @@
+output "slack_sns_topic" {
+  description = "Slack integration sns topic name"
+  value       = module.baselines.slack_sns_topic
+}

--- a/terraform/global-resources/elasticsearch.tf
+++ b/terraform/global-resources/elasticsearch.tf
@@ -251,19 +251,6 @@ data "aws_iam_policy_document" "test" {
 #   }
 # }
 
-module "notify_slack" {
-  source = "terraform-aws-modules/notify-slack/aws"
-  # whilst using terraform 0.12 you must use version 3.5.0
-  version = "3.5.0"
-
-  sns_topic_name   = "elasticsearch-monitoring"
-  create_sns_topic = true
-
-  slack_webhook_url = var.slack_webhook_url
-  slack_channel     = "lower-priority-alarms"
-  slack_username    = "Cloudwatch-reporter"
-}
-
 module "live_elasticsearch_monitoring" {
   source  = "dubiety/elasticsearch-cloudwatch-sns-alarms/aws"
   version = "1.0.4"
@@ -271,7 +258,7 @@ module "live_elasticsearch_monitoring" {
   alarm_name_prefix = "cloud-platform-live-"
   domain_name       = local.live_domain
   create_sns_topic  = false
-  sns_topic         = module.notify_slack.this_slack_topic_arn
+  sns_topic         = data.terraform_remote_state.aws_baseline.outputs.slack_sns_topic
 }
 
 module "audit_elasticsearch_monitoring" {

--- a/terraform/global-resources/elasticsearch.tf
+++ b/terraform/global-resources/elasticsearch.tf
@@ -258,7 +258,7 @@ module "live_elasticsearch_monitoring" {
   alarm_name_prefix = "cloud-platform-live-"
   domain_name       = local.live_domain
   create_sns_topic  = false
-  sns_topic         = data.terraform_remote_state.aws_baseline.outputs.slack_sns_topic
+  sns_topic         = data.terraform_remote_state.account.outputs.slack_sns_topic
 }
 
 module "audit_elasticsearch_monitoring" {
@@ -268,5 +268,5 @@ module "audit_elasticsearch_monitoring" {
   alarm_name_prefix = "cloud-platform-audit-"
   domain_name       = local.audit_domain
   create_sns_topic  = false
-  sns_topic         = module.notify_slack.this_slack_topic_arn
+  sns_topic         = data.terraform_remote_state.account.outputs.slack_sns_topic
 }

--- a/terraform/global-resources/main.tf
+++ b/terraform/global-resources/main.tf
@@ -50,3 +50,13 @@ provider "aws" {
 provider "external" {
 }
 
+data "terraform_remote_state" "aws_baseline" {
+  backend = "s3"
+
+  config = {
+    bucket  = "cloud-platform-terraform-state"
+    region  = "eu-west-1"
+    key     = "cloud-platform-account/terraform.json"
+    profile = "moj-cp"
+  }
+}

--- a/terraform/global-resources/main.tf
+++ b/terraform/global-resources/main.tf
@@ -50,13 +50,13 @@ provider "aws" {
 provider "external" {
 }
 
-data "terraform_remote_state" "aws_baseline" {
+data "terraform_remote_state" "account" {
   backend = "s3"
 
   config = {
     bucket  = "cloud-platform-terraform-state"
     region  = "eu-west-1"
-    key     = "cloud-platform-account/terraform.json"
+    key     = "terraform.tfstate"
     profile = "moj-cp"
   }
 }


### PR DESCRIPTION
To avoid duplication of work and to ensure resources aren't overwritten I have removed the additional notify slack module call from the elasticsearch terraform. This will now be created by the aws-baselines module in the cloud-platform-account terraform and consumed by elasticsearch. 