### PR TITLE
Add external-dns dependence on Prometheus

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -69,6 +69,7 @@ module "external_dns" {
 
   # EKS doesn't use KIAM but it is a requirement for the module.
   dependence_kiam = ""
+  depends_on = [ module.monitoring ]
 
   # This section is for EKS
   eks                         = true

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -69,7 +69,7 @@ module "external_dns" {
 
   # EKS doesn't use KIAM but it is a requirement for the module.
   dependence_kiam = ""
-  depends_on = [ module.monitoring ]
+  depends_on      = [module.monitoring]
 
   # This section is for EKS
   eks                         = true


### PR DESCRIPTION
Because external-dns adds an alertRule, it required CRD. It means Prometheus must be installed first.