### PR TITLE
Add cloud-platform-admin user to eks users

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
@@ -81,11 +81,6 @@ module "eks" {
       groups   = ["system:masters"]
     },
     {
-      userarn  = "arn:aws:iam::754256621582:user/cloud-platform/manager-concourse"
-      username = "manager-concourse"
-      groups   = ["system:masters"]
-    },
-    {
       userarn  = "arn:aws:iam::754256621582:user/SteveMarshall"
       username = "SteveMarshall"
       groups   = ["system:masters"]
@@ -93,6 +88,17 @@ module "eks" {
     {
       userarn  = "arn:aws:iam::754256621582:user/VijayVeeranki"
       username = "VijayVeeranki"
+      groups   = ["system:masters"]
+    },
+    {
+      userarn  = "arn:aws:iam::754256621582:user/cloud-platform/manager-concourse"
+      username = "manager-concourse"
+      groups   = ["system:masters"]
+    },
+    # Manager-concourse-cloud-platform-admin used by the cloud-platform-cli
+    {
+      userarn  = "arn:aws:iam::754256621582:user/cloud-platform/manager-concourse-cloud-platform-admin"
+      username = "manager-concourse-cloud-platform-admin"
       groups   = ["system:masters"]
     }
   ]


### PR DESCRIPTION
Also moved `manager-concourse` down to the end of the list for clarity.