### PR TITLE
 Add metrics and alerts to externalDNS in manager

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -61,7 +61,7 @@ module "cluster_autoscaler" {
 }
 
 module "external_dns" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-external-dns?ref=1.5.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-external-dns?ref=1.6.0"
 
   iam_role_nodes      = data.aws_iam_role.nodes.arn
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/versions.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/versions.tf
@@ -15,7 +15,7 @@ terraform {
     }
     kubectl = {
       source  = "gavinbunney/kubectl"
-      version = "1.11.1"
+      version = "1.11.2"
     }
   }
   required_version = ">= 0.14"


### PR DESCRIPTION
Used the kubectl provider (instead of null resource) to add the PrometheusRule

The metrics are enabled directly by the helm chart.

The end to end was tested in test cluster: cp-2307-1158