### PR TITLE
Add alarm_cluster_status_is_yellow input to live es

### DIFF
--- a/terraform/global-resources/elasticsearch.tf
+++ b/terraform/global-resources/elasticsearch.tf
@@ -259,6 +259,8 @@ module "live_elasticsearch_monitoring" {
   domain_name       = local.live_domain
   create_sns_topic  = false
   sns_topic         = data.terraform_remote_state.account.outputs.slack_sns_topic
+
+  alarm_cluster_status_is_yellow_periods = 10
 }
 
 module "audit_elasticsearch_monitoring" {


### PR DESCRIPTION
This alarm triggers almost every evening during maintenance windows. The nodes aren't unhealthy and there is nothing for an engineer to do. By adding this delay we can ignore this when we don't need to know.

The default value for this input is 1. So, we're waiting for a 10 min yellow cluster status rather than a 1.

Here are the inputs specified:
https://registry.terraform.io/modules/dubiety/elasticsearch-cloudwatch-sns-alarms/aws/latest#inputs