### PR TITLE
Upgraded external-dns to latest version

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/components.tf
@@ -10,7 +10,7 @@ module "cert_manager" {
 }
 
 module "external_dns" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-external-dns?ref=1.5.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-external-dns?ref=1.5.2"
 
   iam_role_nodes      = data.aws_iam_role.nodes.arn
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name


### PR DESCRIPTION
This change is already applied. It updated external-dns to the latest docker image (the one defined by the helm chart by default)