### PR TITLE
Add hcl lock to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .terraform
 *.tfstate*
+.terraform.lock.hcl
 ssh/*id_rsa
 generated/*
 .bundle


### PR DESCRIPTION
We have taken the decision to not commit the version hcl lock file to
git.