### PR TITLE
Update external-dns to latest

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -60,7 +60,7 @@ module "cluster_autoscaler" {
 }
 
 module "external_dns" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-external-dns?ref=1.4.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-external-dns?ref=upgrade-to-latest-external-dns"
 
   iam_role_nodes      = data.aws_iam_role.nodes.arn
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name


### PR DESCRIPTION
In order to achieve updates from simple records to weight records we must upgrade external-dns. Otherwise we face https://github.com/kubernetes-sigs/external-dns/issues/1411. 