### PR TITLE
Output external_subnets_ids for eks.

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/outputs.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/outputs.tf
@@ -18,6 +18,10 @@ output "internal_subnets_ids" {
   value = tolist(data.aws_subnet_ids.private.ids)
 }
 
+output "external_subnets_ids" {
+  value = tolist(data.aws_subnet_ids.public.ids)
+}
+
 output "cluster_domain_name" {
   value = local.fqdn
 }


### PR DESCRIPTION
Because external_subnet_ids are not in eks cluster folder outputs, the terraform state file has this information missing. Hence, when comparing the list of subnets in vpc and determine whether they are orphaned from the HOODAW reports page, it shows the subnets as orphaned for clusters which are available