### PR TITLE
Update external-dns to use the latest v1.7.1

### DIFF
--- a/smoke-tests/spec/external_dns_spec.rb
+++ b/smoke-tests/spec/external_dns_spec.rb
@@ -9,6 +9,7 @@ describe "external DNS", "live-1": true do
   let(:ingress_domain) { domain }
   let(:ingress_name) { domain }
   let(:fixture_name) { "spec/fixtures/external-dns-ingress.yaml.erb" }
+  let(:host) { "#{namespace}.#{domain}" }
 
   let(:set_identifier) { "#{ingress_name}-#{namespace}-#{external_dns_annotation_color}" }
 
@@ -25,7 +26,6 @@ describe "external DNS", "live-1": true do
 
   context "when zone matches ingress domain" do
     before do
-      cleanup_zone(domain, namespace, ingress_name)
       create_namespace(namespace)
     end
 

--- a/smoke-tests/spec/fixtures/external-dns-ingress.yaml.erb
+++ b/smoke-tests/spec/fixtures/external-dns-ingress.yaml.erb
@@ -9,7 +9,7 @@ metadata:
     external-dns.alpha.kubernetes.io/set-identifier: <%= set_identifier %>
 spec:
   rules:
-  - host: <%= domain %>
+  - host: <%= host %>
     http:
       paths:
       - path: /

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -53,7 +53,7 @@ module "cert_manager" {
 }
 
 module "external_dns" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-external-dns?ref=1.7.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-external-dns?ref=1.7.1"
 
   iam_role_nodes      = data.aws_iam_role.nodes.arn
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name


### PR DESCRIPTION
Update external-dns to use the latest v1.7.1
    
This version has a fix for the ErrorsInExternalDNS alert. This alert was looking at total errors, so the alert is not cleared even after the issue is fixed. Fix the alert to look for the last 2 hrs for more than 5 errors, as external-dns trigger alert every minute.
    
    
Update external-dns tests RSpec tests
    
 - Remove cleanup_zone, as external-dns sync will remove records when ingress is deleted
    
    This is to fix "level=error msg="InvalidChangeBatch: [Tried to delete resource record set
    [name='_external_dns.integrationtest.service.justice.gov.uk.', type='TXT', set-identifier='integrationtest.service.justice.gov.uk-integrationtest-dns-20211001113548-blue'] but it was not found,
    
- Use unique host name for external-dns test