### PR TITLE
Revert Kubernetes provider upgrade

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/versions.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.6.1"
+      version = "~> 1.11.1"
     }
     null = {
       source = "hashicorp/null"

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/versions.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/versions.tf
@@ -9,7 +9,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.6.1"
+      version = "~> 1.11"
     }
     null = {
       source = "hashicorp/null"


### PR DESCRIPTION
We are facing this [issue](https://github.com/terraform-aws-modules/terraform-aws-eks/issues/1280), revert the upgrade until we got a fix for it.