### PR TITLE
Fix test ingress controllers default smoke test

### DIFF
--- a/smoke-tests/spec/ingress_controller_spec.rb
+++ b/smoke-tests/spec/ingress_controller_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe "test ingress controllers", speed: "fast", cluster: "test-cluster-only" do
   context "default" do
-    host = "prometheus.apps.#{current_cluster}"
+    host = "prometheus.#{current_cluster}"
     let(:url) { "https://#{host}" }
 
     it "returns 302 for http get" do


### PR DESCRIPTION
By removing ".apps" for hostname

"Test ingress controllers default" smoke test, which is specific for test clusters is failing, this is because we updated the cloud-platform applications to remove ".apps" in the hostname.