### PR TITLE
Revert Prometheus - affinity rules again 

### DIFF
--- a/terraform/cloud-platform-components/components.tf
+++ b/terraform/cloud-platform-components/components.tf
@@ -67,7 +67,7 @@ module "prometheus" {
   enable_cloudwatch_exporter                 = terraform.workspace == local.live_workspace ? true : false
   enable_thanos_helm_chart                   = terraform.workspace == local.live_workspace ? true : false
   enable_thanos_sidecar                      = terraform.workspace == local.live_workspace ? true : false
-  enable_prometheus_affinity_and_tolerations = false
+  enable_prometheus_affinity_and_tolerations = terraform.workspace == local.live_workspace ? true : false
   enable_kibana_audit_proxy                  = terraform.workspace == local.live_workspace ? true : false
   enable_kibana_proxy                        = terraform.workspace == local.live_workspace ? true : false
 


### PR DESCRIPTION
It is too heavy for the nodes and consumes too many resources for the nodes. We just saw a spike of CPU to 99%. 

At least we tried