### PR TITLE
Add test check for all services expected in the cluster

### DIFF
--- a/tests/e2e/services_test.go
+++ b/tests/e2e/services_test.go
@@ -1,0 +1,37 @@
+package integration_tests
+
+import (
+	"fmt"
+
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	. "github.com/onsi/ginkgo"
+)
+
+// Services defined in plain text in the cluster manifest.
+var _ = Describe("Expected services in the cluster", func() {
+	var (
+		servicesNotRunning []string
+	)
+
+	It("exist", func() {
+		services := c.GetExpectedServices()
+
+		if len(services) == 0 {
+			Skip("No services defined, skipping test")
+		}
+
+		for namespace, svc := range services {
+			options := k8s.NewKubectlOptions("", "", namespace)
+			for _, v := range svc {
+				_, err := k8s.GetServiceE(GinkgoT(), options, v)
+				if err != nil {
+					servicesNotRunning = append(servicesNotRunning, v)
+				}
+			}
+		}
+
+		if servicesNotRunning != nil {
+			Fail(fmt.Sprintf("The following services DO NOT exist: %v", servicesNotRunning))
+		}
+	})
+})

--- a/tests/pkg/config/config.go
+++ b/tests/pkg/config/config.go
@@ -10,12 +10,12 @@ import (
 
 // Config holds the basic structure of test's YAML file
 type Config struct {
-	ClusterName            	string                 	`yaml:"clusterName"`
-	Namespaces             	map[string]K8SObjects  	`yaml:"namespaces"`
-	ExternalDNS            	ExternalDNS            	`yaml:"externalDNS"`
-	NginxIngressController 	NginxIngressController 	`yaml:"nginxIngressController"`
-	ModsecIngressController ModsecIngressController	`yaml:"modsecIngressController"`
-	FilesExist              []string               	`yaml:"filesExist"`
+	ClusterName             string                  `yaml:"clusterName"`
+	Namespaces              map[string]K8SObjects   `yaml:"namespaces"`
+	ExternalDNS             ExternalDNS             `yaml:"externalDNS"`
+	NginxIngressController  NginxIngressController  `yaml:"nginxIngressController"`
+	ModsecIngressController ModsecIngressController `yaml:"modsecIngressController"`
+	FilesExist              []string                `yaml:"filesExist"`
 }
 
 // K8SObjects are kubernetes objects nested from namespaces, we need to check
@@ -99,6 +99,24 @@ func (c *Config) GetExpectedServiceMonitors() map[string][]string {
 			r[ns] = serviceMonitors
 		}
 
+	}
+
+	return r
+}
+
+// GetExpectedServices returns a slice of all the services
+// that are expected to be in the cluster.
+func (c *Config) GetExpectedServices() map[string][]string {
+	r := make(map[string][]string)
+
+	for ns, val := range c.Namespaces {
+		var services []string
+
+		services = append(services, val.Services...)
+
+		if len(services) > 0 {
+			r[ns] = services
+		}
 	}
 
 	return r


### PR DESCRIPTION
Services are defined in the `/tests/config/<cluster>.yaml` file in the
infra repository. This check takes all services and confirms they
currently exist in the cluster your kubeconfig is pointing at.