### PR TITLE
Enable cert-man and exDNS tests

### DIFF
--- a/smoke-tests/spec/cert_manager_spec.rb
+++ b/smoke-tests/spec/cert_manager_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-xdescribe "cert-manager" do
+describe "cert-manager" do
   let(:namespace) { "cert-manager-test-#{readable_timestamp}" }
   ingress_class = "nginx"
 

--- a/smoke-tests/spec/external_dns_spec.rb
+++ b/smoke-tests/spec/external_dns_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 ZONE_ID = "Z02429076QQMAO8KXV68" # integrationtest.service.justice.gov.uk zone_id
 
 # This test can only be ran against live-1. Test clusters do not have enough privileges.
-xdescribe "external DNS", "live-1": true do
+describe "external DNS", "live-1": true do
   let(:domain) { "integrationtest.service.justice.gov.uk" } # That zone already exists
   namespace = "integrationtest-dns-#{readable_timestamp}"
   let(:ingress_domain) { domain }


### PR DESCRIPTION
Enable cert-man and exDNS tests to check if stability of other test changes 