### PR TITLE
Replace "null_resource" with "kubectl_manifest"

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -77,7 +77,7 @@ module "external_dns" {
 }
 
 module "ingress_controllers" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=0.3.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=0.3.2"
 
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   is_live_cluster     = lookup(local.prod_workspace, terraform.workspace, false)

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/components.tf
@@ -89,7 +89,7 @@ module "modsec_ingress_controllers" {
 }
 
 module "ingress_controllers" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=0.3.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=0.3.2"
 
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   is_live_cluster     = terraform.workspace == local.live_workspace ? true : false


### PR DESCRIPTION
- As we are seeing multiple issues using null_resource, replacing this with  kubectl_manifest.
- Add '*.apps.<cluster_domain_name>' to all clusters
- Add '*.apps.cloud-platform.service.justice.gov.uk' to live_clusters