### PR TITLE
Implement URLs for monitoring stack

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -121,7 +121,7 @@ module "logging" {
 }
 
 module "monitoring" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=1.7.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=1.7.5"
 
   alertmanager_slack_receivers = var.alertmanager_slack_receivers
   iam_role_nodes               = data.aws_iam_role.nodes.arn

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/components.tf
@@ -58,7 +58,7 @@ module "logging" {
 }
 
 module "prometheus" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=1.6.6"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=1.7.5"
 
   alertmanager_slack_receivers               = var.alertmanager_slack_receivers
   iam_role_nodes                             = data.aws_iam_role.nodes.arn
@@ -75,8 +75,6 @@ module "prometheus" {
   oidc_components_client_id     = data.terraform_remote_state.cluster.outputs.oidc_components_client_id
   oidc_components_client_secret = data.terraform_remote_state.cluster.outputs.oidc_components_client_secret
   oidc_issuer_url               = data.terraform_remote_state.cluster.outputs.oidc_issuer_url
-
-  dependence_opa = "ignore"
 }
 
 module "modsec_ingress_controllers" {


### PR DESCRIPTION
This is in light of the EKS migration
     -  Add external-dns annotation to grafana/kibana/prometheus/alertmanager
     - Configure cluster-specific and live_domain hosts in ingress, for Prometheus and Alertmanager
     
Related to https://github.com/ministryofjustice/cloud-platform/issues/3007