### PR TITLE
remove integration ingress

### DIFF
--- a/smoke-tests/spec/fixtures/helloworld-deployment-modsec.yaml.erb
+++ b/smoke-tests/spec/fixtures/helloworld-deployment-modsec.yaml.erb
@@ -40,7 +40,6 @@ metadata:
     kubernetes.io/ingress.class: <%= ingress_class %> 
     nginx.ingress.kubernetes.io/enable-modsecurity: "false"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
-      Include /etc/nginx/owasp-modsecurity-crs/nginx-modsecurity.conf
       SecRuleEngine On
 spec:
   tls:

--- a/smoke-tests/spec/ingress_controller_spec.rb
+++ b/smoke-tests/spec/ingress_controller_spec.rb
@@ -1,14 +1,13 @@
 require "spec_helper"
 
-describe "ingress controllers", speed: "fast" do
+describe "test ingress controllers", speed: "fast", "live-1": false do
   context "default" do
-    # This needs to be any url of an ingress on the default controller,
-    let(:url) { "https://reports.cloud-platform.service.justice.gov.uk/dashboard" }
+    host = "prometheus.apps.#{current_cluster}"
+    let(:url) { "https://#{host}" }
 
-    it "returns 200 for http get" do
+    it "returns 302 for http get" do
       result = Net::HTTP.get_response(URI(url))
-      expect(result.code).to eq("200")
-      expect(result.message.strip).to eq("OK")
+      expect(result.code).to eq("302")
     end
 
     it "does not return a server header" do
@@ -18,16 +17,20 @@ describe "ingress controllers", speed: "fast" do
       expect(headers).to_not have_key("server")
     end
   end
+end
 
-  context "eks" do
-    let(:url) { "https://concourse.cloud-platform.service.justice.gov.uk/" }
+describe "live ingress controllers", speed: "fast", "live-1": true do
+  context "default" do
+    host = "prometheus.cloud-platform.service.justice.gov.uk"
+    let(:url) { "https://#{host}" }
 
     it "returns 302 for http get" do
       result = Net::HTTP.get_response(URI(url))
-      expect(result.code).to eq("200")
+      expect(result.code).to eq("302")
     end
 
     it "does not return a server header" do
+      # The `Server` response header should be suppressed by the ingress-controller configuration
       result = Net::HTTP.get_response(URI(url))
       headers = result.each_header.to_h
       expect(headers).to_not have_key("server")

--- a/smoke-tests/spec/ingress_controller_spec.rb
+++ b/smoke-tests/spec/ingress_controller_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe "ingress controllers", speed: "fast" do
   context "default" do
     # This needs to be any url of an ingress on the default controller,
-    let(:url) { "https://how-out-of-date-are-we.apps.live-1.cloud-platform.service.justice.gov.uk/dashboard" }
+    let(:url) { "https://reports.cloud-platform.service.justice.gov.uk/dashboard" }
 
     it "returns 200 for http get" do
       result = Net::HTTP.get_response(URI(url))
@@ -13,22 +13,6 @@ describe "ingress controllers", speed: "fast" do
 
     it "does not return a server header" do
       # The `Server` response header should be suppressed by the ingress-controller configuration
-      result = Net::HTTP.get_response(URI(url))
-      headers = result.each_header.to_h
-      expect(headers).to_not have_key("server")
-    end
-  end
-
-  context "modsec01" do
-    # This needs to be any hostname of an ingress on the modsec01 controller,
-    let(:url) { "https://manage-hmpps-auth-accounts-dev.prison.service.justice.gov.uk/" }
-
-    it "returns 302 for http get" do
-      result = Net::HTTP.get_response(URI(url))
-      expect(result.code).to eq("302")
-    end
-
-    it "does not return a server header" do
       result = Net::HTTP.get_response(URI(url))
       headers = result.each_header.to_h
       expect(headers).to_not have_key("server")

--- a/smoke-tests/spec/ingress_spec.rb
+++ b/smoke-tests/spec/ingress_spec.rb
@@ -7,9 +7,7 @@ describe "nginx ingress", speed: "slow" do
   ingress_name = "integration-test-app-ing"
   ingress_class = "nginx"
 
-  # Delay of 300 or lower consistently results in at least one test failure
-  # Delay of 360 fails 50/50
-  let(:sleep_delay) { 400 } # How long to wait after creating/modifying an ingress
+  let(:sleep_delay) { 60 } # How long to wait after creating/modifying an ingress
 
   before(:all) do
     create_namespace(namespace)
@@ -50,10 +48,10 @@ describe "nginx ingress", speed: "slow" do
     end
   end
 
-  context "when ingress is deployed using 'integration-test' ingress controller", kops: true do
+  context "when ingress is deployed using 'modsec01' ingress controller", kops: true do
     before do
       host = "#{namespace}-integration-test.apps.#{current_cluster}"
