### PR TITLE
Add docker config to EKS workers

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
@@ -2,7 +2,6 @@
 # EKS Cluster #
 ###############
 
-
 data "aws_eks_cluster" "cluster" {
   name = module.eks.cluster_id
 }
@@ -35,6 +34,9 @@ module "eks" {
       max_capacity     = 30
       min_capacity     = 1
       subnets          = data.aws_subnet_ids.private.ids
+
+      create_launch_template = true
+      pre_userdata           = local.pre_userdata
 
       instance_type = var.worker_node_machine_type
       k8s_labels = {

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/main.tf
@@ -43,6 +43,24 @@ locals {
   auth0_extra_callbacks = {
     manager = ["https://sonarqube.cloud-platform.service.justice.gov.uk/oauth2/callback/oidc"]
   }
+
+  # Add dockerhub crendentials to worker nodes
+  dockerhub_credentials = "${var.dockerhub_user}:${var.dockerhub_token}"
+  dockerhub_file        = <<-EOD
+{
+  "auths": {
+    "https://index.docker.io/v1/": {
+      "auth": "${base64encode(local.dockerhub_credentials)}"
+    }
+  }
+}
+EOD
+  pre_userdata          = <<-EOD
+mkdir -p "/root/.docker"
+echo '${local.dockerhub_file}' > "/root/.docker/config.json"
+mkdir -p "/var/lib/kubelet/.docker"
+echo '${local.dockerhub_file}' > "/var/lib/kubelet/config.json"
+EOD
 }
 
 data "aws_route53_zone" "cloud_platform_justice_gov_uk" {

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/variables.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/variables.tf
@@ -2,3 +2,11 @@ variable "worker_node_machine_type" {
   description = "The AWS EC2 instance types to use for worker nodes"
   default     = "m4.xlarge"
 }
+
+variable "dockerhub_user" {
+  description = "Cloud platform user (see lastpass). This is required to avoid hitting limits when pulling images."
+}
+
+variable "dockerhub_token" {
+  description = "Token for the above"
+}


### PR DESCRIPTION
adds Dockerhub creds to the worker nodes in order to pull images authenticated (and not rate limited)