### PR TITLE
[kops] Update cert-manager to latest

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/components.tf
@@ -1,5 +1,5 @@
 module "cert_manager" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-certmanager?ref=1.2.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-certmanager?ref=1.3.0"
 
   iam_role_nodes      = data.aws_iam_role.nodes.arn
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name


### PR DESCRIPTION
Using `kubectl` provider instead of `null_resources`