### PR TITLE
Fix go tests which have external-dns annotation

### DIFF
--- a/tests/e2e/modsec_ingress_test.go
+++ b/tests/e2e/modsec_ingress_test.go
@@ -52,8 +52,8 @@ var _ = Describe("Modsec Ingress", func() {
 			TemplateVars := map[string]interface{}{
 				"ingress_annotations": map[string]string{
 					"kubernetes.io/ingress.class":                     "modsec01",
-					"external-dns.alpha.kubernetes.io/aws-weight":     "100",
-					"external-dns.alpha.kubernetes.io/set-identifier": "dns-test",
+					"external-dns.alpha.kubernetes.io/aws-weight":     "\"100\"",
+					"external-dns.alpha.kubernetes.io/set-identifier": "\"dns-test\"",
 					"nginx.ingress.kubernetes.io/enable-modsecurity":  "\"true\"",
 					"nginx.ingress.kubernetes.io/modsecurity-snippet": "|\n     SecRuleEngine On",
 				},

--- a/tests/e2e/nginx_ingress_test.go
+++ b/tests/e2e/nginx_ingress_test.go
@@ -50,8 +50,8 @@ var _ = Describe("Nginx Ingress", func() {
 			TemplateVars := map[string]interface{}{
 				"ingress_annotations": map[string]string{
 					"kubernetes.io/ingress.class":                     "nginx",
-					"external-dns.alpha.kubernetes.io/aws-weight":     "100",
-					"external-dns.alpha.kubernetes.io/set-identifier": "dns-test",
+					"external-dns.alpha.kubernetes.io/aws-weight":     "\"100\"",
+					"external-dns.alpha.kubernetes.io/set-identifier": "\"dns-test\"",
 				},
 				"host": host,
 			}


### PR DESCRIPTION
This is failing on external-dns annotations:
 error: unable to decode