### PR TITLE
Cpu high critical change irate to rate - use latest monitoring module

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -95,7 +95,7 @@ module "logging" {
 }
 
 module "monitoring" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=1.6.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=1.6.3"
 
   alertmanager_slack_receivers = var.alertmanager_slack_receivers
   iam_role_nodes               = data.aws_iam_role.nodes.arn

--- a/terraform/aws-accounts/cloud-platform-ephemeral-test/cloud-platform-components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-ephemeral-test/cloud-platform-components/components.tf
@@ -56,7 +56,7 @@ module "logging" {
 }
 
 module "prometheus" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=1.6.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=1.6.3"
 
   alertmanager_slack_receivers               = var.alertmanager_slack_receivers
   iam_role_nodes                             = data.aws_iam_role.nodes.arn

--- a/terraform/cloud-platform-components/components.tf
+++ b/terraform/cloud-platform-components/components.tf
@@ -58,7 +58,7 @@ module "logging" {
 }
 
 module "prometheus" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=1.6.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=1.6.3"
 
   alertmanager_slack_receivers               = var.alertmanager_slack_receivers
   iam_role_nodes                             = data.aws_iam_role.nodes.arn


### PR DESCRIPTION
Cpu high critical change irate to rate - use latest monitoring module (1.6.2 to 1.6.3)