### PR TITLE
Update external-dns to latest 

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -53,7 +53,7 @@ module "cert_manager" {
 }
 
 module "external_dns" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-external-dns?ref=1.6.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-external-dns?ref=1.6.1"
 
   iam_role_nodes      = data.aws_iam_role.nodes.arn
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name


### PR DESCRIPTION
In this release, it is fixed the Prometheus metrics release name