### PR TITLE
Upgrade monitoring to use the latest module

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/components.tf
@@ -58,7 +58,7 @@ module "logging" {
 }
 
 module "prometheus" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=1.7.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=1.7.5"
 
   alertmanager_slack_receivers               = var.alertmanager_slack_receivers
   iam_role_nodes                             = data.aws_iam_role.nodes.arn


### PR DESCRIPTION
Implement URLs for monitoring stack

    This is in light of the EKS migration
     -  Add external-dns annotation to grafana/kibana/prometheus/alertmanager
     - Configure cluster-specific and live_domain hosts in ingress, for Prometheus and Alertmanager
     - Create ingress to redirect_grafana while accessing live_domain, cannot set up as we did for Prometheus and alert manager as GF_SERVER_ROOT_URL supports only one URL.