### PR TITLE
Enable cluster log types and retention period

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
@@ -21,12 +21,14 @@ module "eks" {
   source  = "terraform-aws-modules/eks/aws"
   version = "v17.1.0"
 
-  cluster_name     = terraform.workspace
-  subnets          = concat(tolist(data.aws_subnet_ids.private.ids), tolist(data.aws_subnet_ids.public.ids))
-  vpc_id           = data.aws_vpc.selected.id
-  write_kubeconfig = false
-  cluster_version  = "1.19"
-  enable_irsa      = true
+  cluster_name                  = terraform.workspace
+  subnets                       = concat(tolist(data.aws_subnet_ids.private.ids), tolist(data.aws_subnet_ids.public.ids))
+  vpc_id                        = data.aws_vpc.selected.id
+  write_kubeconfig              = false
+  cluster_version               = "1.19"
+  enable_irsa                   = true
+  cluster_enabled_log_types     = var.cluster_enabled_log_types
+  cluster_log_retention_in_days = var.cluster_log_retention_in_days
 
   node_groups = {
     default_ng = {

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/variables.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/variables.tf
@@ -21,3 +21,15 @@ variable "check_associate" {
   default     = "true"
   description = "Check for active association during cluster creation. This is required for kuberos to authenticate to the cluster."
 }
+
+variable "cluster_enabled_log_types" {
+  default     = ["api", "audit", "authenticator", "controllerManager", "scheduler"]
+  description = "A list of the desired control plane logging to enable."
+  type        = list(string)
+}
+
+variable "cluster_log_retention_in_days" {
+  default     = 90
+  description = "Number of days to retain log events. Default retention - 90 days."
+  type        = number
+}


### PR DESCRIPTION
This commit connects to
https://github.com/ministryofjustice/cloud-platform/issues/2860 and
relates to the requrement to log all available control plane actions to
cloudwatch.

This commit takes advantage of the AWS EKS Terraform module's option to
enable cluster logging and sets the default values to all available
options.