### PR TITLE
K8S credentials loaded dynamically depending on workspace

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/main.tf
@@ -18,10 +18,19 @@ provider "aws" {
   profile = "moj-cp"
 }
 
-provider "kubernetes" {}
+provider "kubernetes" {
+  host                   = data.aws_eks_cluster.cluster.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+  token                  = data.aws_eks_cluster_auth.cluster.token
+  load_config_file       = false
+}
 
 provider "helm" {
-  kubernetes {}
+  kubernetes {
+    host                   = data.aws_eks_cluster.cluster.endpoint
+    cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+    token                  = data.aws_eks_cluster_auth.cluster.token
+  }
 }
 
 #################
@@ -42,6 +51,14 @@ data "terraform_remote_state" "cluster" {
 ##################
 # Data Resources #
 ##################
+
+data "aws_eks_cluster" "cluster" {
+  name = terraform.workspace
+}
+
+data "aws_eks_cluster_auth" "cluster" {
+  name = terraform.workspace
+}
 
 data "aws_iam_role" "nodes" {
   name = data.terraform_remote_state.cluster.outputs.eks_worker_iam_role_name


### PR DESCRIPTION
This will reduce the chances of making mistakes with kubectl context while we do `terraform apply/destroy`