### PR TITLE
Enable access to integrationtest hostzone in all clusters 

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/main.tf
@@ -51,6 +51,10 @@ data "aws_route53_zone" "selected" {
   name = "${terraform.workspace}.cloud-platform.service.justice.gov.uk"
 }
 
+data "aws_route53_zone" "integrationtest" {
+  name = "integrationtest.service.justice.gov.uk"
+}
+
 data "aws_route53_zone" "cloud_platform" {
   name = "cloud-platform.service.justice.gov.uk"
 }
@@ -69,10 +73,14 @@ locals {
   hostzones = {
     manager = [
       "arn:aws:route53:::hostedzone/${data.aws_route53_zone.selected.zone_id}",
-      "arn:aws:route53:::hostedzone/${data.aws_route53_zone.cloud_platform.zone_id}"
+      "arn:aws:route53:::hostedzone/${data.aws_route53_zone.cloud_platform.zone_id}",
+      "arn:aws:route53:::hostedzone/${data.aws_route53_zone.integrationtest.zone_id}"
     ]
     live    = ["arn:aws:route53:::hostedzone/*"]
-    default = ["arn:aws:route53:::hostedzone/${data.aws_route53_zone.selected.zone_id}"]
+    default = [
+      "arn:aws:route53:::hostedzone/${data.aws_route53_zone.selected.zone_id}",
+      "arn:aws:route53:::hostedzone/${data.aws_route53_zone.integrationtest.zone_id}"
+    ]
   }
 }
 

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/main.tf
@@ -76,7 +76,7 @@ locals {
       "arn:aws:route53:::hostedzone/${data.aws_route53_zone.cloud_platform.zone_id}",
       "arn:aws:route53:::hostedzone/${data.aws_route53_zone.integrationtest.zone_id}"
     ]
-    live    = ["arn:aws:route53:::hostedzone/*"]
+    live = ["arn:aws:route53:::hostedzone/*"]
     default = [
       "arn:aws:route53:::hostedzone/${data.aws_route53_zone.selected.zone_id}",
       "arn:aws:route53:::hostedzone/${data.aws_route53_zone.integrationtest.zone_id}"


### PR DESCRIPTION
In order to enable externalDNS test to run in all clusters, we must give it access to integrationtest hostzone.