### PR TITLE
Upgrade OPA to use the latest image

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -135,7 +135,7 @@ module "monitoring" {
 }
 
 module "opa" {
-  source     = "github.com/ministryofjustice/cloud-platform-terraform-opa?ref=0.1.0"
+  source     = "github.com/ministryofjustice/cloud-platform-terraform-opa?ref=0.2.0"
   depends_on = [module.monitoring, module.ingress_controllers, module.velero, module.cert_manager]
 
   cluster_domain_name            = data.terraform_remote_state.cluster.outputs.cluster_domain_name


### PR DESCRIPTION
imageTag: 0.33.1 for OPA
imageTag: "0.13" for kube-mgmt