### PR TITLE
Update cloud-platform components to remove "apps"

### DIFF
--- a/smoke-tests/spec/fixtures/external-dns-ingress.yaml.erb
+++ b/smoke-tests/spec/fixtures/external-dns-ingress.yaml.erb
@@ -5,6 +5,8 @@ metadata:
   name: <%= ingress_name %>
   annotations:
     kubernetes.io/ingress.class: "nginx"
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
+    external-dns.alpha.kubernetes.io/set-identifier: dns-test
 spec:
   rules:
   - host: <%= domain %>

--- a/smoke-tests/spec/fixtures/helloworld-deployment-modsec.yaml.erb
+++ b/smoke-tests/spec/fixtures/helloworld-deployment-modsec.yaml.erb
@@ -38,6 +38,8 @@ metadata:
   name: integration-test-app-ing
   annotations:
     kubernetes.io/ingress.class: <%= ingress_class %> 
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
+    external-dns.alpha.kubernetes.io/set-identifier: dns-test
     nginx.ingress.kubernetes.io/enable-modsecurity: "false"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On

--- a/smoke-tests/spec/fixtures/helloworld-deployment.yaml.erb
+++ b/smoke-tests/spec/fixtures/helloworld-deployment.yaml.erb
@@ -38,6 +38,8 @@ metadata:
   name: integration-test-app-ing
   annotations:
     kubernetes.io/ingress.class: <%= ingress_class %>
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
+    external-dns.alpha.kubernetes.io/set-identifier: dns-test
 spec:
   tls:
   - hosts:

--- a/smoke-tests/spec/fixtures/invalid-nginx-syntax.yaml.erb
+++ b/smoke-tests/spec/fixtures/invalid-nginx-syntax.yaml.erb
@@ -5,6 +5,8 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     kubernetes.io/ingress.class: "nginx"
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
+    external-dns.alpha.kubernetes.io/set-identifier: dns-test
 spec:
   tls:
   - hosts:

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/main.tf
@@ -134,7 +134,7 @@ module "auth0" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-auth0?ref=1.2.2"
 
   cluster_name         = terraform.workspace
-  services_base_domain = "apps.${local.fqdn}"
+  services_base_domain = local.fqdn
   extra_callbacks      = lookup(local.auth0_extra_callbacks, terraform.workspace, [""])
 }
 

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/kops/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/kops/main.tf
@@ -112,10 +112,9 @@ module "bastion" {
 #########
 
 module "auth0" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-auth0?ref=1.1.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-auth0?ref=1.2.2"
 
   cluster_name         = local.cluster_name
   services_base_domain = local.services_base_domain
-  services_eks_domain  = local.services_eks_domain
   extra_callbacks      = lookup(local.auth0_extra_callbacks, terraform.workspace, [""])
 }

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/kops/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/kops/main.tf
@@ -51,9 +51,12 @@ locals {
   vpc                      = var.vpc_name == "" ? terraform.workspace : var.vpc_name
 
   is_live_cluster      = terraform.workspace == "live-1"
-  services_base_domain = local.is_live_cluster ? "cloud-platform.service.justice.gov.uk" : "apps.${local.cluster_base_domain_name}"
-  is_manager_cluster   = terraform.workspace == "manager"
-  services_eks_domain  = local.is_manager_cluster ? "cloud-platform.service.justice.gov.uk" : "apps.${local.cluster_base_domain_name}"
+  services_base_domain = local.is_live_cluster ? "cloud-platform.service.justice.gov.uk" : local.cluster_base_domain_name
+
+  # This is to maintain multiple URLs for monitoring stack, in light of the EKS migration
+  auth0_extra_callbacks = {
+    live-1 = [for i in ["prometheus", "grafana", "alertmanager"] : "${i}.${local.cluster_base_domain_name}/oauth2/callback"]
+  }
 }
 
 ########
@@ -114,4 +117,5 @@ module "auth0" {
   cluster_name         = local.cluster_name
   services_base_domain = local.services_base_domain
   services_eks_domain  = local.services_eks_domain
+  extra_callbacks      = lookup(local.auth0_extra_callbacks, terraform.workspace, [""])
 }

