### PR TITLE
Remove counts/condition in concourse's ServiceAccounts

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/k8s-resources.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/k8s-resources.tf
@@ -126,8 +126,6 @@ resource "kubernetes_cluster_role_binding" "webops" {
 }
 
 resource "kubernetes_service_account" "concourse_build_environments" {
-  count = lookup(local.prod_workspace, terraform.workspace, false) ? 1 : 0
-
   metadata {
     name      = "concourse-build-environments"
     namespace = "kube-system"
@@ -135,8 +133,6 @@ resource "kubernetes_service_account" "concourse_build_environments" {
 }
 
 resource "kubernetes_cluster_role_binding" "concourse_build_environments" {
-  count = lookup(local.prod_workspace, terraform.workspace, false) ? 1 : 0
-
   metadata {
     name = "concourse-build-environments"
   }

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/k8s-resources.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/k8s-resources.tf
@@ -102,8 +102,6 @@ resource "kubernetes_cluster_role_binding" "webops" {
 
 # ServiceAccount creation for concourse in order to access live-1
 resource "kubernetes_service_account" "concourse_build_environments" {
-  count = terraform.workspace == local.live_workspace ? 1 : 0
-
   metadata {
     name      = "concourse-build-environments"
     namespace = "kube-system"
@@ -111,8 +109,6 @@ resource "kubernetes_service_account" "concourse_build_environments" {
 }
 
 resource "kubernetes_cluster_role_binding" "concourse_build_environments" {
-  count = terraform.workspace == local.live_workspace ? 1 : 0
-
   metadata {
     name = "concourse-build-environments"
   }
@@ -125,7 +121,7 @@ resource "kubernetes_cluster_role_binding" "concourse_build_environments" {
 
   subject {
     kind      = "ServiceAccount"
-    name      = kubernetes_service_account.concourse_build_environments[0].metadata.0.name
+    name      = kubernetes_service_account.concourse_build_environments.metadata.0.name
     namespace = "kube-system"
   }
 }


### PR DESCRIPTION
We don't mind tests clusters get created with this _ServiceAccounts_ because they don't do any harm. 

Removing the `count` makes the code more readable and test clusters more similar to production ones.