### PR TITLE
Change tag to test-cluster-only

### DIFF
--- a/smoke-tests/spec/ingress_controller_spec.rb
+++ b/smoke-tests/spec/ingress_controller_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe "test ingress controllers", speed: "fast", "live-1": false do
+describe "test ingress controllers", speed: "fast", cluster: "test-cluster-only" do
   context "default" do
     host = "prometheus.apps.#{current_cluster}"
     let(:url) { "https://#{host}" }


### PR DESCRIPTION
Integration-tests for live-1 is run excluding tags 'eks-manager', 'cluster:test-cluster-only'. Hence live-1:false will not be excluded from running in live-1