### PR TITLE
Update cert-manager to latest version

### DIFF
--- a/terraform/cloud-platform-components/components.tf
+++ b/terraform/cloud-platform-components/components.tf
@@ -1,5 +1,5 @@
 module "cert_manager" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-certmanager?ref=0.0.10"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-certmanager?ref=0.1.0"
 
   iam_role_nodes      = data.aws_iam_role.nodes.arn
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name


### PR DESCRIPTION
It contains Helm repository inline. More information in https://github.com/ministryofjustice/cloud-platform-terraform-certmanager/pull/17