### PR TITLE
externalDNS e2e tests in Golang

### DIFF
--- a/tests/e2e/config.yaml
+++ b/tests/e2e/config.yaml
@@ -19,4 +19,7 @@ namespaces:
       - "kiam-server"
       - "kiam-agent"
 nginxIngress:
-    namespacePrefix: "smoketest-ingress-"
+  namespacePrefix: "smoketest-ingress-"
+externalDns:
+  zoneID: Z02429076QQMAO8KXV68
+  domain: integrationtest.service.justice.gov.uk

--- a/tests/e2e/config.yaml
+++ b/tests/e2e/config.yaml
@@ -22,5 +22,5 @@ nginxIngressController:
   namespacePrefix: "smoketest-ingress-"
 externalDNS:
   namespacePrefix: "e2e-tests-externaldns-"
-  hostedZoneId: Z1OWR28V4Q2RTU
-  domain: cloud-platform.service.justice.gov.uk
+  hostedZoneId: Z02429076QQMAO8KXV68
+  domain: integrationtest.service.justice.gov.uk

--- a/tests/e2e/config.yaml
+++ b/tests/e2e/config.yaml
@@ -18,8 +18,9 @@ namespaces:
     daemonsets:
       - "kiam-server"
       - "kiam-agent"
-nginxIngress:
+nginxIngressController:
   namespacePrefix: "smoketest-ingress-"
-externalDns:
-  zoneID: Z02429076QQMAO8KXV68
-  domain: integrationtest.service.justice.gov.uk
+externalDNS:
+  namespacePrefix: "e2e-tests-externaldns-"
+  hostedZoneId: Z1OWR28V4Q2RTU
+  domain: cloud-platform.service.justice.gov.uk

