### PR TITLE
Increase wait_for_cluster_timeout to 15 min

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
@@ -116,6 +116,7 @@ module "eks" {
   enable_irsa                   = true
   cluster_enabled_log_types     = var.cluster_enabled_log_types
   cluster_log_retention_in_days = var.cluster_log_retention_in_days
+  wait_for_cluster_timeout      = "900"
 
   node_groups = {
     default_ng    = local.default_ng


### PR DESCRIPTION
A timeout (in seconds) to wait for the cluster to be available is set as 300s by default. Creating cluster is failing sometimes with error:
connect: connection timed out
in data "http" "wait_for_cluster":

As it is taking, longer than the default timeout set, increased the timeout to 15 min.