### PR TITLE
Upgrade cert-maanger to v1.4.0

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -36,7 +36,7 @@ module "concourse" {
 }
 
 module "cert_manager" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-certmanager?ref=1.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-certmanager?ref=1.2.0"
 
   iam_role_nodes      = data.aws_iam_role.nodes.arn
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name


### PR DESCRIPTION
This release fixes an issue where an ACME Certificate, with a long name (52 characters or more)
jetstack/cert-manager#3866.

Ticket related to it:
ministryofjustice/cloud-platform#2976