### PR TITLE
Add cert-manager integration test and go mod tidy

### DIFF
--- a/tests/config/live.yaml
+++ b/tests/config/live.yaml
@@ -2,6 +2,9 @@
 clusterName: 'live.cloud-platform.service.justice.gov.uk'
 namespaces:
   cert-manager:
+    services:
+      - "cert-manager"
+      - "cert-manager-webhook"
     servicemonitors:
       - cert-manager
   ingress-controllers:

--- a/tests/e2e/certmanager_test.go
+++ b/tests/e2e/certmanager_test.go
@@ -105,24 +105,3 @@ func waitForCertificateToBeReady(namespace string, options *k8s.KubectlOptions, 
 	}
 	return fmt.Errorf("Certificate %s is not ready", namespace)
 }
-
-// func WaitUntilIngressAvailableV1Beta1(t testing.TestingT, options *k8s.KubectlOptions, ingressName string, retries int, sleepBetweenRetries time.Duration) {
-// 	statusMsg := fmt.Sprintf("Wait for ingress %s to be provisioned.", ingressName)
-// 	message := retry.DoWithRetry(
-// 		t,
-// 		statusMsg,
-// 		retries,
-// 		sleepBetweenRetries,
-// 		func() (string, error) {
-// 			ingress, err := GetIngressV1Beta1E(t, options, ingressName)
-// 			if err != nil {
-// 				return "", err
-// 			}
-// 			if !IsIngressAvailableV1Beta1(ingress) {
-// 				return "", IngressNotAvailableV1Beta1{ingress: ingress}
-// 			}
-// 			return "Ingress is now available", nil
-// 		},
-// 	)
-// 	logger.Logf(t, message)
-// }

