### PR TITLE
Adding commit messages checker

### DIFF
--- a/.github/workflows/commit-message-checker-with-regex.yaml
+++ b/.github/workflows/commit-message-checker-with-regex.yaml
@@ -1,0 +1,41 @@
+name: 'Commit Message Check'
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+jobs:
+  check-commit-message:
+    name: Check Commit Message
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get PR Commits
+        id: 'get-pr-commits'
+        uses: tim-actions/get-pr-commits@master
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check Subject Line Length
+        uses: tim-actions/commit-message-checker-with-regex@v0.3.1
+        with:
+          commits: ${{ steps.get-pr-commits.outputs.commits }}
+          pattern: '^.{0,72}(\n.*)*$'
+          error: 'Subject too long (max 72)'
+          
+      - name: Check for Capitalize the subject line
+        uses: tim-actions/commit-message-checker-with-regex@v0.3.1
+        with:
+          commits: ${{ steps.get-pr-commits.outputs.commits }}
+          pattern: '^[A-Z]'
+          error: 'You should capitalize the first word of the subject line'
+
+      - name: Check Body Line Length
+        if: ${{ success() || failure() }}
+        uses: tim-actions/commit-message-checker-with-regex@v0.3.1
+        with:
+          commits: ${{ steps.get-pr-commits.outputs.commits }}
+          pattern: '^.+(\n.{0,72})*$'
+          error: 'Body line too long (max 72)'

--- a/.github/workflows/commit-message-checker-with-regex.yaml
+++ b/.github/workflows/commit-message-checker-with-regex.yaml
@@ -31,11 +31,3 @@ jobs:
           commits: ${{ steps.get-pr-commits.outputs.commits }}
           pattern: '^[A-Z]'
           error: 'You should capitalize the first word of the subject line'
-
-      - name: Check Body Line Length
-        if: ${{ success() || failure() }}
-        uses: tim-actions/commit-message-checker-with-regex@v0.3.1
-        with:
-          commits: ${{ steps.get-pr-commits.outputs.commits }}
-          pattern: '^.+(\n.{0,72})*$'
-          error: 'Body line too long (max 72)'


### PR DESCRIPTION
It is required to be stricter with commit messages, we're giving a try to enforce some of the policies using a GitHub action

This closes: https://github.com/ministryofjustice/cloud-platform/issues/3004
