### PR TITLE
Fix non-determinic failure with modsec integration test

### DIFF
--- a/tests/e2e/modsec_ingress_test.go
+++ b/tests/e2e/modsec_ingress_test.go
@@ -66,16 +66,12 @@ var _ = Describe("Modsec Ingress", func() {
 			k8s.KubectlApplyFromString(GinkgoT(), options, tpl)
 			k8s.WaitUntilIngressAvailableV1Beta1(GinkgoT(), options, "integration-test-app-ing", 60, 5*time.Second)
 
-			retry.DoWithRetry(GinkgoT(), fmt.Sprintf("Waiting for sucessfull DNS lookup from %s", host), 20, 10*time.Second, func() (string, error) {
-				return helpers.DNSLookUp(host)
-			})
-
-			retry.DoWithRetry(GinkgoT(), fmt.Sprintf("evaluating http code for %s", host), 20, 10*time.Second, func() (string, error) {
-
+			retry.DoWithRetry(GinkgoT(), fmt.Sprintf("evaluating http code for %s", host), 2, 120*time.Second, func() (string, error) {
 				s, err := helpers.HttpStatusCode(url)
 				if err != nil {
 					log.Fatalf("execution: %s", err)
 				}
+
 				if s != 200 {
 					return "", fmt.Errorf("Expected http return code 200. Got '%v'", s)
 				}

--- a/tests/makefile
+++ b/tests/makefile
@@ -1,4 +1,4 @@
-VERSION=0.5
+VERSION=0.6
 PREFIX=ministryofjustice/cloud-platform-tests
 TAG=$(VERSION)
 


### PR DESCRIPTION
Even when the endpoint returns 200 it doesn't mean modsec ingress controller is ready. It takes some seconds extra (even if the website is serving 200s) to be enabled.

This was determined by testing/tuning the values of the timeouts and steps between tries.

It was also removed the DNS check, which is not needed here We have a wildcard DNS value for the hostzone.