### PR TITLE
latest-tag-opa-live-1

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/components.tf
@@ -103,7 +103,7 @@ module "ingress_controllers" {
 }
 
 module "opa" {
-  source     = "github.com/ministryofjustice/cloud-platform-terraform-opa?ref=0.0.11"
+  source     = "github.com/ministryofjustice/cloud-platform-terraform-opa?ref=0.0.13"
   depends_on = [module.prometheus, module.ingress_controllers, module.velero, module.kiam, module.cert_manager]
 
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name


### PR DESCRIPTION
Why:
[Release new version of OPA#3091](https://app.zenhub.com/workspaces/cloud-platform-team-5ccb0b8a81f66118c983c189/issues/ministryofjustice/cloud-platform/3091)
(ensure the latest tag is used in our live-1 infrastructure).
```
~/projects/cloud-platform-infrastructure/smoke-tests
```
<img width="544" alt="Screen Shot 2021-08-09 at 15 30 28" src="https://user-images.githubusercontent.com/6805936/128723371-aaffe2d2-8aaf-4983-ad53-39eacb3bf0c9.png">
