### PR TITLE
Explicit sleep for nginx modsec test

### DIFF
--- a/tests/e2e/modsec_ingress_test.go
+++ b/tests/e2e/modsec_ingress_test.go
@@ -78,6 +78,7 @@ var _ = Describe("Modsec Ingress", func() {
 				return "", nil
 			})
 
+			// This is not ideal, we need to find the way how improve this.
 			time.Sleep(120 * time.Second)
 
 			Expect(helpers.HttpStatusCode(bad_url)).To(Equal(403))

--- a/tests/e2e/modsec_ingress_test.go
+++ b/tests/e2e/modsec_ingress_test.go
@@ -78,6 +78,8 @@ var _ = Describe("Modsec Ingress", func() {
 				return "", nil
 			})
 
+			time.Sleep(120 * time.Second)
+
 			Expect(helpers.HttpStatusCode(bad_url)).To(Equal(403))
 
 			By("having an benign url, request succeeds")


### PR DESCRIPTION
Somehow, even if modsec returns 200's for the site, it doesn't mean it is acting as WAF. It takes a small amount of time (less than 2 mins) to get properly ready. This PR adds two minute wait (can be less but requires more testing/tuning) before doing the check for bad URLs and modsecurity.