### PR TITLE
Fix create cluster dependency for kops and eks

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -84,7 +84,6 @@ module "ingress_controllers" {
   dependence_prometheus  = "ignore"
   dependence_certmanager = module.cert_manager.helm_cert_manager_status
   dependence_opa         = "ignore"
-  depends_on             = [module.cert_manager]
 }
 
 module "modsec_ingress_controllers" {

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -36,7 +36,7 @@ module "concourse" {
 }
 
 module "cert_manager" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-certmanager?ref=1.2.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-certmanager?ref=1.2.1"
 
   iam_role_nodes      = data.aws_iam_role.nodes.arn
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
@@ -81,9 +81,10 @@ module "ingress_controllers" {
   is_live_cluster     = lookup(local.prod_workspace, terraform.workspace, false)
 
   # This module requires prometheus and cert-manager
-  dependence_prometheus  = module.monitoring.helm_prometheus_operator_status
+  dependence_prometheus  = "ignore"
   dependence_certmanager = module.cert_manager.helm_cert_manager_status
   dependence_opa         = "ignore"
+  depends_on             = [module.cert_manager]
 }
 
 module "modsec_ingress_controllers" {
@@ -92,8 +93,7 @@ module "modsec_ingress_controllers" {
   controller_name = "modsec01"
   replica_count   = "4"
 
-  dependence_prometheus  = module.monitoring.helm_prometheus_operator_status
-  dependence_certmanager = module.cert_manager.helm_cert_manager_status
+  depends_on = [module.ingress_controllers]
 }
 
 module "kuberos" {
@@ -142,7 +142,8 @@ module "monitoring" {
 }
 
 module "opa" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-opa?ref=0.0.11"
+  source     = "github.com/ministryofjustice/cloud-platform-terraform-opa?ref=0.0.11"
+  depends_on = [module.monitoring, module.ingress_controllers, module.velero, module.cert_manager]
 
   cluster_domain_name            = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   enable_invalid_hostname_policy = lookup(local.prod_workspace, terraform.workspace, false) ? false : true

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/components.tf
@@ -93,12 +93,11 @@ module "ingress_controllers" {
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   is_live_cluster     = terraform.workspace == local.live_workspace ? true : false
 
+  # This module requires cert-manager
   dependence_certmanager = module.cert_manager.helm_cert_manager_status
   dependence_opa         = "ignore"
   # already set by cert-manager
   dependence_prometheus = "ignore"
-  # This module requires cert-manager
-  depends_on = [module.cert_manager]
 }
 
 module "opa" {

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/components.tf
@@ -1,5 +1,5 @@
 module "cert_manager" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-certmanager?ref=1.2.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-certmanager?ref=1.2.1"
 
   iam_role_nodes      = data.aws_iam_role.nodes.arn
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
@@ -93,15 +93,17 @@ module "ingress_controllers" {
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   is_live_cluster     = terraform.workspace == local.live_workspace ? true : false
 
-  # This module requires cert-manager
   dependence_certmanager = module.cert_manager.helm_cert_manager_status
   dependence_opa         = "ignore"
   # already set by cert-manager
   dependence_prometheus = "ignore"
+  # This module requires cert-manager
+  depends_on = [module.cert_manager]
 }
 
 module "opa" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-opa?ref=0.0.11"
+  source     = "github.com/ministryofjustice/cloud-platform-terraform-opa?ref=0.0.11"
+  depends_on = [module.prometheus, module.ingress_controllers, module.velero, module.kiam, module.cert_manager]
 
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   # boolean expression for applying opa valid hostname for test clusters only.


### PR DESCRIPTION
Add multiple modules depends on for OPA to install it at the end.


Upgrade cert-manger chart to latest which got a fix for null resource dependency