### PR TITLE
Add security context with fsgroup for eks

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -35,7 +35,7 @@ module "concourse" {
 }
 
 module "cert_manager" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-certmanager?ref=1.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-certmanager?ref=1.1.1"
 
   iam_role_nodes      = data.aws_iam_role.nodes.arn
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/components.tf
@@ -1,5 +1,5 @@
 module "cert_manager" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-certmanager?ref=1.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-certmanager?ref=1.1.1"
 
   iam_role_nodes      = data.aws_iam_role.nodes.arn
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name


### PR DESCRIPTION
This is to modify the cert-manager deployment with the correct
filesystem permissions, so the serviceaccount token can be read.

Information related to it:
https://github.com/cert-manager/website/pull/456/