### PR TITLE
Set up logging for eks-live cluster

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -110,7 +110,7 @@ module "kuberos" {
 }
 
 module "logging" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-logging?ref=1.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-logging?ref=1.1.1"
 
   elasticsearch_host       = lookup(var.elasticsearch_hosts_maps, terraform.workspace, "placeholder-elasticsearch")
   elasticsearch_audit_host = lookup(var.elasticsearch_audit_hosts_maps, terraform.workspace, "placeholder-elasticsearch")

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/variables.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/variables.tf
@@ -19,6 +19,7 @@ variable "cloud_platform_slack_webhook" {
 variable "elasticsearch_hosts_maps" {
   default = {
     manager = "search-cloud-platform-live-dibidbfud3uww3lpxnhj2jdws4.eu-west-2.es.amazonaws.com"
+    live    = "search-cloud-platform-live-dibidbfud3uww3lpxnhj2jdws4.eu-west-2.es.amazonaws.com"
   }
 }
 


### PR DESCRIPTION
This change to push logs from eks-live fluent-bit to live AWS-ES, with separate index for a cluster.

Related to:
https://github.com/ministryofjustice/cloud-platform/issues/3006