### PR TITLE
Update monitoring and kuberos module to latest in EKS

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -93,7 +93,7 @@ module "modsec_ingress_controllers" {
 }
 
 module "kuberos" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-kuberos?ref=0.3.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-kuberos?ref=0.3.3"
 
   cluster_domain_name           = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   oidc_kubernetes_client_id     = data.terraform_remote_state.cluster.outputs.oidc_kubernetes_client_id
@@ -113,7 +113,7 @@ module "logging" {
 }
 
 module "monitoring" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=1.7.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=1.7.8"
 
   alertmanager_slack_receivers               = var.alertmanager_slack_receivers
   iam_role_nodes                             = data.aws_iam_role.nodes.arn


### PR DESCRIPTION
This adds changes to module in PR:
https://github.com/ministryofjustice/cloud-platform-terraform-kuberos/pull/11 and 
https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/pull/106