### PR TITLE
Bump version for concourse to 1.6.1

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -1,6 +1,6 @@
 
 module "concourse" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-concourse?ref=1.6.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-concourse?ref=1.6.1"
 
   vpc_id                                            = data.terraform_remote_state.cluster.outputs.vpc_id
   internal_subnets                                  = data.terraform_remote_state.cluster.outputs.internal_subnets


### PR DESCRIPTION
More details in the PR: https://github.com/ministryofjustice/cloud-platform-terraform-concourse/pull/39