### PR TITLE
Update external-dns helm chart in live-1 to latest

### DIFF
--- a/terraform/cloud-platform-components/components.tf
+++ b/terraform/cloud-platform-components/components.tf
@@ -11,7 +11,7 @@ module "cert_manager" {
 }
 
 module "external_dns" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-external-dns?ref=1.2.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-external-dns?ref=1.3.0"
 
   iam_role_nodes      = data.aws_iam_role.nodes.arn
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name


### PR DESCRIPTION
Upgrade already done in EKS and also ran [eks integration tests](https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/reporting/jobs/eks-integration-tests/builds/618) to ensure everything is fine. 

