### PR TITLE
Add metrics and alerts to externalDNS in live-1

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/components.tf
@@ -10,7 +10,7 @@ module "cert_manager" {
 }
 
 module "external_dns" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-external-dns?ref=1.5.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-external-dns?ref=1.6.0"
 
   iam_role_nodes      = data.aws_iam_role.nodes.arn
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/main.tf
@@ -16,6 +16,7 @@ provider "aws" {
 }
 
 provider "kubernetes" {}
+provider "kubectl" {}
 
 provider "helm" {
   kubernetes {}

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/versions.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/versions.tf
@@ -10,6 +10,10 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = "~> 1.11"
     }
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = "1.11.2"
+    }
     null = {
       source = "hashicorp/null"
     }


### PR DESCRIPTION
Used the kubectl provider (instead of null resource) to add the PrometheusRule

The metrics are enabled directly by the helm chart.

The end to end was tested in test cluster: cp-2307-1158