--- a/tests/e2e/fixtures/external-dns-ingress.yaml.tmpl
+++ b/tests/e2e/fixtures/external-dns-ingress.yaml.tmpl
@@ -5,6 +5,8 @@ metadata:
   name: e2e-tests-externaldns
   annotations:
     kubernetes.io/ingress.class: "nginx"
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
+    external-dns.alpha.kubernetes.io/set-identifier: dns-test
 spec:
   rules:
   - host: {{ .domain }}

--- a/tests/e2e/modsec_ingress_test.go
+++ b/tests/e2e/modsec_ingress_test.go
@@ -51,8 +51,10 @@ var _ = Describe("Modsec Ingress", func() {
 
 			TemplateVars := map[string]interface{}{
 				"ingress_annotations": map[string]string{
-					"kubernetes.io/ingress.class":                     "modsec01",
-					"nginx.ingress.kubernetes.io/enable-modsecurity":  "\"true\"",
+					"kubernetes.io/ingress.class": "modsec01",
+					"external-dns.alpha.kubernetes.io/aws-weight": "100",
+					"external-dns.alpha.kubernetes.io/set-identifier": "dns-test",
+					"nginx.ingress.kubernetes.io/enable-modsecurity": "\"true\"",
 					"nginx.ingress.kubernetes.io/modsecurity-snippet": "|\n     SecRuleEngine On",
 				},
 				"host": host,

--- a/tests/e2e/modsec_ingress_test.go
+++ b/tests/e2e/modsec_ingress_test.go
@@ -51,10 +51,10 @@ var _ = Describe("Modsec Ingress", func() {
 
 			TemplateVars := map[string]interface{}{
 				"ingress_annotations": map[string]string{
-					"kubernetes.io/ingress.class": "modsec01",
-					"external-dns.alpha.kubernetes.io/aws-weight": "100",
+					"kubernetes.io/ingress.class":                     "modsec01",
+					"external-dns.alpha.kubernetes.io/aws-weight":     "100",
 					"external-dns.alpha.kubernetes.io/set-identifier": "dns-test",
-					"nginx.ingress.kubernetes.io/enable-modsecurity": "\"true\"",
+					"nginx.ingress.kubernetes.io/enable-modsecurity":  "\"true\"",
 					"nginx.ingress.kubernetes.io/modsecurity-snippet": "|\n     SecRuleEngine On",
 				},
 				"host": host,

--- a/tests/e2e/nginx_ingress_test.go
+++ b/tests/e2e/nginx_ingress_test.go
@@ -49,8 +49,8 @@ var _ = Describe("Nginx Ingress", func() {
 
 			TemplateVars := map[string]interface{}{
 				"ingress_annotations": map[string]string{
-					"kubernetes.io/ingress.class": "nginx",
-					"external-dns.alpha.kubernetes.io/aws-weight": "100",
+					"kubernetes.io/ingress.class":                     "nginx",
+					"external-dns.alpha.kubernetes.io/aws-weight":     "100",
 					"external-dns.alpha.kubernetes.io/set-identifier": "dns-test",
 				},
 				"host": host,

--- a/tests/e2e/nginx_ingress_test.go
+++ b/tests/e2e/nginx_ingress_test.go
@@ -50,6 +50,8 @@ var _ = Describe("Nginx Ingress", func() {
 			TemplateVars := map[string]interface{}{
 				"ingress_annotations": map[string]string{
 					"kubernetes.io/ingress.class": "nginx",
+					"external-dns.alpha.kubernetes.io/aws-weight": "100",
+					"external-dns.alpha.kubernetes.io/set-identifier": "dns-test",
 				},
 				"host": host,
 			}


### PR DESCRIPTION
Update cloud-platform components to remove "apps", this is in the DNS name and add the external-dns annotation.

This is related to the ticket:
https://github.com/ministryofjustice/cloud-platform/issues/3116