### PR TITLE
Increase wait_for_active_associate to try for 60

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/main.tf
@@ -145,7 +145,7 @@ resource "null_resource" "wait_for_active_associate" {
 variable "wait_for_active_associate_cmd" {
   description = "Custom local-exec command to execute for determining if the associate identity provider is active. Cluster name will be available as an environment variable called CLUSTER"
   type        = string
-  default     = "for i in `seq 1 50`; do if [[ `aws eks --region 'eu-west-2' describe-identity-provider-config --cluster-name $CLUSTER --identity-provider-config type='oidc',name='Auth0' --output json --query 'identityProviderConfig.oidc.status'` == '\"ACTIVE\"' ]]; then exit 0;else echo 'Checking again for active Auth0 association'; sleep 30;fi; done; echo 'TIMEOUT due to maximum retries to check for active Auth0 association'; exit 1"
+  default     = "for i in `seq 1 60`; do if [[ `aws eks --region 'eu-west-2' describe-identity-provider-config --cluster-name $CLUSTER --identity-provider-config type='oidc',name='Auth0' --output json --query 'identityProviderConfig.oidc.status'` == '\"ACTIVE\"' ]]; then exit 0;else echo 'Checking again for active Auth0 association'; sleep 30;fi; done; echo 'TIMEOUT due to maximum retries to check for active Auth0 association'; exit 1"
 }
 
 variable "wait_for_active_associate_interpreter" {


### PR DESCRIPTION
This is because Pipeline is timingout to build EKS test cluser