### PR TITLE
Add explicit dependency for creating route53

### DIFF
--- a/terraform/cloud-platform/main.tf
+++ b/terraform/cloud-platform/main.tf
@@ -100,6 +100,9 @@ module "bastion" {
   vpc_name            = local.vpc
   route53_zone        = module.cluster_dns.cluster_dns_zone_name
   cluster_domain_name = local.cluster_base_domain_name
+  depends_on = [
+   module.cluster_dns 
+  ]
 }
 
 #########

--- a/terraform/cloud-platform/main.tf
+++ b/terraform/cloud-platform/main.tf
@@ -101,7 +101,7 @@ module "bastion" {
   route53_zone        = module.cluster_dns.cluster_dns_zone_name
   cluster_domain_name = local.cluster_base_domain_name
   depends_on = [
-   module.cluster_dns 
+    module.cluster_dns
   ]
 }
 


### PR DESCRIPTION
When creating test clusters `terraform plan` throw error ```Error: no matching Route53Zone found
  on .terraform/modules/bastion/main.tf line 25, in data "aws_route53_zone" "selected":
  25: data "aws_route53_zone" "selected" {```

This is because the bastion module data.aws_route53_zone.selected expects the zone to be created. And for some reason  terraform cannot infer dependency calculations. 