### PR TITLE
Add PSP tactical fix to create-cluster script

### DIFF
--- a/create-cluster.rb
+++ b/create-cluster.rb
@@ -37,7 +37,7 @@ def main(options)
   execute "git-crypt unlock" if gitcrypt_unlock
 
   create_vpc(vpc_name)
-  if kind == "eks"
+  if kind == "eks" || kind == "EKS"
     create_cluster_eks(cluster_name, vpc_name)
     sleep(extra_wait)
     fix_psp()

--- a/create-cluster.rb
+++ b/create-cluster.rb
@@ -144,11 +144,8 @@ def install_components_kops(cluster_name)
   end
 end
 
-# This is a tactical fix to install our own pod security policies in an EKS cluster. When PSP's are deprecated and we create policies via another means,
-# this method can be removed.
-# This methos
+# This is a tactical fix to install our own pod security policies in an EKS cluster. When PSP's are deprecated and we create policies via another means, this method can be removed.
 def fix_psp(dir)
-  # Remove current psp.privileged psp.
   cmd_delete = "kubectl delete psp eks.privileged"
   if cmd_successful?(cmd_delete)
     log "Deleted eks.privileged psp."


### PR DESCRIPTION
What problem does this PR fix
---
Before this PR we had a problem where bootstrapped EKS clusters would use the `eks.privileged` pod security policy. This policy essentially makes PSP's redundant as all pods will assume it, which allows them to do anything they like (i.e. priv escalation). We have our own carefully thought out Pod Security Policies that are easily applied to a kOps cluster but not EKS.

Why merge this PR
---
Merging this PR means all future EKS clusters will use our own Pod Security Policies.

How
---
It's not an elegant fix, but it amends the `create-cluster` script to do the following:
- Delete the old eks.priv psp
- Apply our own psps
- Recycle every pod in the cluster

The important thing to note here is that at point of execution we have a minimal set of pods in the cluster. This reduces the amount of work required by the API/kubelet. 