### PR TITLE
Change default log retention for control plane logs

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/variables.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/variables.tf
@@ -29,7 +29,7 @@ variable "cluster_enabled_log_types" {
 }
 
 variable "cluster_log_retention_in_days" {
-  default     = 90
+  default     = 400 # Slightly over three months as per security advice https://security-guidance.service.justice.gov.uk/logging-and-monitoring/#log-retention
   description = "Number of days to retain log events. Default retention - 90 days."
   type        = number
 }


### PR DESCRIPTION
This commit connects to
https://github.com/ministryofjustice/cloud-platform/issues/2860 and
relates to the requirement to keep API log data for 13 months as per
security requirements.

The default value has to be either 365 or 400, nothing in between. I've
chosen 400 as it's only 5 days over 13 months.

src:
https://security-guidance.service.justice.gov.uk/logging-and-monitoring/#log-retention