### PR TITLE
Upgrade live-1 monitoring module to use v1.7.0

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/components.tf
@@ -58,7 +58,7 @@ module "logging" {
 }
 
 module "prometheus" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=1.6.6"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=1.7.0"
 
   alertmanager_slack_receivers               = var.alertmanager_slack_receivers
   iam_role_nodes                             = data.aws_iam_role.nodes.arn

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/components.tf
@@ -58,7 +58,7 @@ module "logging" {
 }
 
 module "prometheus" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=1.7.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=1.7.4"
 
   alertmanager_slack_receivers               = var.alertmanager_slack_receivers
   iam_role_nodes                             = data.aws_iam_role.nodes.arn
@@ -75,6 +75,7 @@ module "prometheus" {
   oidc_components_client_id     = data.terraform_remote_state.cluster.outputs.oidc_components_client_id
   oidc_components_client_secret = data.terraform_remote_state.cluster.outputs.oidc_components_client_secret
   oidc_issuer_url               = data.terraform_remote_state.cluster.outputs.oidc_issuer_url
+  enable_large_nodesgroup       = terraform.workspace == local.live_workspace ? true : false
 }
 
 module "modsec_ingress_controllers" {

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/components.tf
@@ -75,8 +75,6 @@ module "prometheus" {
   oidc_components_client_id     = data.terraform_remote_state.cluster.outputs.oidc_components_client_id
   oidc_components_client_secret = data.terraform_remote_state.cluster.outputs.oidc_components_client_secret
   oidc_issuer_url               = data.terraform_remote_state.cluster.outputs.oidc_issuer_url
-
-  dependence_opa = "ignore"
 }
 
 module "modsec_ingress_controllers" {

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/kops/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/kops/main.tf
@@ -55,7 +55,8 @@ locals {
 
   # This is to maintain multiple URLs for monitoring stack, in light of the EKS migration
   auth0_extra_callbacks = {
-    live-1 = [for i in ["prometheus", "grafana", "alertmanager"] : "${i}.${local.cluster_base_domain_name}/oauth2/callback"]
+    live-1 = concat([for i in ["prometheus", "alertmanager"] : "https://${i}.${local.cluster_base_domain_name}/oauth2/callback"],
+    ["https://grafana.${local.cluster_base_domain_name}/login/generic_oauth"])
   }
 }
 


### PR DESCRIPTION
The monitoring module in live-1 fails when it is upgraded from module v1.6.6 to the latest version(v1.7.5)

Upgrade live-1 monitoring module to use v1.7.0, this is to do incremental apply to live-1.

This module contains changes:
https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/pull/93