### PR TITLE
Upgrade default & modsec Ingress-controller for Kops

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -89,7 +89,7 @@ module "ingress_controllers" {
 }
 
 module "modsec_ingress_controllers" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-modsec-ingress-controller?ref=0.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-modsec-ingress-controller?ref=0.3.0"
 
   controller_name = "modsec01"
   replica_count   = "4"

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/components.tf
@@ -79,7 +79,7 @@ module "prometheus" {
 }
 
 module "modsec_ingress_controllers" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-modsec-ingress-controller?ref=0.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-modsec-ingress-controller?ref=0.3.0"
 
   controller_name = "modsec01"
   replica_count   = "4"

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/components.tf
@@ -79,7 +79,7 @@ module "prometheus" {
 }
 
 module "modsec_ingress_controllers" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-modsec-ingress-controller?ref=0.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-modsec-ingress-controller?ref=0.1.0"
 
   controller_name = "modsec01"
   replica_count   = "4"
@@ -88,7 +88,7 @@ module "modsec_ingress_controllers" {
 }
 
 module "ingress_controllers" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=0.2.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=0.3.0"
 
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   is_live_cluster     = terraform.workspace == local.live_workspace ? true : false


### PR DESCRIPTION
Upgrade to chart v3.34.0 for both default and modsec ingress controller,
this is to have both controllers running on the same version.

For modsec ingress controller, remove controller name to fix NLB recreation and validation webhook issue.
More info:
https://github.com/ministryofjustice/cloud-platform/issues/2989#issuecomment-866103729

Related to ticket:
https://github.com/ministryofjustice/cloud-platform/issues/2994