### PR TITLE
Add paginated list_policies responses

### DIFF
--- a/smoke-tests/spec/kiam_helper.rb
+++ b/smoke-tests/spec/kiam_helper.rb
@@ -99,6 +99,21 @@ class KiamRole
     rtn
   end
 
+  def list_policies(client)
+    rtn = []
+    is_truncated = true
+    marker = nil
+
+    while is_truncated
+      policies = client.list_policies(marker: marker)
+      rtn += policies.policies
+      is_truncated = policies.is_truncated
+      marker = policies.marker
+    end
+
+    rtn
+  end
+
   # If the role was created during a test run for a different cluster, the current
   # cluster's nodes will not be included as principals in the role's trust
   # relationships.
@@ -163,9 +178,10 @@ class KiamRole
   end
 
   def fetch_or_create_policy(args)
+ 
     policy_name = args.fetch(:policy_name)
-
-    if policy = client.list_policies.policies.find { |p| p.policy_name == args.fetch(:policy_name) }
+    
+    if policy = list_policies(client).find { |p| p.policy_name == args.fetch(:policy_name) }
       arn = policy.arn
     else
       resp = client.create_policy(

--- a/smoke-tests/spec/kiam_spec.rb
+++ b/smoke-tests/spec/kiam_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 # Kiam will enable code running in the cluster to assume an AWS role if
 # both the pod and the namespace are annotated appropriately.
-xdescribe "kiam", kops: true do
+describe "kiam", kops: true do
   KIAM_ROLE_NAME = "integration-test-kiam-iam-role"
 
   # Do not use a dynamically-generated role_name here. This test


### PR DESCRIPTION
The list_policies started failing with 

`Aws::IAM::Errors::EntityAlreadyExists:
       A policy called integration-test-kiam-policy already exists. Duplicate names are not allowed.`

because the policy expected is not in the first set of responses. This PR change will call list_policies until all policies are returned and hence the test pass.