### PR TITLE
Scale up live aws elastic-search.

### DIFF
--- a/terraform/global-resources/elasticsearch.tf
+++ b/terraform/global-resources/elasticsearch.tf
@@ -96,7 +96,7 @@ resource "aws_elasticsearch_domain" "live_1" {
 
   ebs_options {
     ebs_enabled = "true"
-    volume_type = "gp2"
+    volume_type = "gp3"
     volume_size = "1536"
   }
 

--- a/terraform/global-resources/elasticsearch.tf
+++ b/terraform/global-resources/elasticsearch.tf
@@ -82,7 +82,7 @@ resource "aws_elasticsearch_domain" "live_1" {
   elasticsearch_version = "7.4"
 
   cluster_config {
-    instance_type            = "m4.4xlarge.elasticsearch"
+    instance_type            = "r5.4xlarge.elasticsearch"
     instance_count           = "15"
     dedicated_master_enabled = true
     dedicated_master_type    = "m4.large.elasticsearch"

--- a/terraform/global-resources/elasticsearch.tf
+++ b/terraform/global-resources/elasticsearch.tf
@@ -96,7 +96,7 @@ resource "aws_elasticsearch_domain" "live_1" {
 
   ebs_options {
     ebs_enabled = "true"
-    volume_type = "gp3"
+    volume_type = "gp2"
     volume_size = "1536"
   }
 


### PR DESCRIPTION
We are using a single elastic search for multiple clusters (live-1, manager and eks-live), scale up AWS live ES to accommodate the load.

ref for ES pricing:
https://aws.amazon.com/elasticsearch-service/pricing/

As we are going to create a separate index for all the clusters, fluent-bit by default push 1-week logs with the new index.

scaled up to "r5.4xlarge.elasticsearch",  observing for 1-2 weeks we need to scale up or down depending upon the load.