### PR TITLE
Add namespace annotation test

### DIFF
--- a/tests/config/live.yaml
+++ b/tests/config/live.yaml
@@ -14,10 +14,6 @@ namespaces:
       - "fluent-bit"
     servicemonitors:
       - fluent-bit
-  kiam:
-    daemonsets:
-      - "kiam-server"
-      - "kiam-agent"
   monitoring:
     daemonsets:
       - "prometheus-operator-prometheus-node-exporter"

--- a/tests/e2e/namespaces_test.go
+++ b/tests/e2e/namespaces_test.go
@@ -5,18 +5,24 @@ import (
 
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	. "github.com/onsi/ginkgo"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// Namespace checks refer to checks that involve namespace
+// specifics in a cluster.
 var _ = Describe("Namespace checks", func() {
 	var (
 		notFoundNamespaces []string
 	)
 
-	It("should exist exist the following namespaces", func() {
+	// Namespaces listed in the config file should exist.
+	It("should contain namespaces outlined in the config file", func() {
 		if len(c.Namespaces) == 0 {
-			Skip("None namespaces defined, skipping test")
+			Skip("No namespaces have been found. Skipping.")
 		}
 
+		// Loop over namespaces defined in the config file and add them
+		// to a collection if not found.
 		for ns, _ := range c.Namespaces {
 			options := k8s.NewKubectlOptions("", "", ns)
 			_, err := k8s.GetNamespaceE(GinkgoT(), options, ns)
@@ -26,8 +32,49 @@ var _ = Describe("Namespace checks", func() {
 			}
 		}
 
+		// If the notFoundNamespaces collection contains and entry the test will fail.
 		if notFoundNamespaces != nil {
-			Fail(fmt.Sprintf("The following namespaces DOES NOT exist: %v", notFoundNamespaces))
+			Fail(fmt.Sprintf("The following namespaces DO NOT exist: %v", notFoundNamespaces))
 		}
+	})
+
+	// Namespaces must have the appropriate annotations for things like
+	// monitoring. This test checks all namespaces for annotations. If the
+	// annotation list appears empty, it will fail.
+	It("must have the appropriate annotations", func() {
+		options := k8s.NewKubectlOptions("", "", "")
+		listOptions := metav1.ListOptions{}
+
+		// Grab all pods in the cluster to query the namespace name.
+		allPods := k8s.ListPods(GinkgoT(), options, listOptions)
+
+		// Becuase of the lack of a 'get all ns' in terratest we
+		// need to loop over every pod, grab the namepspace name
+		// and add it to a map. A map was chosen so we can perform
+		// a quick lookup of duplicates (because of the lack of
+		// slice.contains in go).
+		m := make(map[string]string)
+		for _, ns := range allPods {
+			_, ok := m[ns.Namespace]
+			if !ok {
+				m[ns.Namespace] = ""
+			}
+		}
+
+		// Loop over each key in the map and add namespace names
+		// to a collection.
+		var unannotatedNs []string
+		for k, _ := range m {
+			ns, _ := k8s.GetNamespaceE(GinkgoT(), options, k)
+			if len(ns.Annotations) < 1 {
+				unannotatedNs = append(unannotatedNs, ns.Name)
+			}
+		}
+
+		// If the unannotatedNs collection has entries the test will fail.
+		if unannotatedNs != nil {
+			Fail(fmt.Sprintf("The following namespaces DO NOT have annotations: %v", unannotatedNs))
+		}
+
 	})
 })


### PR DESCRIPTION
Overview
---
This connects to https://github.com/ministryofjustice/cloud-platform/issues/2919 and relates to the creation of a namespace annotation test in EKS clusters. We already have a ns-annotation smoketest for live-1 https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/main/smoke-tests/spec/namespace_annotations_spec.rb but this is very specific to live-1.

What's in this PR
---
This PR contains:
- a new Ginkgo test within the Namespace description. 
- a slight wording tweak on the other namespace test.
- removes kiam from list of expected daemonsets in the live cluster.

Why do we want to merge it
---
All namespaces (including `kube-system`) should contain annotations specific to the cluster. This test will confirm if a namespace has been created manually or erroneously.