### PR TITLE
Add missing storage class in EKS

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/k8s-resources.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/k8s-resources.tf
@@ -18,6 +18,22 @@ resource "kubernetes_storage_class" "storageclass" {
   }
 }
 
+resource "kubernetes_storage_class" "io1" {
+  metadata {
+    name = "io1-expand"
+  }
+
+  storage_provisioner    = "kubernetes.io/aws-ebs"
+  reclaim_policy         = "Delete"
+  allow_volume_expansion = "true"
+
+  parameters = {
+    type      = "io1"
+    iopsPerGB = "10000"
+    fsType    = "ext4"
+  }
+}
+
 module "eks_csi" {
   count       = 0
   source      = "github.com/ministryofjustice/cloud-platform-terraform-eks-csi?ref=gp3"


### PR DESCRIPTION
The storage class io-expand, used bu Prometheus, is missing in EKS. If we want to be consistent with live-1 and with Prometheus it should be added