### PR TITLE
Update monitoring/prometheus module in components

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -121,7 +121,7 @@ module "logging" {
 }
 
 module "monitoring" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=1.7.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=1.7.4"
 
   alertmanager_slack_receivers = var.alertmanager_slack_receivers
   iam_role_nodes               = data.aws_iam_role.nodes.arn


### PR DESCRIPTION
Update to the latest Prometheus/Monitoring module in order to use io1-expand storage class in EKS side.