--- a/tests/e2e/certmanager_test.go
+++ b/tests/e2e/certmanager_test.go
@@ -15,77 +15,91 @@ import (
 )
 
 var _ = Describe("cert-manager", func() {
-	var (
-		namespace = fmt.Sprintf("cert-test-%v", strings.ToLower(random.UniqueId()))
-		options   = k8s.NewKubectlOptions("", "", namespace)
-		domain    = "integrationtest.service.justice.gov.uk"
-		host      = fmt.Sprintf("%s.%s", namespace, domain)
+	const (
+		domain = "integrationtest.service.justice.gov.uk" // All clusters have access to the test domain name
 	)
 
-	BeforeEach(func() {
-		k8s.CreateNamespace(GinkgoT(), options, namespace)
+	Context("when the namespace has a certificate resource", func() {
+		var (
+			namespace = fmt.Sprintf("cert-smoketest-%v", strings.ToLower(random.UniqueId()))
+			options   = k8s.NewKubectlOptions("", "", namespace)
+			host      = fmt.Sprintf("%s.%s", namespace, domain)
 
-		// Create the application and ingress rule
-		app := helpers.HelloworldOpt{
-			Hostname:   host,
-			Class:      "nginx",
-			Identifier: namespace + "-integration-test-" + "green",
-			Namespace:  namespace,
-			Weight:     "\"100\"",
-		}
+			err  error
+			cert []string
+			// resp *http.Response
+			conn *tls.Conn
+		)
 
-		err := helpers.CreateHelloWorldApp(&app, options)
-		Expect(err).NotTo(HaveOccurred())
+		BeforeEach(func() {
+			k8s.CreateNamespace(GinkgoT(), options, namespace)
+			app := helpers.HelloworldOpt{
+				Hostname:   host,
+				Class:      "nginx",
+				Identifier: "integration-test-app-ing-" + namespace + "-green",
+				Namespace:  namespace,
+				Weight:     "\"100\"",
+			}
 
-		// Create the certificate resource
-		tpl, err := helpers.TemplateFile("./fixtures/certificate.yaml.tmpl", "certificate.yaml.tmpl", template.FuncMap{
-			"certname":    namespace,
-			"namespace":   namespace,
-			"hostname":    host,
-			"environment": "staging",
-		})
-		Expect(err).NotTo(HaveOccurred())
-
-		err = k8s.KubectlApplyFromStringE(GinkgoT(), options, tpl)
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	AfterEach(func() {
-		defer k8s.DeleteNamespace(GinkgoT(), options, namespace)
-	})
-
-	Context("when a certificate resource is created", func() {
-		FIt("should return the correct certificate name", func() {
-			// time.Sleep(160 * time.Second) // Wait for the certificate to be ready
-			waitForCertificate(options, namespace, 120)
-
-			conn, err := tls.Dial("tcp", host+":443", &tls.Config{InsecureSkipVerify: true})
+			err = helpers.CreateHelloWorldApp(&app, options)
 			Expect(err).NotTo(HaveOccurred())
 
-			defer conn.Close()
-
-			cert := conn.ConnectionState().PeerCertificates[0].Issuer.Organization
-
-			Expect(cert[0]).To(Equal("(STAGING) Let's Encrypt"))
+			err = createCertificate(namespace, host, options)
+			Expect(err).NotTo(HaveOccurred())
 		})
 
-		// gomega validation
+		AfterEach(func() {
+			k8s.DeleteNamespace(GinkgoT(), options, namespace)
+		})
+
+		FIt("should succeed and present a staging certificate", func() {
+			conn, err = tls.Dial("tcp", host+":443", &tls.Config{InsecureSkipVerify: true})
+			Expect(err).NotTo(HaveOccurred())
+			cert = conn.ConnectionState().PeerCertificates[0].Issuer.Organization
+			// resp, _ = http.Get("https://" + host)
+
+			// defer resp.Body.Close()
+			// defer conn.Close()
+
+			Expect(cert[0]).To(Equal("(STAGING) Let's Encrypt"))
+			// Expect(resp.StatusCode).To(Equal(200))
+		})
 	})
 })
 
-func waitForCertificate(options *k8s.KubectlOptions, namespace string, seconds int) string {
-	var status string
-	for i := 0; i < 12; i++ {
-		status, err := k8s.RunKubectlAndGetOutputE(GinkgoT(), options, "get", "certificate", namespace, "-o", "jsonpath='{.items[*].status.conditions[?(@.type==\"Ready\")].status}'")
-		Expect(err).NotTo(HaveOccurred())
-
-		fmt.Println(status)
-		if status == "True" {
-			break
-		}
-		time.Sleep(10 * time.Second)
-		fmt.Println("Waiting for certificate to be ready")
+func createCertificate(namespace, host string, options *k8s.KubectlOptions) error {
+	tpl, err := helpers.TemplateFile("./fixtures/certificate.yaml.tmpl", "certificate.yaml.tmpl", template.FuncMap{
+		"certname":    namespace,
+		"namespace":   namespace,
+		"hostname":    host,
+		"environment": "staging",
+	})
+	if err != nil {
+		return err
 	}
 
-	return status
+	err = k8s.KubectlApplyFromStringE(GinkgoT(), options, tpl)
+	if err != nil {
+		return err
+	}
+
+	// err = waitForCertificateToBeReady(namespace, options)
+	// if err != nil {
+	// 	return err
+	// }
+	time.Sleep(160 * time.Second) // Wait for the certificate to be ready
+
+	return nil
+}
+
+func waitForCertificateToBeReady(namespace string, options *k8s.KubectlOptions) error {
+	// Wait 160 seconds for the certificate to be ready
+	for i := 0; i < 160; i++ {
+		err := k8s.RunKubectlE(GinkgoT(), options, "get", "certificate", namespace, "-o", "jsonpath={.status.conditions[?(@.type=='Ready')].status}")
+		if err == nil {
+			return nil
+		}
+		time.Sleep(1 * time.Second)
+	}
+	return nil
 }

--- a/tests/e2e/certmanager_test.go
+++ b/tests/e2e/certmanager_test.go
@@ -1,0 +1,36 @@
+package integration_tests
+
+import (
+	"fmt"
+	"math/rand"
+
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("cert-manager", func() {
+	var (
+		namespace    = fmt.Sprintf("cert-manager-test-%v", rand.Int())
+		ingressClass = "nginx"
+		ingressName  = "integration-test"
+		options      = k8s.NewKubectlOptions("", "", namespace)
+	)
+
+	BeforeEach(func() {
+		// create namespace
+		k8s.CreateNamespace(GinkgoT(), options, namespace)
+		// create ingress resource
+		// create certificate
+	})
+
+	AfterEach(func() {
+		// destroy ingress resource
+		// destroy namespace
+	})
+
+	Context("when a certificate resource is created", func() {
+		// validate_certificate
+		// gomega validation
+	})
+})

--- a/tests/e2e/certmanager_test.go
+++ b/tests/e2e/certmanager_test.go
@@ -18,7 +18,7 @@ var _ = Describe("cert-manager", func() {
 	var (
 		namespace = fmt.Sprintf("cert-test-%v", strings.ToLower(random.UniqueId()))
 		options   = k8s.NewKubectlOptions("", "", namespace)
-		domain    = "raz-test.cloud-platform.service.justice.gov.uk"
+		domain    = "integrationtest.service.justice.gov.uk"
 		host      = fmt.Sprintf("%s.%s", namespace, domain)
 	)
 
@@ -53,9 +53,13 @@ var _ = Describe("cert-manager", func() {
 		// defer k8s.DeleteNamespace(GinkgoT(), options, namespace)
 	})
 
+	Context("to verifiy the installation", func() {
+		//https://cert-manager.io/next-docs/installation/verify/
+	})
+
 	Context("when a certificate resource is created", func() {
 		FIt("should allow a TLS handshake \n", func() {
-			c, err := tls.Dial("tcp", host+":443", nil)
+			_, err := tls.Dial("tcp", host+":443", nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			time.Sleep(120 * time.Second)

--- a/tests/e2e/certmanager_test.go
+++ b/tests/e2e/certmanager_test.go
@@ -2,29 +2,45 @@ package integration_tests
 
 import (
 	"fmt"
+	"html/template"
 	"math/rand"
 
 	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/ministryofjustice/cloud-platform-infrastructure/tests/pkg/helpers"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("cert-manager", func() {
 	var (
-		namespace    = fmt.Sprintf("cert-manager-test-%v", rand.Int())
-		ingressClass = "nginx"
-		ingressName  = "integration-test"
-		options      = k8s.NewKubectlOptions("", "", namespace)
+		namespace = fmt.Sprintf("cert-manager-test-%v", rand.Int())
+		options   = k8s.NewKubectlOptions("", "", namespace)
+		host      = fmt.Sprintf("https://%s.%v", namespace, c.ClusterName)
 	)
 
 	BeforeEach(func() {
-		// create namespace
 		k8s.CreateNamespace(GinkgoT(), options, namespace)
-		// create ingress resource
-		// create certificate
+
+		app := helpers.HelloworldOpt{
+			Hostname: host,
+		}
+
+		err := helpers.CreateHelloWorldApp(&app, options)
+		Expect(err).NotTo(HaveOccurred())
+
+		tpl, err := helpers.TemplateFile("./fixtures/certificate.yaml.tmpl", "cert.yaml.tmpl", template.FuncMap{
+			"cert-name":   namespace,
+			"namespace":   namespace,
+			"hostname":    host,
+			"environment": "staging",
+		})
+
+		err = k8s.KubectlApplyFromStringE(GinkgoT(), options, tpl)
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	AfterEach(func() {
+		defer k8s.DeleteNamespace(GinkgoT(), options, namespace)
 		// destroy ingress resource
 		// destroy namespace
 	})

--- a/tests/e2e/fixtures/certificate.yaml.tmpl
+++ b/tests/e2e/fixtures/certificate.yaml.tmpl
@@ -1,0 +1,13 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ .cert-name }}
+  namespace: {{ .namespace }}
+spec:
+  commonName: {{ .hostname }}
+  dnsNames:
+  - {{ .hostname }}
+  secretName: {{ .cert-name }}-secret
+  issuerRef:
+    kind: Clusterissuer
+    name: letsencrypt-{{ .environment }}

--- a/tests/e2e/fixtures/certificate.yaml.tmpl
+++ b/tests/e2e/fixtures/certificate.yaml.tmpl
@@ -7,7 +7,7 @@ spec:
   commonName: {{ .hostname }}
   dnsNames:
   - {{ .hostname }}
-  secretName: {{ .certname }}-secret
+  secretName: {{ .namespace }}-secret
   issuerRef:
     kind: ClusterIssuer
     name: letsencrypt-{{ .environment }}

--- a/tests/e2e/fixtures/certificate.yaml.tmpl
+++ b/tests/e2e/fixtures/certificate.yaml.tmpl
@@ -1,13 +1,13 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ .cert-name }}
+  name: {{ .certname }}
   namespace: {{ .namespace }}
 spec:
   commonName: {{ .hostname }}
   dnsNames:
   - {{ .hostname }}
-  secretName: {{ .cert-name }}-secret
+  secretName: {{ .certname }}-secret
   issuerRef:
-    kind: Clusterissuer
+    kind: ClusterIssuer
     name: letsencrypt-{{ .environment }}

--- a/tests/e2e/fixtures/helloworld-deployment.yaml.tmpl
+++ b/tests/e2e/fixtures/helloworld-deployment.yaml.tmpl
@@ -44,7 +44,7 @@ spec:
   tls:
   - hosts:
     - {{ .host }}
-    secretName: hello-world-ssl
+    secretName: {{ .namespace }}-secret
   rules:
   - host: {{ .host }}
     http:

--- a/tests/e2e/tests_suite_test.go
+++ b/tests/e2e/tests_suite_test.go
@@ -13,6 +13,9 @@ import (
 	"github.com/ministryofjustice/cloud-platform-infrastructure/tests/pkg/config"
 )
 
+// All clusters have access to the test domain name
+const testDomain = "integrationtest.service.justice.gov.uk"
+
 // c is global, so all tests has access to it
 var c *config.Config
 

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -4,7 +4,6 @@ go 1.15
 
 require (
 	github.com/aws/aws-sdk-go v1.27.1
-	github.com/davecgh/go-spew v1.1.1
 	github.com/go-resty/resty/v2 v2.6.0
 	github.com/gruntwork-io/terratest v0.34.4
 	github.com/onsi/ginkgo v1.15.0
@@ -15,8 +14,6 @@ require (
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.4.0
 	gopkg.in/yaml.v2 v2.3.0
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
-	k8s.io/api v0.19.3 // indirect
 	k8s.io/apimachinery v0.19.3
 	k8s.io/client-go v0.19.3
 )

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -123,7 +123,9 @@ github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:Htrtb
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
+github.com/elazarl/goproxy v0.0.0-20190911111923-ecfe977594f1 h1:yY9rWGoXv1U5pl4gxqlULARMQD7x0QG85lqEXTWysik=
 github.com/elazarl/goproxy v0.0.0-20190911111923-ecfe977594f1/go.mod h1:Ro8st/ElPeALwNFlcTpWmkr6IoMFfkjXAvTHpevnDsM=
+github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2 h1:dWB6v3RcOy03t/bUadywsbyrQwCqZeNIEX6M1OtSZOM=
 github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2/go.mod h1:gNh8nYJoAm43RfaxurUnxr+N1PwuFV3ZMl/efxlIlY8=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
@@ -229,6 +231,7 @@ github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-containerregistry v0.0.0-20200110202235-f4fb41bf00a3/go.mod h1:2wIuQute9+hhWqvL3vEI7YB0EKluF4WcPzI1eAliazk=
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
@@ -296,12 +299,15 @@ github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvW
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/konsorten/go-windows-terminal-sequences v1.0.2 h1:DB17ag19krx9CFsz4o3enTrPXyIXCl+2iCXH/aMAp9s=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
@@ -618,6 +624,7 @@ golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gonum.org/v1/gonum v0.0.0-20190331200053-3d26580ed485/go.mod h1:2ltnJ7xHfj0zHS40VVPYEAAMTa3ZGguvHGBSJeRWqE0=
 gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0/go.mod h1:wa6Ws7BG/ESfp6dHfk7C6KdzKA7wR7u/rKwOGE66zvw=
@@ -665,6 +672,7 @@ google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGj
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
@@ -685,7 +693,6 @@ gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/tests/makefile
+++ b/tests/makefile
@@ -1,4 +1,4 @@
-VERSION=0.8
+VERSION=0.9
 PREFIX=ministryofjustice/cloud-platform-tests
 TAG=$(VERSION)
 

--- a/tests/pkg/helpers/certificates.go
+++ b/tests/pkg/helpers/certificates.go
@@ -1,0 +1,61 @@
+package helpers
+
+import (
+	"fmt"
+	"text/template"
+	"time"
+
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	. "github.com/onsi/ginkgo"
+	"github.com/pkg/errors"
+)
+
+// CreateCertificate creates a certificate resource in the specified namespace.
+func CreateCertificate(namespace, host string, options *k8s.KubectlOptions) error {
+	tpl, err := TemplateFile("./fixtures/certificate.yaml.tmpl", "certificate.yaml.tmpl", template.FuncMap{
+		"certname":    namespace,
+		"namespace":   namespace,
+		"hostname":    host,
+		"environment": "staging",
+	})
+	if err != nil {
+		return err
+	}
+
+	err = k8s.KubectlApplyFromStringE(GinkgoT(), options, tpl)
+	if err != nil {
+		return err
+	}
+
+	// Wait for the certificate 20 times, with a 10 second sleep between each check
+	err = WaitForCertificateToBeReady(namespace, options, 20, 10)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// WaitForCertificateToBeReady takes a certificate name and KubectlOptions arguments along with an along
+// with an appropriate number of retries. It will wait until the certificate returns a status of Ready.
+// The time between retries is specified by the retryInterval argument.
+// If the certificate does not return a status of Ready after the specified number of retries, an error is returned.
+func WaitForCertificateToBeReady(certName string, options *k8s.KubectlOptions, retries, retryInterval int) error {
+	fmt.Printf("Waiting for certificate %s to be ready %v times\n", certName, retries)
+
+	for i := 0; i < retries; i++ {
+		fmt.Println("Checking certificate status: attempt: " + fmt.Sprintf("%v", i+1))
+		status, err := k8s.RunKubectlAndGetOutputE(GinkgoT(), options, "get", "certificate", certName, "-o", "jsonpath='{.status.conditions[?(@.type==\"Ready\")].status}'")
+		if err != nil {
+			return errors.New("Certificate creation failed")
+		}
+		fmt.Println("status:", status)
+		if status == "'True'" {
+			return nil
+		}
+
+		fmt.Printf("Failed to validate certificate %s, sleeping for 10 seconds\n", certName)
+		time.Sleep(time.Duration(retryInterval) * time.Second)
+	}
+	return fmt.Errorf("certificate %s is not ready", certName)
+}

--- a/tests/pkg/helpers/certificates.go
+++ b/tests/pkg/helpers/certificates.go
@@ -49,12 +49,11 @@ func WaitForCertificateToBeReady(certName string, options *k8s.KubectlOptions, r
 		if err != nil {
 			return errors.New("Certificate creation failed")
 		}
-		fmt.Println("status:", status)
 		if status == "'True'" {
 			return nil
 		}
 
-		fmt.Printf("Failed to validate certificate %s, sleeping for 10 seconds\n", certName)
+		fmt.Printf("Failed to validate certificate %s, sleeping for %v seconds\n", certName, retryInterval)
 		time.Sleep(time.Duration(retryInterval) * time.Second)
 	}
 	return fmt.Errorf("certificate %s is not ready", certName)

--- a/tests/pkg/helpers/main.go
+++ b/tests/pkg/helpers/main.go
@@ -17,10 +17,9 @@ import (
 type HelloworldOpt struct {
 	Class      string `default:"nginx"`
 	Identifier string `default:"integration-test-green"`
-	// EnableModSec  string `default:"\"false\""`
-	Weight string `default:"\"100\""`
-	// ModSecSnippet string
-	Hostname string `example:"hostname.cloud-platform...."`
+	Weight     string `default:"\"100\""`
+	Hostname   string `example:"hostname.cloud-platform...."`
+	Namespace  string `default:"default"`
 }
 
 // CreateHelloWorldApp takes a HelloworldOpt type and KubectlOptions arguments
@@ -35,10 +34,9 @@ func CreateHelloWorldApp(app *HelloworldOpt, opt *k8s.KubectlOptions) error {
 			"kubernetes.io/ingress.class":                     app.Class,
 			"external-dns.alpha.kubernetes.io/aws-weight":     app.Weight,
 			"external-dns.alpha.kubernetes.io/set-identifier": app.Identifier,
-			// "nginx.ingress.kubernetes.io/enable-modsecurity":  app.EnableModSec,
-			// "nginx.ingress.kubernetes.io/modsecurity-snippet": "|\n     SecRuleEngine On",
 		},
-		"host": app.Hostname,
+		"host":      app.Hostname,
+		"namespace": app.Namespace,
 	}
 
 	tpl, err := TemplateFile("./fixtures/helloworld-deployment.yaml.tmpl", "helloworld-deployment.yaml.tmpl", templateVars)

--- a/tests/pkg/helpers/main.go
+++ b/tests/pkg/helpers/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"text/template"
+	"time"
 
 	"github.com/go-resty/resty/v2"
 	"github.com/gruntwork-io/terratest/modules/k8s"
@@ -14,12 +15,12 @@ import (
 // HellowoldOpt type allows you to specify options for
 // deploying a helloworld app template in a cluster.
 type HelloworldOpt struct {
-	Class         string `default:"nginx"`
-	Identifier    string `default:"green-blue"`
-	EnableModSec  string `default:"false"`
-	Weight        string `default:"100"`
-	ModSecSnippet string
-	Hostname      string `example:"hostname.cloud-platform...."`
+	Class      string `default:"nginx"`
+	Identifier string `default:"integration-test-green"`
+	// EnableModSec  string `default:"\"false\""`
+	Weight string `default:"\"100\""`
+	// ModSecSnippet string
+	Hostname string `example:"hostname.cloud-platform...."`
 }
 
 // CreateHelloWorldApp takes a HelloworldOpt type and KubectlOptions arguments
@@ -34,13 +35,13 @@ func CreateHelloWorldApp(app *HelloworldOpt, opt *k8s.KubectlOptions) error {
 			"kubernetes.io/ingress.class":                     app.Class,
 			"external-dns.alpha.kubernetes.io/aws-weight":     app.Weight,
 			"external-dns.alpha.kubernetes.io/set-identifier": app.Identifier,
-			"nginx.ingress.kubernetes.io/enable-modsecurity":  app.EnableModSec,
-			"nginx.ingress.kubernetes.io/modsecurity-snippet": "|\n     SecRuleEngine On",
+			// "nginx.ingress.kubernetes.io/enable-modsecurity":  app.EnableModSec,
+			// "nginx.ingress.kubernetes.io/modsecurity-snippet": "|\n     SecRuleEngine On",
 		},
 		"host": app.Hostname,
 	}
 
-	tpl, err := TemplateFile("./fixtures/helloworld-deployment.yaml.tmpl", "outputTemplateDeployment.yaml.tmpl", templateVars)
+	tpl, err := TemplateFile("./fixtures/helloworld-deployment.yaml.tmpl", "helloworld-deployment.yaml.tmpl", templateVars)
 	if err != nil {
 		return fmt.Errorf("failed to create the helloworld template: %s", err)
 	}
@@ -49,6 +50,8 @@ func CreateHelloWorldApp(app *HelloworldOpt, opt *k8s.KubectlOptions) error {
 	if err != nil {
 		return fmt.Errorf("failed to apply the helloworld template: %s", err)
 	}
+
+	k8s.WaitUntilIngressAvailableV1Beta1(GinkgoT(), opt, "integration-test-app-ing", 60, 5*time.Second)
 
 	return nil
 }

--- a/tests/pkg/helpers/main.go
+++ b/tests/pkg/helpers/main.go
@@ -7,7 +7,51 @@ import (
 	"text/template"
 
 	"github.com/go-resty/resty/v2"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	. "github.com/onsi/ginkgo"
 )
+
+// HellowoldOpt type allows you to specify options for
+// deploying a helloworld app template in a cluster.
+type HelloworldOpt struct {
+	Class         string `default:"nginx"`
+	Identifier    string `default:"green-blue"`
+	EnableModSec  string `default:"false"`
+	Weight        string `default:"100"`
+	ModSecSnippet string
+	Hostname      string `example:"hostname.cloud-platform...."`
+}
+
+// CreateHelloWorldApp takes a HelloworldOpt type and KubectlOptions arguments
+// to create a HelloWorld app in the environment of your choice.
+func CreateHelloWorldApp(app *HelloworldOpt, opt *k8s.KubectlOptions) error {
+	if app.Hostname == "" {
+		return fmt.Errorf("helloworld app hostname must not be empty")
+	}
+
+	templateVars := map[string]interface{}{
+		"ingress_annotations": map[string]string{
+			"kubernetes.io/ingress.class":                     app.Class,
+			"external-dns.alpha.kubernetes.io/aws-weight":     app.Weight,
+			"external-dns.alpha.kubernetes.io/set-identifier": app.Identifier,
+			"nginx.ingress.kubernetes.io/enable-modsecurity":  app.EnableModSec,
+			"nginx.ingress.kubernetes.io/modsecurity-snippet": "|\n     SecRuleEngine On",
+		},
+		"host": app.Hostname,
+	}
+
+	tpl, err := TemplateFile("./fixtures/helloworld-deployment.yaml.tmpl", "outputTemplateDeployment.yaml.tmpl", templateVars)
+	if err != nil {
+		return fmt.Errorf("failed to create the helloworld template: %s", err)
+	}
+
+	err = k8s.KubectlApplyFromStringE(GinkgoT(), opt, tpl)
+	if err != nil {
+		return fmt.Errorf("failed to apply the helloworld template: %s", err)
+	}
+
+	return nil
+}
 
 // HttpStatusCode return the HTTP code for an endpoint
 func HttpStatusCode(u string) (int, error) {


### PR DESCRIPTION
Overview
---

This PR relates to the requirement of a cert-manager integration test for live clusters. It includes a full GinkGo BDD test for the existence of a certificate created by the Staging Let's Encrypt provider. To make this test lightweight and the code re-usable, I created two new "helper" functions in the `helpers` package. This allows callers to create and test for a positive status of 'Ready'. 

Other things to note
---

To make creating a Helloworld application easier, I created new struct optionality and functionality to do this in a few lines of code.

How to test
---

```
git checkout cert-manager-tests
cd tests/e2e
go test -v -config ../config/live.yaml ./...
```

To test just this function: checkout the branch and add an "F" to the beginning of the `It` Ginkgo call.