### PR TITLE
Increase ModSec replica count to 6

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -87,7 +87,7 @@ module "modsec_ingress_controllers" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-modsec-ingress-controller?ref=0.3.1"
 
   controller_name = "modsec01"
-  replica_count   = "4"
+  replica_count   = "6"
 
   depends_on = [module.ingress_controllers]
 }

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/components.tf
@@ -82,7 +82,7 @@ module "modsec_ingress_controllers" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-modsec-ingress-controller?ref=0.3.1"
 
   controller_name = "modsec01"
-  replica_count   = "4"
+  replica_count   = "6"
 
   depends_on = [module.ingress_controllers]
 }


### PR DESCRIPTION
WHAT
Increase replica count to 6

WHY
We are seeing an intermittent issue on the modsec ingress with pods crashing and not coming back without being killed by an admin. Increasing the replica count till a solution is found, 