### PR TITLE
Add live cluster tags to live-1 VPC

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/main.tf
@@ -26,7 +26,7 @@ locals {
   vpc_name             = terraform.workspace
   vpc_base_domain_name = "${local.vpc_name}.cloud-platform.service.justice.gov.uk"
   cluster_tags = {
-    for name in var.cluster_names :
+    for name in lookup(var.cluster_names, terraform.workspace, terraform.workspace) :
     "kubernetes.io/cluster/${name}" => "shared"
   }
   vpc_tags = merge({

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/main.tf
@@ -26,7 +26,7 @@ locals {
   vpc_name             = terraform.workspace
   vpc_base_domain_name = "${local.vpc_name}.cloud-platform.service.justice.gov.uk"
   cluster_tags = {
-    for name in lookup(var.cluster_names, terraform.workspace, terraform.workspace) :
+    for name in lookup(var.cluster_names, terraform.workspace, [terraform.workspace]) :
     "kubernetes.io/cluster/${name}" => "shared"
   }
   vpc_tags = merge({

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/variables.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/variables.tf
@@ -32,7 +32,7 @@ variable "worker_node_machine_type" {
 }
 
 variable "cluster_names" {
-  description = "The AWS EC2 instance types to use for master nodes"
+  description = "List of Clusters within Live-1 VPC"
   default = {
     live-1  = ["live-1.cloud-platform.service.justice.gov.uk","manager","live"]
   }

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/variables.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/variables.tf
@@ -34,6 +34,6 @@ variable "worker_node_machine_type" {
 variable "cluster_names" {
   description = "List of Clusters within Live-1 VPC"
   default = {
-    live-1  = ["live-1.cloud-platform.service.justice.gov.uk","manager","live"]
+    live-1 = ["live-1.cloud-platform.service.justice.gov.uk", "manager", "live"]
   }
 }

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/variables.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/variables.tf
@@ -32,7 +32,8 @@ variable "worker_node_machine_type" {
 }
 
 variable "cluster_names" {
-  description = "A list of every Kubernetes cluster present in the VPC"
-  type        = list(string)
-  default     = []
+  description = "The AWS EC2 instance types to use for master nodes"
+  default = {
+    live-1  = ["live-1.cloud-platform.service.justice.gov.uk","manager","live"]
+  }
 }


### PR DESCRIPTION
WHAT
This PR adds live cluster tags to AWS VPC and all 6 subnets owned by live-1 

WHY
This is required so live cluster can create LB using the subnets created by live-1 cluster. Live is installed within live1 vpc.
The tag for the VPC is not technically required anymore but will be removed in the future. 

https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html - VPC tagging