### PR TITLE
Update monitoring nodegroup to use right taint key

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
@@ -93,7 +93,7 @@ locals {
     }
     taints = [
       {
-        key    = "monitoring-node"
+        key    = "cloud-platform.justice.gov.uk/monitoring-ng"
         value  = true
         effect = "NO_SCHEDULE"
       }


### PR DESCRIPTION
Update monitoring nodegroup to use right taint key