### PR TITLE
Add kuberos, associate Auth0 identity provider and wait for active

### DIFF
--- a/create-cluster.rb
+++ b/create-cluster.rb
@@ -9,7 +9,6 @@
 #
 require "fileutils"
 require "optparse"
-require "json"
 
 MAX_CLUSTER_NAME_LENGTH = 12
 CLUSTER_SUFFIX = "cloud-platform.service.justice.gov.uk"
@@ -29,7 +28,6 @@ def main(options)
   integration_tests = options[:integration_tests]
   dockerconfig = options[:dockerconfig]
   extra_wait = options[:extra_wait]
-  activate_oidc = options[:activate_oidc]
 
   vpc_name = cluster_name if vpc_name.nil?
   usage if cluster_name.nil?

--- a/create-cluster.rb
+++ b/create-cluster.rb
@@ -41,7 +41,7 @@ def main(options)
   if kind == "eks" || kind == "EKS"
     create_cluster_eks(cluster_name, vpc_name)
     sleep(extra_wait)
-    check_identity_provider_assiciation(cluster_name) if activate_oidc
+    check_identity_provider_assoiciation(cluster_name) if activate_oidc
     install_components_eks(cluster_name)
   else
     create_cluster_kops(cluster_name, vpc_name)
@@ -116,7 +116,7 @@ def check_identity_provider_assoiciation(cluster_name)
 end
 
 def status_active?(cmd)
-  response,_,_ = execute(cmd)
+  response = execute(cmd)
   current_status =  JSON.parse(response).dig("identityProviderConfig","oidc","status")
   log "Current Status: #{current_status}"
   current_status == "ACTIVE"

--- a/create-cluster.rb
+++ b/create-cluster.rb
@@ -28,6 +28,7 @@ def main(options)
   integration_tests = options[:integration_tests]
   dockerconfig = options[:dockerconfig]
   extra_wait = options[:extra_wait]
+  activate_oidc = options[:activate_oidc]
 
   vpc_name = cluster_name if vpc_name.nil?
   usage if cluster_name.nil?
@@ -40,6 +41,7 @@ def main(options)
   if kind == "eks" || kind == "EKS"
     create_cluster_eks(cluster_name, vpc_name)
     sleep(extra_wait)
+    check_identity_provider_assiciation(cluster_name) if activate_oidc
     install_components_eks(cluster_name)
   else
     create_cluster_kops(cluster_name, vpc_name)
@@ -90,6 +92,34 @@ def create_cluster_eks(cluster_name, vpc_name)
   ].join(" ")
 
   run_and_output "cd #{dir}; #{tf_apply}"
+end
+
+def check_identity_provider_assoiciation(cluster_name)
+  max_tries = 1
+  validated = false
+
+  (1..max_tries).each do |attempt|
+    log "Check for active Auth0 Identity Provider Association, attempt #{attempt} of #{max_tries}..."
+
+    cmd = "aws eks describe-identity-provider-config --cluster-name #{cluster_name} --identity-provider-config '{\"type\": \"oidc\", \"name\": \"Auth0\"}'"
+    if status_active?(cmd)
+      log "Auth0 Identity provider association to the cluster successful."
+      validated = true
+      break
+    else
+      log "Sleeping before retry..."
+      sleep 20
+    end
+  end
+
+  raise "ERROR Failed to associate Auth0 Identity provider to the  cluster after #{max_tries} attempts." unless validated
+end
+
+def status_active?(cmd)
+  response,_,_ = execute(cmd)
+  current_status =  JSON.parse(response).dig("identityProviderConfig","oidc","status")
+  log "Current Status: #{current_status}"
+  current_status == "ACTIVE"
 end
 
 def run_kops(cluster_name, dockerconfig)
@@ -220,7 +250,7 @@ def wait_for_kops_validate
     end
   end
 
-  raise "ERROR Failed to validate cluster after $max_tries attempts." unless validated
+  raise "ERROR Failed to validate cluster after #{max_tries} attempts." unless validated
 end
 
 def switch_terraform_workspace(dir, name)
