### PR TITLE
Dockerfile and makefile for e2e testing

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,7 +1,6 @@
-FROM golang:1.15-alpine AS builder
+FROM golang:1.16-alpine AS builder
 
-ENV GO111MODULE=on \
-    CGO_ENABLED=0 \
+ENV CGO_ENABLED=0 \
     GOOS=linux
 
 WORKDIR /build
@@ -12,15 +11,54 @@ RUN go mod download
 COPY . .
 RUN cd e2e && go test -c -o e2e-tests 
 
+FROM python:3-alpine3.13 AS installer
+
+ENV AWSCLI_VERSION=2.2.0
+
+RUN apk add --no-cache \
+    gcc \
+    git \
+    libc-dev \
+    libffi-dev \
+    openssl-dev \
+    py3-pip \
+    zlib-dev \
+    make \
+    cmake
+
+RUN git clone --recursive  --depth 1 --branch ${AWSCLI_VERSION} --single-branch https://github.com/aws/aws-cli.git
+
+WORKDIR /aws-cli
+
+# Follow https://github.com/six8/pyinstaller-alpine to install pyinstaller on alpine
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir pycrypto \
+    && git clone --depth 1 --single-branch --branch v$(grep PyInstaller requirements-build.txt | cut -d'=' -f3) https://github.com/pyinstaller/pyinstaller.git /tmp/pyinstaller \
+    && cd /tmp/pyinstaller/bootloader \
+    && CFLAGS="-Wno-stringop-overflow -Wno-stringop-truncation" python ./waf configure --no-lsb all \
+    && pip install .. \
+    && rm -Rf /tmp/pyinstaller \
+    && cd - \
+    && boto_ver=$(grep botocore setup.cfg | cut -d'=' -f3) \
+    && git clone --single-branch --branch v2 https://github.com/boto/botocore /tmp/botocore \
+    && cd /tmp/botocore \
+    && git checkout $(git log --grep $boto_ver --pretty=format:"%h") \
+    && pip install . \
+    && rm -Rf /tmp/botocore  \
+    && cd -
+
+RUN sed -i '/botocore/d' requirements.txt \
+    && scripts/installers/make-exe
+
+RUN unzip dist/awscli-exe.zip \
+    && ./aws/install --bin-dir /aws-cli-bin
+
 FROM alpine:3.13
 
-RUN apk update && apk add --no-cache --upgrade curl python3 py3-pip
-RUN pip install awscli
-
-RUN apk --purge -v del py-pip
+RUN apk update && apk add --no-cache --upgrade curl groff
 RUN rm /var/cache/apk/*
 
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.15.1/bin/linux/amd64/kubectl
+RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
 RUN chmod 755 kubectl && mv kubectl /bin/kubectl
 
 RUN addgroup -g 1000 -S appgroup && \
@@ -30,5 +68,8 @@ WORKDIR /tests
 
 COPY --from=builder /build/e2e/e2e-tests /usr/bin/
 COPY --from=builder /build/config /tests/
+
+COPY --from=installer /usr/local/aws-cli/ /usr/local/aws-cli/
+COPY --from=installer /aws-cli-bin/ /usr/local/bin/
 
 USER 1000

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15-alpine AS cloud_platform_tester
+FROM golang:1.15-alpine AS builder
 
 ENV GO111MODULE=on \
     CGO_ENABLED=0 \
@@ -8,7 +8,27 @@ WORKDIR /build
 COPY go.mod .
 COPY go.sum .
 RUN go mod download
-COPY . .
-RUN cd e2e && go test -c -o test 
-RUN pwd && ls
 
+COPY . .
+RUN cd e2e && go test -c -o e2e-tests 
+
+FROM alpine:3.13
+
+RUN apk update && apk add --no-cache --upgrade curl python3 py3-pip
+RUN pip install awscli
+
+RUN apk --purge -v del py-pip
+RUN rm /var/cache/apk/*
+
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.15.1/bin/linux/amd64/kubectl
+RUN chmod 755 kubectl && mv kubectl /bin/kubectl
+
+RUN addgroup -g 1000 -S appgroup && \
+    adduser -u 1000 -S appuser -G appgroup
+
+WORKDIR /tests
+
+COPY --from=builder /build/e2e/e2e-tests /usr/bin/
+COPY --from=builder /build/config /tests/
+
+USER 1000

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.15-alpine AS cloud_platform_tester
+
+ENV GO111MODULE=on \
+    CGO_ENABLED=0 \
+    GOOS=linux
+
+WORKDIR /build
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+COPY . .
+RUN cd e2e && go test -c -o test 
+RUN pwd && ls
+

--- a/tests/makefile
+++ b/tests/makefile
@@ -6,11 +6,19 @@ all: build push
 
 build:
 	@echo "Building image:"
-	docker build -t $(PREFIX):$(TAG) .
+	docker build  --network host -t $(PREFIX):$(TAG) .
+
 push:
 	@echo "Pushing image:"
 	docker push $(PREFIX):$(TAG)
-# test:
-# 	@echo "Running container:"
-# 	docker run --rm -p 8080:8080 $(PREFIX):$(TAG)
 
+test:
+	@echo "Running container:"
+	docker run -it --rm \
+		-v $(KUBE_CONFIG):/tests/config \
+		-v $(HOME)/.aws:/tests/.aws \
+		-e AWS_CONFIG_FILE=/tests/.aws/config \
+		-e AWS_PROFILE=$(AWS_PROFILE) \
+		-e AWS_SHARED_CREDENTIALS_FILE=/tests/.aws/credentials \
+		-e KUBECONFIG=/tests/config \
+		$(PREFIX):$(TAG) sh

--- a/tests/makefile
+++ b/tests/makefile
@@ -1,0 +1,16 @@
+VERSION=0.1
+PREFIX=ministryofjustice/cloud-platform-tests
+TAG=$(VERSION)
+
+all: build push
+
+build:
+	@echo "Building image:"
+	docker build -t $(PREFIX):$(TAG) .
+push:
+	@echo "Pushing image:"
+	docker push $(PREFIX):$(TAG)
+# test:
+# 	@echo "Running container:"
+# 	docker run --rm -p 8080:8080 $(PREFIX):$(TAG)
+


### PR DESCRIPTION
This will be useful when we decide to trigger pipelines that execute the e2e tests. 

- Good news: container can be as small as 40MB
- Bad news: To connect to EKS (not the kops side) you need `aws-cli` installed which adds so many MBs of size

Total image size: 94MB 

https://hub.docker.com/repository/docker/ministryofjustice/cloud-platform-tests/tags?page=1&ordering=last_updated