### PR TITLE
Remove output for instance_types

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/outputs.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/outputs.tf
@@ -59,7 +59,3 @@ output "cluster_id" {
 output "cluster_endpoint" {
   value = module.eks.cluster_endpoint
 }
-
-output "instance_types" {
-  value = module.eks.node_groups.default_ng.instance_types
-}


### PR DESCRIPTION
This is not used any where, also causing the divergence pipeline to fail