### PR TITLE
Remove failover test ingress controller

### DIFF
--- a/terraform/cloud-platform-components/components.tf
+++ b/terraform/cloud-platform-components/components.tf
@@ -112,22 +112,6 @@ module "ingress_controllers" {
   dependence_certmanager = module.cert_manager.helm_cert_manager_status
 }
 
-module "ingress_controllers_k8snginx_fallback" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-k8s-ingress-controller?ref=0.0.5"
-
-  # boolean expression for applying standby ingress-controller for live-1 cluster only.
-  enable_fallback_ingress_controller = terraform.workspace == local.live_workspace ? true : false
-  # Will be used as the ingress controller name and the class annotation
-  controller_name                                    = "k8snginx"
-  replica_count                                      = "6"
-  enable_ingress_controller_affinity_and_tolerations = terraform.workspace == local.live_workspace ? true : false
-
-  # This module requires prometheus and certmanager
-  dependence_prometheus  = module.prometheus.helm_prometheus_operator_status
-  dependence_certmanager = module.cert_manager.helm_cert_manager_status
-}
-
-
 module "opa" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-opa?ref=0.0.11"
 


### PR DESCRIPTION
WHAT
Remove failover test ingress controller - ingress_controllers_k8snginx_fallback

WHY
This was created for the major nginx ingress upgrade and used for testing. As this work is complete this is no longer required. 