@@ -341,6 +371,10 @@ def parse_options
 
     opts.on("-d", "--dockerconfig DOCKER-CONFIG", "Authenticate to Docker hub using a docker config file") do |name|
       options[:dockerconfig] = name
+    end
+
+    opts.on("-o", "--no-active-oidc", "Dont wait for the OIDC Association to be active after cluster creation") do |name|
+      options[:activate_oidc] = true
     end
 
     opts.on_tail("-h", "--help", "Show help message") do

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -105,6 +105,17 @@ module "logging" {
   eks                      = true
 }
 
+module "kuberos" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-kuberos?ref=0.3.0"
+
+  cluster_domain_name           = data.terraform_remote_state.cluster.outputs.cluster_domain_name
+  oidc_kubernetes_client_id     = data.terraform_remote_state.cluster.outputs.oidc_kubernetes_client_id
+  oidc_kubernetes_client_secret = data.terraform_remote_state.cluster.outputs.oidc_kubernetes_client_secret
+  oidc_issuer_url               = data.terraform_remote_state.cluster.outputs.oidc_issuer_url
+  cluster_address               = data.terraform_remote_state.cluster.outputs.cluster_endpoint
+  create_aws_redirect           = terraform.workspace == local.prod_workspace ? true : false
+}
+
 module "monitoring" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=1.7.1"
 

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -113,7 +113,7 @@ module "kuberos" {
   oidc_kubernetes_client_secret = data.terraform_remote_state.cluster.outputs.oidc_kubernetes_client_secret
   oidc_issuer_url               = data.terraform_remote_state.cluster.outputs.oidc_issuer_url
   cluster_address               = data.terraform_remote_state.cluster.outputs.cluster_endpoint
-  create_aws_redirect           = terraform.workspace == local.prod_workspace ? true : false
+  create_aws_redirect           = false
 }
 
 module "monitoring" {

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/main.tf
@@ -159,7 +159,7 @@ resource "null_resource" "wait_for_active_associate" {
 variable "wait_for_active_associate_cmd" {
   description = "Custom local-exec command to execute for determining if the associate identity provider is active. Cluster name will be available as an environment variable called CLUSTER"
   type        = string
-  default     = "for i in `seq 1 20`; do if [[ `aws eks describe-identity-provider-config --cluster-name pk-eks-01 --identity-provider-config type='oidc',name='Auth0' --output json --query 'identityProviderConfig.oidc.status'` == '\"ACTIVE\"' ]]; then exit 0;else echo 'Checking again for active Auth0 association'; sleep 2;fi; done; echo 'TIMEOUT due to maximum retries to check for active Auth0 association'; exit 1"
+  default     = "for i in `seq 1 10`; do if [[ `aws eks describe-identity-provider-config --cluster-name pk-eks-01 --identity-provider-config type='oidc',name='Auth0' --output json --query 'identityProviderConfig.oidc.status'` == '\"ACTIVE\"' ]]; then exit 0;else echo 'Checking again for active Auth0 association'; sleep 2;fi; done; echo 'TIMEOUT due to maximum retries to check for active Auth0 association'; exit 1"
 }
 
 variable "wait_for_active_associate_interpreter" {

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/main.tf
@@ -163,7 +163,7 @@ variable "wait_for_active_associate_cmd" {
 }
 
 variable "wait_for_active_associate_interpreter" {
-  description = "Custom local-exec command line interpreter for the command to determining if the eks cluster is healthy."
+  description = "Custom local-exec command line interpreter for the command to determining if the Auth0 association to eks cluster is active."
   type        = list(string)
   default     = ["/bin/sh", "-c"]
 }

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/main.tf
@@ -137,3 +137,10 @@ module "auth0" {
   services_base_domain = "apps.${local.fqdn}"
   extra_callbacks      = lookup(local.auth0_extra_callbacks, terraform.workspace, [""])
 }
+
+resource "null_resource" "associate_identity_provider" {
+  provisioner "local-exec" {
+    command = "aws eks associate-identity-provider-config --cluster-name '${terraform.workspace}' --oidc identityProviderConfigName='Auth0',issuerUrl='${var.auth0_issuerUrl}',clientId='${module.auth0.oidc_kubernetes_client_id}',usernameClaim=email,groupsClaim='${var.auth0_groupsClaim}',requiredClaims={}"
+  }
+
+}

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/main.tf
@@ -159,7 +159,7 @@ resource "null_resource" "wait_for_active_associate" {
 variable "wait_for_active_associate_cmd" {
   description = "Custom local-exec command to execute for determining if the associate identity provider is active. Cluster name will be available as an environment variable called CLUSTER"
   type        = string
-  default     = "for i in `seq 1 10`; do if [[ `aws eks describe-identity-provider-config --cluster-name pk-eks-01 --identity-provider-config type='oidc',name='Auth0' --output json --query 'identityProviderConfig.oidc.status'` == '\"ACTIVE\"' ]]; then exit 0;else echo 'Checking again for active Auth0 association'; sleep 2;fi; done; echo 'TIMEOUT due to maximum retries to check for active Auth0 association'; exit 1"
+  default     = "for i in `seq 1 40`; do if [[ `aws eks describe-identity-provider-config --cluster-name $CLUSTER --identity-provider-config type='oidc',name='Auth0' --output json --query 'identityProviderConfig.oidc.status'` == '\"ACTIVE\"' ]]; then exit 0;else echo 'Checking again for active Auth0 association'; sleep 30;fi; done; echo 'TIMEOUT due to maximum retries to check for active Auth0 association'; exit 1"
 }
 
 variable "wait_for_active_associate_interpreter" {

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/outputs.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/outputs.tf
@@ -54,4 +54,5 @@ output "cluster_id" {
 }
 output "cluster_endpoint" {
   value = module.eks.cluster_endpoint
+  depends_on = [null_resource.wait_for_active_associate]
 }

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/outputs.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/outputs.tf
@@ -52,3 +52,6 @@ output "cluster_oidc_issuer_url" {
 output "cluster_id" {
   value = module.eks.cluster_id
 }
+output "cluster_endpoint" {
+  value = module.eks.cluster_endpoint
+}

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/variables.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/variables.tf
@@ -15,3 +15,8 @@ variable "auth0_groupsClaim" {
   description = "OIDC Group Claim domain for justice cloud-platform account"
   default = "https://k8s.integration.dsd.io/groups"
 }
+
+variable "check_associate" {
+  description = "Check for active association during cluster creation. This is required for kuberos to authenticate to the cluster."
+  default = "true"
+}

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/variables.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/variables.tf
@@ -5,3 +5,13 @@ variable "dockerhub_user" {
 variable "dockerhub_token" {
   description = "Token for the above"
 }
+variable "auth0_issuerUrl" {
+  description = "domain IssuerURL by which Auth0 can find the OpenID Provider Configuration Document"
+  default = "https://justice-cloud-platform.eu.auth0.com/"
+}
+
+# Set when Auth0 account is setup in here: /terraform/global-resources/auth0.tf
+variable "auth0_groupsClaim" {
+  description = "OIDC Group Claim domain for justice cloud-platform account"
+  default = "https://k8s.integration.dsd.io/groups"
+}

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/variables.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/variables.tf
@@ -17,6 +17,7 @@ variable "auth0_groupsClaim" {
 }
 
 variable "check_associate" {
-  description = "Check for active association during cluster creation. This is required for kuberos to authenticate to the cluster."
+  type        = string
   default = "true"
+  description = "Check for active association during cluster creation. This is required for kuberos to authenticate to the cluster."
 }


### PR DESCRIPTION
Related to: https://github.com/ministryofjustice/cloud-platform/issues/2945

This PR adds
- a null resource to associate the identity provider (Auth0) to the cluster
- wait for the association to be active
- Add kuberos to all EKS clusters. 