-      ingress_class = "integration-test"
+      ingress_class = "modsec01"
 
       apply_template_file(
         namespace: namespace,

--- a/smoke-tests/spec/ingress_spec.rb
+++ b/smoke-tests/spec/ingress_spec.rb
@@ -7,7 +7,9 @@ describe "nginx ingress", speed: "slow" do
   ingress_name = "integration-test-app-ing"
   ingress_class = "nginx"
 
-  let(:sleep_delay) { 60 } # How long to wait after creating/modifying an ingress
+  # Delay of 300 or lower consistently results in at least one test failure
+  # Delay of 360 fails 50/50
+  let(:sleep_delay) { 400 } # How long to wait after creating/modifying an ingress
 
   before(:all) do
     create_namespace(namespace)

--- a/smoke-tests/spec/modsec_spec.rb
+++ b/smoke-tests/spec/modsec_spec.rb
@@ -4,12 +4,12 @@ require "spec_helper"
 # Integration tests has the dedicated ingress controller with ingress class - integration-test
 # The below spec uses the ingress_class = "integration-test" in its ingress annotation
 
-describe "Testing modsec on ingress class: 'integration-test'", kops: true do
-  namespace = "integrationtest-modsec-#{readable_timestamp}"
+describe "Testing modsec on ingress class: 'modsec01'", kops: true do
+  namespace = "smoketest-modsec-#{readable_timestamp}"
   host = "#{namespace}.apps.#{current_cluster}"
   let(:url) { "https://#{host}" }
   ingress_name = "integration-test-app-ing"
-  ingress_class = "integration-test"
+  ingress_class = "modsec01"
 
   let(:good_url) { "https://#{host}" }
   let(:bad_url) { "https://#{host}?exec=/bin/bash" }
@@ -25,7 +25,7 @@ describe "Testing modsec on ingress class: 'integration-test'", kops: true do
       binding: binding
     )
     wait_for(namespace, "ingress", ingress_name)
-    sleep 180 # We need to wait for a while *after* the ingress is created before we try to test it, or we get failures.
+    sleep 60 # We need to wait for a while *after* the ingress is created before we try to test it, or we get failures.
   end
 
   after(:all, kops: true) do
@@ -36,7 +36,7 @@ describe "Testing modsec on ingress class: 'integration-test'", kops: true do
     before do
       annotations_hash = {'nginx.ingress.kubernetes.io/enable-modsecurity': "true"}
       annotate_ingress(namespace, ingress_name, annotations_hash)
-      sleep 30
+      sleep 10
     end
 
     context "when the url is benign" do
@@ -60,7 +60,7 @@ describe "Testing modsec on ingress class: 'integration-test'", kops: true do
     before do
       annotations_hash = {'nginx.ingress.kubernetes.io/enable-modsecurity': "false"}
       annotate_ingress(namespace, ingress_name, annotations_hash)
-      sleep 30
+      sleep 10
     end
 
     context "when the url is benign" do

--- a/smoke-tests/spec/modsec_spec.rb
+++ b/smoke-tests/spec/modsec_spec.rb
@@ -25,7 +25,7 @@ describe "Testing modsec on ingress class: 'modsec01'", kops: true do
       binding: binding
     )
     wait_for(namespace, "ingress", ingress_name)
-    sleep 60 # We need to wait for a while *after* the ingress is created before we try to test it, or we get failures.
+    sleep 180 # We need to wait for a while *after* the ingress is created before we try to test it, or we get failures.
   end
 
   after(:all, kops: true) do
@@ -36,7 +36,7 @@ describe "Testing modsec on ingress class: 'modsec01'", kops: true do
     before do
       annotations_hash = {'nginx.ingress.kubernetes.io/enable-modsecurity': "true"}
       annotate_ingress(namespace, ingress_name, annotations_hash)
-      sleep 10
+      sleep 30
     end
 
     context "when the url is benign" do
@@ -60,7 +60,7 @@ describe "Testing modsec on ingress class: 'modsec01'", kops: true do
     before do
       annotations_hash = {'nginx.ingress.kubernetes.io/enable-modsecurity': "false"}
       annotate_ingress(namespace, ingress_name, annotations_hash)
-      sleep 10
+      sleep 30
     end
 
     context "when the url is benign" do

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/components.tf
@@ -5,7 +5,7 @@ module "cert_manager" {
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   hostzone            = lookup(var.cluster_r53_resource_maps, terraform.workspace, ["arn:aws:route53:::hostedzone/${data.terraform_remote_state.cluster.outputs.hosted_zone_id}"])
 
-  dependence_prometheus = "ignore" #module.prometheus.helm_prometheus_operator_status
+  dependence_prometheus = module.prometheus.helm_prometheus_operator_status
   dependence_opa        = "ignore"
 }
 


### PR DESCRIPTION
```
# rspec ./spec/ingress_controller_spec.rb ./spec/ingress_spec.rb ./spec/modsec_spec.rb --format progress --format documentation

ingress controllers
  default
.    returns 200 for http get
.    does not return a server header
  eks
.    returns 302 for http get
.    does not return a server header

nginx ingress
  when ingress is not deployed
.    fails http get
  when ingress is deployed using 'nginx' ingress controller
.    returns 200 for http get
  when ingress is deployed using 'modsec01' ingress controller
.    responds to http get
  when ingress is deployed with invalid syntax
.    is rejected by the admission webhook

Testing modsec on ingress class: 'modsec01'
  when modsec is deployed
    when the url is benign
.      request succeeds
    when the url is malicious
.      request is blocked
  when modsec is disabled
    when the url is benign
.      request succeeds
    when the url is malicious
.      request succeeds


Finished in 4 minutes 36.8 seconds (files took 0.85491 seconds to load)
12 examples, 0 failures
```