### PR TITLE
Skip concourse tests for eks-live

### DIFF
--- a/smoke-tests/spec/concourse_spec.rb
+++ b/smoke-tests/spec/concourse_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe "concourse-test", "eks-manager": true do
+describe "concourse-test", "eks-manager": true, "concourse-test": true do
   specify do
     expect(namespace_exists?("concourse")).to eq(true)
   end


### PR DESCRIPTION
This skips concourse tests in the eks-live cluster, as concourse only runs in manager cluster.