### PR TITLE
Update ingress-controller module to latest version

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/components.tf
@@ -88,7 +88,7 @@ module "modsec_ingress_controllers" {
 }
 
 module "ingress_controllers" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=0.3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=0.3.1"
 
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   is_live_cluster     = terraform.workspace == local.live_workspace ? true : false


### PR DESCRIPTION
This is to include *.apps.live-1 for "eks-live" cluster, so users can use apps.live-1 domain, when migrating to eks-live cluster.

This is related to the issue:
https://github.com/ministryofjustice/cloud-platform/issues/3013