### PR TITLE
Amend eks module to allow for live creation

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
@@ -35,7 +35,7 @@ module "eks" {
       min_capacity     = 1
       subnets          = data.aws_subnet_ids.private.ids
 
-      instance_type = var.worker_node_machine_type
+      instance_type = local.is_manager_cluster ? "m4.xlarge" : "r5.xlarge"
       k8s_labels = {
         Terraform = "true"
         Cluster   = local.cluster_name
@@ -43,6 +43,8 @@ module "eks" {
       }
       additional_tags = {
         default_ng = "true"
+        application   = "moj-cloud-platform"
+        business-unit = "platforms"
       }
     }
   }

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
@@ -42,7 +42,7 @@ module "eks" {
         Domain    = local.cluster_base_domain_name
       }
       additional_tags = {
-        default_ng = "true"
+        default_ng    = "true"
         application   = "moj-cloud-platform"
         business-unit = "platforms"
       }

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -85,6 +85,16 @@ module "ingress_controllers" {
   dependence_opa         = "ignore"
 }
 
+module "modsec_ingress_controllers" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-modsec-ingress-controller?ref=0.0.7"
+
+  controller_name = "modsec01"
+  replica_count   = "4"
+
+  dependence_prometheus  = module.monitoring.helm_prometheus_operator_status
+  dependence_certmanager = module.cert_manager.helm_cert_manager_status
+}
+
 module "logging" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-logging?ref=1.1.0"
 

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/variables.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/variables.tf
@@ -2,6 +2,7 @@ variable "vpc_name" {
   description = "The VPC name where the cluster(s) are going to be provisioned. VPCs are created in cloud-platform-network"
   default = {
     manager = "live-1"
+    live    = "live-1"
   }
 }
 


### PR DESCRIPTION
Overview
---
This PR connects to https://github.com/ministryofjustice/cloud-platform/issues/2854 and relates to the creation of a new production grade cluster named `live`. This cluster's name is deliberately vague to ensure future upgrades and iterations don't change name. It requires a change to the cluster, main and vpc terraform HCL in this repository. At the end of this PR, we should have a `live` production EKS cluster bootstrapped and initial components installed.

What's in this PR
---
We would like to create as close to
`live-1` as possible. `Live-1` is currently running 19 worker nodes and
three masters. At the start of `Live` it will need a different instance
type `r5.xlarge` for mem optimisation but we can keep the instance count
the same and utilise the out of the box autoscaling.

There are also a few tags that need to be included as part of our
tagging strategy.

I wanted to keep the if conditions down as much as possible. This can be
iterated in the future.