### PR TITLE
Upgrade OPA to use the latest version

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/components.tf
@@ -102,7 +102,7 @@ module "ingress_controllers" {
 }
 
 module "opa" {
-  source     = "github.com/ministryofjustice/cloud-platform-terraform-opa?ref=0.1.0"
+  source     = "github.com/ministryofjustice/cloud-platform-terraform-opa?ref=0.2.1"
   depends_on = [module.prometheus, module.ingress_controllers, module.velero, module.kiam, module.cert_manager]
 
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name


### PR DESCRIPTION
This version have
- imageTag: 0.33.1 for OPA
- imageTag: "0.13" for kube-mgmt
- New policy to deny forbidden snippets.