--- a/tests/e2e/external_dns_test.go
+++ b/tests/e2e/external_dns_test.go
@@ -1,0 +1,68 @@
+package integration_tests
+
+import (
+	"fmt"
+	"html/template"
+	"time"
+
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/retry"
+	"github.com/ministryofjustice/tiny-k8s-tester/pkg/helpers"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("external-DNS checks", func() {
+	var (
+		namespaceName = c.ExternalDNS.GetNamespaceName()
+		options       = k8s.NewKubectlOptions("", "", namespaceName)
+		domain        = fmt.Sprintf("%s.%s", namespaceName, c.ExternalDNS.Domain)
+		tpl           string
+	)
+
+	BeforeEach(func() {
+		k8s.CreateNamespace(GinkgoT(), options, namespaceName)
+	})
+
+	AfterEach(func() {
+		defer k8s.KubectlDeleteFromString(GinkgoT(), options, tpl)
+		defer k8s.DeleteNamespace(GinkgoT(), options, namespaceName)
+	})
+
+	Context("when ingress resource is created", func() {
+		It("should work create the A record", func() {
+			By("Deploying ingress resource")
+
+			tpl, err := helpers.TemplateFile("./fixtures/external-dns-ingress.yaml.tmpl", "external-dns-ingress.yaml.tmpl", template.FuncMap{
+				"domain": domain,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			k8s.KubectlApplyFromString(GinkgoT(), options, tpl)
+			k8s.WaitUntilIngressAvailableV1Beta1(GinkgoT(), options, "e2e-tests-externaldns", 60, 5*time.Second)
+
+			By("having an ingress resource deployed we should expect DNS entry for it")
+
+			var existArecord bool
+
+			retry.DoWithRetry(GinkgoT(), fmt.Sprintf("Waiting for sucessfull DNS entry in Route53 (returning: %t)", existArecord), 8, 10*time.Second, func() (string, error) {
+				a, err := helpers.RecordSets(domain, &c.ExternalDNS)
+				if err != nil {
+					return "", err
+				}
+
+				if a == false {
+					return "", fmt.Errorf("Expected A record in Route53 but the AWS query returns '%t'", a)
+				}
+
+				existArecord = a
+
+				return "", nil
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+			Ω(existArecord).Should(BeTrue())
+		})
+	})
+})

--- a/tests/e2e/fixtures/external-dns-ingress.yaml.tmpl
+++ b/tests/e2e/fixtures/external-dns-ingress.yaml.tmpl
@@ -1,0 +1,16 @@
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: e2e-tests-externaldns
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+spec:
+  rules:
+  - host: {{ .domain }}
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: ingress-external-svc
+          servicePort: 80

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -3,6 +3,7 @@ module github.com/ministryofjustice/tiny-k8s-tester
 go 1.15
 
 require (
+	github.com/aws/aws-sdk-go v1.27.1
 	github.com/davecgh/go-spew v1.1.1
 	github.com/go-resty/resty/v2 v2.6.0
 	github.com/gruntwork-io/terratest v0.34.4

--- a/tests/pkg/config/config.go
+++ b/tests/pkg/config/config.go
@@ -10,8 +10,10 @@ import (
 
 // Config holds the basic structure of test's YAML file
 type Config struct {
-	ClusterName string                `yaml:"clusterName"`
-	Namespaces  map[string]K8SObjects `yaml:"namespaces"`
+	ClusterName            string                 `yaml:"clusterName"`
+	Namespaces             map[string]K8SObjects  `yaml:"namespaces"`
+	ExternalDNS            ExternalDNS            `yaml:"externalDNS"`
+	NginxIngressController NginxIngressController `yaml:"nginxIngressController"`
 }
 
 // K8SObjects are kubernetes objects nested from namespaces, we need to check
@@ -20,6 +22,11 @@ type K8SObjects struct {
 	Daemonsets []string `yaml:"daemonsets"`
 	Services   []string `yaml:"services"`
 	Secrets    []string `yaml:"secrets"`
+}
+
+// NginxIngressController holds the config for nginx ingress controller component
+type NginxIngressController struct {
+	NamespacePrefix string `yaml:"namespacePrefix"`
 }
 
 // ParseConfigFile loads the test file supplied

--- a/tests/pkg/config/external_dns.go
+++ b/tests/pkg/config/external_dns.go
@@ -1,0 +1,25 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gruntwork-io/terratest/modules/random"
+)
+
+// ExternalDNS holds the config for externalDNS component
+type ExternalDNS struct {
+	NamespacePrefix string `yaml:"namespacePrefix"`
+	HostedZoneId    string `yaml:"hostedZoneId"`
+	Domain          string `yaml:"domain"`
+}
+
+// GetNamespaceName returns random namespace name, it considers (if set) the prefix
+// specified in the configuration
+func (e *ExternalDNS) GetNamespaceName() string {
+	if e.NamespacePrefix != "" {
+		return fmt.Sprintf("%s%s", e.NamespacePrefix, strings.ToLower(random.UniqueId()))
+	}
+
+	return fmt.Sprintf("external-dns-test-%s", strings.ToLower(random.UniqueId()))
+}

--- a/tests/pkg/config/nginx_ingress_controller.go
+++ b/tests/pkg/config/nginx_ingress_controller.go
@@ -1,0 +1,6 @@
+package config
+
+// NginxIngressController holds the config for nginx ingress controller component
+type NginxIngressController struct {
+	NamespacePrefix string `yaml:"namespacePrefix"`
+}

--- a/tests/pkg/helpers/externaldns.go
+++ b/tests/pkg/helpers/externaldns.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/ministryofjustice/tiny-k8s-tester/pkg/config"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -28,9 +27,7 @@ func RecordSets(d string, c *config.ExternalDNS) (bool, error) {
 
 	for _, v := range sets.ResourceRecordSets {
 		record := strings.TrimRight(*v.Name, ".")
-		spew.Dump(record)
 		if record == d {
-			fmt.Println("FOUND! Returning now")
 			return true, nil
 		}
 	}

--- a/tests/pkg/helpers/externaldns.go
+++ b/tests/pkg/helpers/externaldns.go
@@ -1,0 +1,39 @@
+package helpers
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/ministryofjustice/tiny-k8s-tester/pkg/config"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/route53"
+)
+
+// RecordSets uses the AWS API to return domain entry existence in Route53
+// using the hostzone ID specified in the configuration
+func RecordSets(d string, c *config.ExternalDNS) (bool, error) {
+	svc := route53.New(session.New())
+
+	params := &route53.ListResourceRecordSetsInput{
+		HostedZoneId: aws.String(c.HostedZoneId),
+	}
+
+	sets, err := svc.ListResourceRecordSets(params)
+	if err != nil {
+		return false, err
+	}
+
+	for _, v := range sets.ResourceRecordSets {
+		record := strings.TrimRight(*v.Name, ".")
+		spew.Dump(record)
+		if record == d {
+			fmt.Println("FOUND! Returning now")
+			return true, nil
+		}
+	}
+
+	return false, nil
+}


### PR DESCRIPTION
This closes https://github.com/ministryofjustice/cloud-platform/issues/2920 adding support to check external-DNS component in Kubernetes cluster. 

The check consist in:
1) Create an ingress resource 
2) Wait until external-DNS creates in Route53
3) Ensure the A records exist in Route53 with the domain specified in Step 1 ingress record
