### PR TITLE
Add null resource associate Identity Provider to cluster 

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/main.tf
@@ -137,3 +137,33 @@ module "auth0" {
   services_base_domain = "apps.${local.fqdn}"
   extra_callbacks      = lookup(local.auth0_extra_callbacks, terraform.workspace, [""])
 }
+
+resource "null_resource" "associate_identity_provider" {
+  provisioner "local-exec" {
+    command = "aws eks associate-identity-provider-config --cluster-name '${terraform.workspace}' --oidc identityProviderConfigName='Auth0',issuerUrl='${var.auth0_issuerUrl}',clientId='${module.auth0.oidc_kubernetes_client_id}',usernameClaim=email,groupsClaim='${var.auth0_groupsClaim}',requiredClaims={}; exit 0"
+  }
+
+}
+
+resource "null_resource" "wait_for_active_associate" {
+  count = var.check_associate == "true" ? 1 : 0
+  provisioner "local-exec" {
+    command     = var.wait_for_active_associate_cmd
+    interpreter = var.wait_for_active_associate_interpreter
+    environment = {
+      CLUSTER = terraform.workspace
+    }
+  }
+}
+
+variable "wait_for_active_associate_cmd" {
+  description = "Custom local-exec command to execute for determining if the associate identity provider is active. Cluster name will be available as an environment variable called CLUSTER"
+  type        = string
+  default     = "for i in `seq 1 40`; do if [[ `aws eks describe-identity-provider-config --cluster-name $CLUSTER --identity-provider-config type='oidc',name='Auth0' --output json --query 'identityProviderConfig.oidc.status'` == '\"ACTIVE\"' ]]; then exit 0;else echo 'Checking again for active Auth0 association'; sleep 30;fi; done; echo 'TIMEOUT due to maximum retries to check for active Auth0 association'; exit 1"
+}
+
+variable "wait_for_active_associate_interpreter" {
+  description = "Custom local-exec command line interpreter for the command to determining if the Auth0 association to eks cluster is active."
+  type        = list(string)
+  default     = ["/bin/sh", "-c"]
+}

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/outputs.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/outputs.tf
@@ -52,3 +52,7 @@ output "cluster_oidc_issuer_url" {
 output "cluster_id" {
   value = module.eks.cluster_id
 }
+output "cluster_endpoint" {
+  value      = module.eks.cluster_endpoint
+  depends_on = [null_resource.wait_for_active_associate]
+}

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/variables.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/variables.tf
@@ -5,3 +5,19 @@ variable "dockerhub_user" {
 variable "dockerhub_token" {
   description = "Token for the above"
 }
+variable "auth0_issuerUrl" {
+  description = "domain IssuerURL by which Auth0 can find the OpenID Provider Configuration Document"
+  default     = "https://justice-cloud-platform.eu.auth0.com/"
+}
+
+# Set when Auth0 account is setup in here: /terraform/global-resources/auth0.tf
+variable "auth0_groupsClaim" {
+  description = "OIDC Group Claim domain for justice cloud-platform account"
+  default     = "https://k8s.integration.dsd.io/groups"
+}
+
+variable "check_associate" {
+  type        = string
+  default     = "true"
+  description = "Check for active association during cluster creation. This is required for kuberos to authenticate to the cluster."
+}


### PR DESCRIPTION
add null resource to associate the identity provider (Auth0) to the cluster
add  null_resource wait for the association to be active

This is required for authenticate to the cluster using OIDC via Auth0.
Related to: https://github.com/ministryofjustice/cloud-platform/issues/2945