### PR TITLE
Create node size terraform map

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
@@ -38,14 +38,16 @@ module "eks" {
       create_launch_template = true
       pre_userdata           = local.pre_userdata
 
-      instance_type = var.worker_node_machine_type
+      instance_type = lookup(local.node_size, terraform.workspace, local.node_size["default"])
       k8s_labels = {
         Terraform = "true"
         Cluster   = terraform.workspace
         Domain    = local.fqdn
       }
       additional_tags = {
-        default_ng = "true"
+        default_ng    = "true"
+        application   = "moj-cloud-platform"
+        business-unit = "platforms"
       }
     }
   }

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/main.tf
@@ -39,6 +39,12 @@ locals {
     default = "4"
   }
 
+  node_size = {
+    live    = "r5.xlarge"
+    manager = "m4.xlarge"
+    default = "r5.xlarge"
+  }
+
   # Some clusters (like manage) need extra callbacks URLs in auth0
   auth0_extra_callbacks = {
     manager = ["https://sonarqube.cloud-platform.service.justice.gov.uk/oauth2/callback/oidc"]

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/variables.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/variables.tf
@@ -1,8 +1,3 @@
-variable "worker_node_machine_type" {
-  description = "The AWS EC2 instance types to use for worker nodes"
-  default     = "m4.xlarge"
-}
-
 variable "dockerhub_user" {
   description = "Cloud platform user (see lastpass). This is required to avoid hitting limits when pulling images."
 }


### PR DESCRIPTION
Overview
---
This PR connects to https://github.com/ministryofjustice/cloud-platform/issues/2854 and relates to the creation of a new production grade cluster named `live`. This cluster's name is deliberately vague to ensure future upgrades and iterations don't change name. It requires a change to the cluster, main and vpc terraform HCL in this repository. At the end of this PR, we should have a `live` production EKS cluster bootstrapped and initial components installed.

What's in this PR
---
We would like to create as close to
`live-1` as possible. `Live-1` is currently running 19 worker nodes and
three masters. At the start of `Live` it will need a different instance
type `r5.xlarge` for mem optimisation but we can keep the instance count
the same and utilise the out of the box autoscaling.

There are also a few tags that need to be included as part of our
tagging strategy.

I wanted to keep the if conditions down as much as possible. This can be
iterated in the future.