### PR TITLE
Make node_type a list and change instance type for clusters

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
@@ -38,7 +38,7 @@ module "eks" {
       create_launch_template = true
       pre_userdata           = local.pre_userdata
 
-      instance_type = lookup(local.node_size, terraform.workspace, local.node_size["default"])
+      instance_types = lookup(local.node_size, terraform.workspace, local.node_size["default"])
       k8s_labels = {
         Terraform = "true"
         Cluster   = terraform.workspace

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/main.tf
@@ -35,7 +35,7 @@ locals {
   }
 
   node_groups_count = {
-    live    = "19"
+    live    = "54"
     default = "4"
   }
 

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/main.tf
@@ -40,12 +40,12 @@ locals {
   }
 
   node_size = {
-    live    = "r5.xlarge"
-    manager = "m4.xlarge"
-    default = "r5.xlarge"
+    live    = ["r5.xlarge", "r4.xlarge"]
+    manager = ["m5.xlarge", "m4.xlarge"]
+    default = ["m5.large", "m4.large"]
   }
 
-  # Some clusters (like manage) need extra callbacks URLs in auth0
+  # Some clusters (like manager) need extra callbacks URLs in auth0
   auth0_extra_callbacks = {
     manager = ["https://sonarqube.cloud-platform.service.justice.gov.uk/oauth2/callback/oidc"]
   }

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/outputs.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/outputs.tf
@@ -55,3 +55,7 @@ output "cluster_id" {
 output "cluster_endpoint" {
   value = module.eks.cluster_endpoint
 }
+
+output "instance_types" {
+  value = module.eks.node_groups.default_ng.instance_types
+}


### PR DESCRIPTION
WHAT
Change node_type to a list and add a secondary instance type if first is not available for any reason.
Increase the number of nodes on live to up the limit on available IP addresses = pods

WHY
A list allows to choose more than one node type as we have had a previous incident when a node type was not available in a particular AZ.
IP address limits (pods) per node_type - https://github.com/awslabs/amazon-eks-ami/blob/master/files/eni-max-pods.txt