### PR TITLE
Fix logging rspec tests

### DIFF
--- a/smoke-tests/spec/logging_spec.rb
+++ b/smoke-tests/spec/logging_spec.rb
@@ -27,7 +27,7 @@ describe "Log collection", "live-1": true do
     #       intermittent pipeline failures
 
     date = Date.today.strftime("%Y.%m.%d")
-    search_url = "#{ELASTIC_SEARCH}/kubernetes_cluster-#{date}/_search"
+    search_url = "#{ELASTIC_SEARCH}/kubernetes_cluster_live-1-#{date}/_search"
 
     # this job queries elasticsearch, looking for all log data for our namespace, today
     create_job(namespace, "spec/fixtures/logging-job.yaml.erb", {


### PR DESCRIPTION
This is to fix the logging test by updating the right search_url, as ES indices are now updated by adding cluster name to the suffix.