### PR TITLE
Upgrade certmanager to release 1.1.0

### DIFF
--- a/terraform/cloud-platform-components/components.tf
+++ b/terraform/cloud-platform-components/components.tf
@@ -1,5 +1,5 @@
 module "cert_manager" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-certmanager?ref=1.0.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-certmanager?ref=1.1.0"
 
   iam_role_nodes      = data.aws_iam_role.nodes.arn
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name


### PR DESCRIPTION
This has the chart version upgrade to 1.2.0.

Related to: https://github.com/ministryofjustice/cloud-platform/issues/2771