### PR TITLE
Cert manager upgrade for eks and ephemeral-test accounts

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -35,7 +35,7 @@ module "concourse" {
 }
 
 module "cert_manager" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-certmanager?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-certmanager?ref=1.1.0"
 
   iam_role_nodes      = data.aws_iam_role.nodes.arn
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name

--- a/terraform/aws-accounts/cloud-platform-ephemeral-test/cloud-platform-components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-ephemeral-test/cloud-platform-components/components.tf
@@ -18,7 +18,7 @@ module "kuberos" {
 }
 
 module "cert_manager" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-certmanager?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-certmanager?ref=1.1.0"
 
   iam_role_nodes      = data.aws_iam_role.nodes.arn
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name


### PR DESCRIPTION
More details in this PR: https://github.com/ministryofjustice/cloud-platform-terraform-certmanager/pull/18