### PR TITLE
Removed global's terraform_remote_state

### DIFF
--- a/terraform/cloud-platform-components/main.tf
+++ b/terraform/cloud-platform-components/main.tf
@@ -43,17 +43,6 @@ data "terraform_remote_state" "network" {
   }
 }
 
-data "terraform_remote_state" "global" {
-  backend = "s3"
-
-  config = {
-    bucket  = "cloud-platform-terraform-state"
-    region  = "eu-west-1"
-    key     = "global-resources/terraform.tfstate"
-    profile = "moj-cp"
-  }
-}
-
 // This is the kubernetes role that node hosts are assigned.
 data "aws_iam_role" "nodes" {
   name = "nodes.${data.terraform_remote_state.cluster.outputs.cluster_domain_name}"


### PR DESCRIPTION
This is not being used, I can't find any reference within the files