### PR TITLE
Use apply instead of create

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/k8s-resources.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/k8s-resources.tf
@@ -24,7 +24,7 @@ resource "kubernetes_storage_class" "storageclass" {
 
 resource "null_resource" "pod_security_policy" {
   provisioner "local-exec" {
-    command = "kubectl create -f ${path.module}/resources/psp/pod-security-policy.yaml"
+    command = "kubectl apply -f ${path.module}/resources/psp/pod-security-policy.yaml"
   }
 
   provisioner "local-exec" {


### PR DESCRIPTION
This will allow re-applying the psp if the resources already exists.

When creating test clusters, it throw the below error. 
```Error: Error running command 'kubectl create -f ./resources/psp/pod-security-policy.yaml': exit status 1. Output: Error from server (AlreadyExists): error when creating "./resources/psp/pod-security-policy.yaml": podsecuritypolicies.policy "privileged" already exists```

Because the psp are created before installing components to remove the eks.privileged, it cannot be created again when installing components. Refer (https://github.com/ministryofjustice/cloud-platform-infrastructure/pull/1174).
