### PR TITLE
Remove cluster-autoscaler

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
@@ -18,6 +18,8 @@ provider "kubernetes" {
 }
 
 locals {
+  # desired_capcity change is a manual step after initial cluster creation (when no cluster-autoscaler)
+  # https://github.com/terraform-aws-modules/terraform-aws-eks/issues/835
   node_groups_count = {
     live    = "54"
     manager = "4"

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -52,14 +52,6 @@ module "cert_manager" {
   eks_cluster_oidc_issuer_url = data.terraform_remote_state.cluster.outputs.cluster_oidc_issuer_url
 }
 
-module "cluster_autoscaler" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-cluster-autoscaler?ref=0.1.0"
-
-  cluster_domain_name         = data.terraform_remote_state.cluster.outputs.cluster_domain_name
-  eks_cluster_id              = data.terraform_remote_state.cluster.outputs.cluster_id
-  eks_cluster_oidc_issuer_url = data.terraform_remote_state.cluster.outputs.cluster_oidc_issuer_url
-}
-
 module "external_dns" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-external-dns?ref=1.6.0"
 


### PR DESCRIPTION
WHAT
Remove cluster autoscaler from being used on EKS clusters

WHY
We have not tested full implementation of autoscaler and currently default setup takes too long for new node to come up. This will be looked into, once solved will bring back cluster-autoscaler