### PR TITLE
Update kops external-dns to use latest v1.7.1

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/components.tf
@@ -10,7 +10,7 @@ module "cert_manager" {
 }
 
 module "external_dns" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-external-dns?ref=1.7.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-external-dns?ref=1.7.1"
 
   iam_role_nodes      = data.aws_iam_role.nodes.arn
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name


### PR DESCRIPTION
This version have fix for ErrorsInExternalDNS alert