### PR TITLE
Increase the sleep time for docker-registry-cache test

### DIFF
--- a/smoke-tests/spec/docker_registry_cache_spec.rb
+++ b/smoke-tests/spec/docker_registry_cache_spec.rb
@@ -27,7 +27,7 @@ describe "docker-registry-cache", kops: true do
       before_lines = get_pod_logs(namespace, pod_name).split("\n")
       execute("kubectl run --generator=run-pod/v1 output-date --image alpine date > /dev/null")
 
-      sleep 20
+      sleep 60
 
       after_lines = get_pod_logs(namespace, pod_name).split("\n")
       execute("kubectl delete pod output-date > /dev/null")


### PR DESCRIPTION
The docker-registry-cache integration test is failing regularly, Increasing the sleep time to wait for logs, before comparing the logs.

Tested this locally multiple times, increasing the delay, not seen any failure.