### PR TITLE
Increase concourse resource limit to 8gi

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -1,7 +1,7 @@
 
 module "concourse" {
   count  = terraform.workspace == "manager" ? 1 : 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-concourse?ref=1.7.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-concourse?ref=1.7.8"
 
   concourse_hostname                                = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   github_auth_client_id                             = var.github_auth_client_id


### PR DESCRIPTION
This is to fix "ProcessNotFoundError",
The suggestion below to tune resource values:
https://github.com/concourse/concourse/wiki/Error-Messages-And-What-To-Do-About-Them#processnotfounderror