### PR TITLE
cert-manager test - Increase waiting time after creating ingress 

### DIFF
--- a/smoke-tests/spec/cert_manager_spec.rb
+++ b/smoke-tests/spec/cert_manager_spec.rb
@@ -28,7 +28,7 @@ describe "cert-manager" do
 
       # Certificate creation and subsequent 2 minute wait for certificate status to equal "True"
       create_certificate(namespace, host)
-      sleep 150
+      sleep 240
 
       result = validate_certificate(host)
       expect(result).to match(/#{host}/)


### PR DESCRIPTION
The  cert-manager spec is consistently failing because it failed to resolve the DNS for host created. Even though the ingress was created in <90s and the external DNS entry created in A record around 114s, It takes some time to get the DNS resolved.

When ran locally, it passed when the wait time is 240. It did failed sometimes when set to 180.