### PR TITLE
Removed terraform_remote_state dependency

### DIFF
--- a/terraform/cloud-platform/outputs.tf
+++ b/terraform/cloud-platform/outputs.tf
@@ -7,7 +7,7 @@ output "cluster_domain_name" {
 }
 
 output "kops_state_store" {
-  value = data.terraform_remote_state.cloud_platform_account.outputs.cloud_platform_kops_state
+  value = data.aws_s3_bucket.kops_state.bucket
 }
 
 output "availability_zones" {


### PR DESCRIPTION
There is state dependency within `cloud-platform/` folder. This PR removed it and take advantage of AWS data resources 