### PR TITLE
Adding authorized keys test - made generic http file checker

### DIFF
--- a/tests/e2e/files_exist_test.go
+++ b/tests/e2e/files_exist_test.go
@@ -1,0 +1,22 @@
+package integration_tests
+
+import (
+	http_helper "github.com/gruntwork-io/terratest/modules/http-helper"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Files exist checks", func() {
+	It("should exist exist the following namespaces", func() {
+		if len(c.FilesExist) == 0 {
+			Skip("None files defined, skipping test")
+		}
+
+		for _, f := range c.FilesExist {
+			statusCode, _ := http_helper.HttpGet(GinkgoT(), f, nil)
+
+			Ω(statusCode).Should(Equal(200))
+		}
+	})
+})

--- a/tests/e2e/live.yaml
+++ b/tests/e2e/live.yaml
@@ -24,3 +24,5 @@ externalDNS:
   namespacePrefix: "e2e-tests-externaldns-"
   hostedZoneId: Z02429076QQMAO8KXV68
   domain: integrationtest.service.justice.gov.uk
+filesExist:
+  - "https://github.com/ministryofjustice/cloud-platform-terraform-bastion/blob/main/files/authorized_keys.txt"

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	github.com/aws/aws-sdk-go v1.27.1
+	github.com/davecgh/go-spew v1.1.1
 	github.com/go-resty/resty/v2 v2.6.0
 	github.com/gruntwork-io/terratest v0.34.4
 	github.com/onsi/ginkgo v1.15.0

--- a/tests/pkg/config/config.go
+++ b/tests/pkg/config/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	Namespaces             map[string]K8SObjects  `yaml:"namespaces"`
 	ExternalDNS            ExternalDNS            `yaml:"externalDNS"`
 	NginxIngressController NginxIngressController `yaml:"nginxIngressController"`
+	FilesExist             []string               `yaml:"filesExist"`
 }
 
 // K8SObjects are kubernetes objects nested from namespaces, we need to check


### PR DESCRIPTION
This PR includes a new generic field (`filesExist`) which performs an HTTP check of the status code, if it doesn't match `200` the test fails. 