### PR TITLE
Removed affinity rules for Prometheus

### DIFF
--- a/terraform/cloud-platform-components/components.tf
+++ b/terraform/cloud-platform-components/components.tf
@@ -67,7 +67,7 @@ module "prometheus" {
   enable_cloudwatch_exporter                 = terraform.workspace == local.live_workspace ? true : false
   enable_thanos_helm_chart                   = terraform.workspace == local.live_workspace ? true : false
   enable_thanos_sidecar                      = terraform.workspace == local.live_workspace ? true : false
-  enable_prometheus_affinity_and_tolerations = terraform.workspace == local.live_workspace ? true : false
+  enable_prometheus_affinity_and_tolerations = false
   enable_kibana_audit_proxy                  = terraform.workspace == local.live_workspace ? true : false
   enable_kibana_proxy                        = terraform.workspace == local.live_workspace ? true : false
 


### PR DESCRIPTION
As discussed here, we are giving a try at removing the affinity rules for Prometheus, It means the pod is going to be scheduled in a normal node.

Before applying this it is important to change Prometheus's pingdom health check, so it doesn't trigger when node-recycling triggers