### PR TITLE
Add external_dns annotation and remove apps from host

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -101,7 +101,7 @@ module "modsec_ingress_controllers" {
 }
 
 module "kuberos" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-kuberos?ref=0.3.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-kuberos?ref=0.3.2"
 
   cluster_domain_name           = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   oidc_kubernetes_client_id     = data.terraform_remote_state.cluster.outputs.oidc_kubernetes_client_id

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/components.tf
@@ -33,7 +33,7 @@ module "kiam" {
 }
 
 module "kuberos" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-kuberos?ref=0.3.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-kuberos?ref=0.3.2"
 
   cluster_domain_name           = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   oidc_kubernetes_client_id     = data.terraform_remote_state.cluster.outputs.oidc_kubernetes_client_id


### PR DESCRIPTION
    - This is to add external_dns annotation as we are going to apply,
    OPA policy to restrict ingress which doesn't have these annotations.
    - Remove "apps" from the hostname