### PR TITLE
Updating Prometheus Operator in Manager 

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -106,7 +106,7 @@ module "monitoring" {
   oidc_components_client_secret = data.terraform_remote_state.cluster.outputs.oidc_components_client_secret
   oidc_issuer_url               = data.terraform_remote_state.cluster.outputs.oidc_issuer_url
   enable_thanos_sidecar         = terraform.workspace == local.live_workspace ? true : false
-  enable_large_nodesgroup       = terraform.workspace == local.live_workspace ? true : false
+  enable_large_nodesgroup       = false
 
   enable_thanos_helm_chart = terraform.workspace == local.live_workspace ? true : false
   enable_thanos_compact    = terraform.workspace == local.live_workspace ? true : false

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -106,7 +106,7 @@ module "monitoring" {
   oidc_components_client_secret = data.terraform_remote_state.cluster.outputs.oidc_components_client_secret
   oidc_issuer_url               = data.terraform_remote_state.cluster.outputs.oidc_issuer_url
   enable_thanos_sidecar         = terraform.workspace == local.live_workspace ? true : false
-  enable_large_nodesgroup.      = terraform.workspace == local.live_workspace ? true : false
+  enable_large_nodesgroup       = terraform.workspace == local.live_workspace ? true : false
 
   enable_thanos_helm_chart = terraform.workspace == local.live_workspace ? true : false
   enable_thanos_compact    = terraform.workspace == local.live_workspace ? true : false

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -95,7 +95,7 @@ module "logging" {
 }
 
 module "monitoring" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=1.6.6"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=1.7.0"
 
   alertmanager_slack_receivers = var.alertmanager_slack_receivers
   iam_role_nodes               = data.aws_iam_role.nodes.arn
@@ -106,11 +106,10 @@ module "monitoring" {
   oidc_components_client_secret = data.terraform_remote_state.cluster.outputs.oidc_components_client_secret
   oidc_issuer_url               = data.terraform_remote_state.cluster.outputs.oidc_issuer_url
   enable_thanos_sidecar         = terraform.workspace == local.live_workspace ? true : false
+  enable_large_nodesgroup.      = terraform.workspace == local.live_workspace ? true : false
 
   enable_thanos_helm_chart = terraform.workspace == local.live_workspace ? true : false
   enable_thanos_compact    = terraform.workspace == local.live_workspace ? true : false
-
-  dependence_opa = "ignore"
 
   # This section is for EKS
   eks                         = true


### PR DESCRIPTION
This should fix the Prometheus operator issue in the manager cluster. It basically reduces the resources quotas set for live-1 (we are in manager, we don't need that amount of memory + we don't have large node groups)

