### PR TITLE
Added depends on cert-manager for ingress-controller

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -85,7 +85,7 @@ module "ingress_controllers" {
   dependence_certmanager = module.cert_manager.helm_cert_manager_status
   dependence_opa         = "ignore"
   # It depends on complete cert-manager module
-  depends_on             = [module.cert_manager]
+  depends_on = [module.cert_manager]
 }
 
 module "modsec_ingress_controllers" {

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -84,6 +84,8 @@ module "ingress_controllers" {
   dependence_prometheus  = "ignore"
   dependence_certmanager = module.cert_manager.helm_cert_manager_status
   dependence_opa         = "ignore"
+  # It depends on complete cert-manager module
+  depends_on             = [module.cert_manager]
 }
 
 module "modsec_ingress_controllers" {

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/components.tf
@@ -93,11 +93,12 @@ module "ingress_controllers" {
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   is_live_cluster     = terraform.workspace == local.live_workspace ? true : false
 
-  # This module requires cert-manager
   dependence_certmanager = module.cert_manager.helm_cert_manager_status
   dependence_opa         = "ignore"
   # already set by cert-manager
   dependence_prometheus = "ignore"
+  # This module requires cert-manager module
+  depends_on = [module.cert_manager]
 }
 
 module "opa" {


### PR DESCRIPTION
As cert-manager module contains creating cluster issuer, and the ingress controller module creating default cert depends on it.