### PR TITLE
Create Policy to check external-dns annotation

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -146,11 +146,12 @@ module "monitoring" {
 }
 
 module "opa" {
-  source     = "github.com/ministryofjustice/cloud-platform-terraform-opa?ref=0.0.12"
+  source     = "github.com/ministryofjustice/cloud-platform-terraform-opa?ref=0.0.13"
   depends_on = [module.monitoring, module.ingress_controllers, module.velero, module.cert_manager]
 
   cluster_domain_name            = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   enable_invalid_hostname_policy = lookup(local.prod_workspace, terraform.workspace, false) ? false : true
+  enable_external_dns_weight     = terraform.workspace == "live" ? true : false
 }
 
 module "velero" {


### PR DESCRIPTION
     - This is to deny ingress creation with out external_dns annotation.
     -  Terraform count condition to enable this policy,
         as only get applied to live-eks.
     -  Create tests for external-dns annotation check

     This is related to:
     https://github.com/ministryofjustice/cloud-platform/issues/3008