### PR TITLE
Update the logging module to use the latest.

### DIFF
--- a/smoke-tests/spec/logging_spec.rb
+++ b/smoke-tests/spec/logging_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 # Use the cluster: 'live-1' tag to identify tests which can only run against the live-1 cluster
 # (in this case, because that's the only place where elasticsearch is set up with these values)
-describe "Log collection", "live-1": true do
+describe "Log collection", "live-1": true, "eks-manager": true do
   let(:namespace) { "smoketest-logging-#{readable_timestamp}" }
 
   ELASTIC_SEARCH = "https://search-cloud-platform-live-dibidbfud3uww3lpxnhj2jdws4.eu-west-2.es.amazonaws.com"
@@ -27,7 +27,8 @@ describe "Log collection", "live-1": true do
     #       intermittent pipeline failures
 
     date = Date.today.strftime("%Y.%m.%d")
-    search_url = "#{ELASTIC_SEARCH}/kubernetes_cluster_live-1-#{date}/_search"
+    short_cluster_name = current_cluster.partition(".").first
+    search_url = "#{ELASTIC_SEARCH}/kubernetes_cluster_#{short_cluster_name}-#{date}/_search"
 
     # this job queries elasticsearch, looking for all log data for our namespace, today
     create_job(namespace, "spec/fixtures/logging-job.yaml.erb", {

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -110,12 +110,13 @@ module "kuberos" {
 }
 
 module "logging" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-logging?ref=1.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-logging?ref=1.1.2"
 
   elasticsearch_host       = lookup(var.elasticsearch_hosts_maps, terraform.workspace, "placeholder-elasticsearch")
   elasticsearch_audit_host = lookup(var.elasticsearch_audit_hosts_maps, terraform.workspace, "placeholder-elasticsearch")
   dependence_prometheus    = module.monitoring.helm_prometheus_operator_status
   eks                      = true
+  enable_curator_cronjob   = terraform.workspace == "live" ? true : false
 }
 
 module "monitoring" {

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -116,7 +116,6 @@ module "logging" {
   elasticsearch_audit_host = lookup(var.elasticsearch_audit_hosts_maps, terraform.workspace, "placeholder-elasticsearch")
   dependence_prometheus    = module.monitoring.helm_prometheus_operator_status
   eks                      = true
-  enable_curator_cronjob   = terraform.workspace == "live" ? true : false
 }
 
 module "monitoring" {

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/components.tf
@@ -53,6 +53,7 @@ module "logging" {
   elasticsearch_audit_host = replace(terraform.workspace, "live", "") != terraform.workspace ? "search-cloud-platform-audit-dq5bdnjokj4yt7qozshmifug6e.eu-west-2.es.amazonaws.com" : "placeholder-elasticsearch-audit"
 
   dependence_prometheus  = module.prometheus.helm_prometheus_operator_status
+  enable_curator_cronjob = terraform.workspace == local.live_workspace ? true : false
 }
 
 module "prometheus" {

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/components.tf
@@ -44,7 +44,7 @@ module "kuberos" {
 
 
 module "logging" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-logging?ref=1.1.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-logging?ref=1.1.2"
 
   # if you need to connect to the test elasticsearch cluster, replace "placeholder-elasticsearch" with "search-cloud-platform-test-zradqd7twglkaydvgwhpuypzy4.eu-west-2.es.amazonaws.com"
   # -> value = "${replace(terraform.workspace, "live", "") != terraform.workspace ? "search-cloud-platform-live-dibidbfud3uww3lpxnhj2jdws4.eu-west-2.es.amazonaws.com" : "search-cloud-platform-test-zradqd7twglkaydvgwhpuypzy4.eu-west-2.es.amazonaws.com"
@@ -53,7 +53,6 @@ module "logging" {
   elasticsearch_audit_host = replace(terraform.workspace, "live", "") != terraform.workspace ? "search-cloud-platform-audit-dq5bdnjokj4yt7qozshmifug6e.eu-west-2.es.amazonaws.com" : "placeholder-elasticsearch-audit"
 
   dependence_prometheus  = module.prometheus.helm_prometheus_operator_status
-  enable_curator_cronjob = terraform.workspace == local.live_workspace ? true : false
 }
 
 module "prometheus" {


### PR DESCRIPTION
The latest module got a fix for elastic search-curator.

Update logging RSpec tests to run on all clusters, this excludes test clusters, as logs don't get to ES for test clusters.

Not moving the curator job to eks-live yet, as clearing completed jobs is working as expected in eks.
 - We don't have TTLAfterFinished, as it only supports EKS from K8's v.1.20.
 - Jobs are not deleted as configured in "failed_jobs_history_limit" and "successful_jobs_history_limit"
