### PR TITLE
Add starter-pack namespaces to system namespaces

### DIFF
--- a/destroy-cluster.rb
+++ b/destroy-cluster.rb
@@ -30,7 +30,7 @@ EKS_SYSTEM_NAMESPACES = %w[
   monitoring
   opa
   velero
-]
+] + (0..9).map { |i| "starter-pack-#{i}" }
 
 MAX_CLUSTER_NAME_LENGTH = 12
 REQUIRED_ENV_VARS = %w[AWS_PROFILE AUTH0_DOMAIN AUTH0_CLIENT_ID AUTH0_CLIENT_SECRET KOPS_STATE_STORE]


### PR DESCRIPTION
This was caught by our failing destroy cluster pipeline that picked starter-pack-0 up as a user namespace.