### PR TITLE
Create null resource to test default cert incident

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/k8s-resources.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/k8s-resources.tf
@@ -93,3 +93,17 @@ resource "kubernetes_cluster_role_binding" "concourse_build_environments" {
     namespace = "kube-system"
   }
 }
+
+
+### This is to test the cert incident which applied to live-1 instated of manager
+
+resource "null_resource" "test-kubectl-context" {
+  provisioner "local-exec" {
+    command = "kubectl apply -n default -f ${path.module}/resources/helloworld-deployment.yaml"
+  }
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = "kubectl delete -n default --ignore-not-found -f ${path.module}/resources/helloworld-deployment.yaml"
+  }
+}

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/resources/helloworld-deployment.yaml
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/resources/helloworld-deployment.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: integration-test-helloworld
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: integration-test-app
+  template:
+    metadata:
+      labels:
+        app: integration-test-app
+    spec:
+      containers:
+      - name: nginx
+        image: bitnami/nginx
+        ports:
+        - containerPort: 8080
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: integration-test-svc
+  labels:
+    app: integration-test-svc
+spec:
+  ports:
+  - port: 80
+    name: http
+    targetPort: 8080
+  selector:
+    app: integration-test-app


### PR DESCRIPTION
This is to check if the infrastructure apply pipeline is, using the right kubectl context to apply null resources.