### PR TITLE
Refactor code - remove almost all conditionals

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
@@ -2,6 +2,7 @@
 # EKS Cluster #
 ###############
 
+
 data "aws_eks_cluster" "cluster" {
   name = module.eks.cluster_id
 }

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
@@ -21,7 +21,7 @@ module "eks" {
   source  = "terraform-aws-modules/eks/aws"
   version = "v15.2.0"
 
-  cluster_name     = local.cluster_name
+  cluster_name     = terraform.workspace
   subnets          = concat(tolist(data.aws_subnet_ids.private.ids), tolist(data.aws_subnet_ids.public.ids))
   vpc_id           = data.aws_vpc.selected.id
   write_kubeconfig = false
@@ -38,8 +38,8 @@ module "eks" {
       instance_type = var.worker_node_machine_type
       k8s_labels = {
         Terraform = "true"
-        Cluster   = local.cluster_name
-        Domain    = local.cluster_base_domain_name
+        Cluster   = terraform.workspace
+        Domain    = local.fqdn
       }
       additional_tags = {
         default_ng = "true"
@@ -105,7 +105,7 @@ module "eks" {
 
   tags = {
     Terraform = "true"
-    Cluster   = local.cluster_name
-    Domain    = local.cluster_base_domain_name
+    Cluster   = terraform.workspace
+    Domain    = local.fqdn
   }
 }

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/outputs.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/outputs.tf
@@ -7,7 +7,7 @@ output "eks_worker_iam_role_name" {
 }
 
 output "cluster_name" {
-  value = local.cluster_name
+  value = terraform.workspace
 }
 
 output "vpc_id" {
@@ -22,16 +22,12 @@ output "internal_subnets_ids" {
   value = tolist(data.aws_subnet_ids.private.ids)
 }
 
-output "base_route53_hostzone" {
-  value = local.base_route53_hostzone
-}
-
 output "cluster_domain_name" {
-  value = local.cluster_base_domain_name
+  value = local.fqdn
 }
 
 output "oidc_issuer_url" {
-  value = "https://${local.auth0_tenant_domain}/"
+  value = "https://justice-cloud-platform.eu.auth0.com/"
 }
 
 output "oidc_kubernetes_client_id" {

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/outputs.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/outputs.tf
@@ -6,10 +6,6 @@ output "eks_worker_iam_role_name" {
   value = module.eks.worker_iam_role_name
 }
 
-output "cluster_name" {
-  value = terraform.workspace
-}
-
 output "vpc_id" {
   value = data.aws_vpc.selected.id
 }


### PR DESCRIPTION
This PR removes all conditionals and also uses the new auth0 module version, which simplifies all `locals`

This PR also removes the bastion host, which we don't need on EKS (anyway we already have the kops one within the live-1 VPC)