### PR TITLE
Update default certificate of "live" cluster

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -75,10 +75,11 @@ module "external_dns" {
 }
 
 module "ingress_controllers" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=0.3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=0.3.1"
 
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   is_live_cluster     = lookup(local.prod_workspace, terraform.workspace, false)
+  live1_cert_dns_name = lookup(local.live1_cert_dns_name, terraform.workspace, "")
 
   # This module requires prometheus and cert-manager
   dependence_prometheus  = "ignore"

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/main.tf
@@ -82,6 +82,9 @@ locals {
       "arn:aws:route53:::hostedzone/${data.aws_route53_zone.integrationtest.zone_id}"
     ]
   }
+  live1_cert_dns_name = {
+    live = format("- '*.apps.%s'", var.live1_domain)
+  }
 }
 
 ##########

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/variables.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/variables.tf
@@ -2,6 +2,11 @@ variable "pagerduty_config" {
   description = "Add PagerDuty key to allow integration with a PD service."
 }
 
+variable "live1_domain" {
+  default     = "live-1.cloud-platform.service.justice.gov.uk"
+  description = "cluster domain name for live-1"
+}
+
 variable "alertmanager_slack_receivers" {
   description = "A list of configuration values for Slack receivers"
   type        = list(any)


### PR DESCRIPTION
This is to include *.apps.live-1, so users can use apps.live-1 domain, when migrating to eks-live cluster.

This is related to the issue:
https://github.com/ministryofjustice/cloud-platform/issues/3013