### PR TITLE
Update monitoring module to latest release 1.7.7 for EKS clusters.

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -113,7 +113,7 @@ module "logging" {
 }
 
 module "monitoring" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=1.7.6"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=1.7.7"
 
   alertmanager_slack_receivers               = var.alertmanager_slack_receivers
   iam_role_nodes                             = data.aws_iam_role.nodes.arn


### PR DESCRIPTION
This has increased memory limit for prometheus.