### PR TITLE
Upgrade K8s to 1.20

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
@@ -27,7 +27,7 @@ locals {
   }
   # To manage different cluster versions
   cluster_version = {
-    live    = "1.19"
+    live    = "1.20"
     manager = "1.20"
     default = "1.20"
   }
@@ -109,7 +109,7 @@ locals {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "v17.24.0"
+  version = "v17.23.0"
 
   cluster_name                  = terraform.workspace
   subnets                       = concat(tolist(data.aws_subnet_ids.private.ids), tolist(data.aws_subnet_ids.public.ids))

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
@@ -28,8 +28,8 @@ locals {
   # To manage different cluster versions
   cluster_version = {
     live    = "1.19"
-    manager = "1.19"
-    default = "1.19"
+    manager = "1.20"
+    default = "1.20"
   }
   node_size = {
     live    = ["r5.xlarge", "r4.xlarge"]
@@ -109,7 +109,7 @@ locals {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "v17.3.0"
+  version = "v17.23.0"
 
   cluster_name                  = terraform.workspace
   subnets                       = concat(tolist(data.aws_subnet_ids.private.ids), tolist(data.aws_subnet_ids.public.ids))
@@ -187,7 +187,7 @@ module "eks" {
 # EKS Cluster add-ons #
 #######################
 module "aws_eks_addons" {
-  source                  = "github.com/ministryofjustice/cloud-platform-terraform-eks-add-ons?ref=1.0.4"
+  source                  = "github.com/ministryofjustice/cloud-platform-terraform-eks-add-ons?ref=1.0.5"
   depends_on              = [module.eks]
   cluster_name            = terraform.workspace
   eks_cluster_id          = module.eks.cluster_id

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
@@ -109,7 +109,7 @@ locals {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "v17.23.0"
+  version = "v17.24.0"
 
   cluster_name                  = terraform.workspace
   subnets                       = concat(tolist(data.aws_subnet_ids.private.ids), tolist(data.aws_subnet_ids.public.ids))
@@ -188,7 +188,7 @@ module "eks" {
 #######################
 module "aws_eks_addons" {
   source                  = "github.com/ministryofjustice/cloud-platform-terraform-eks-add-ons?ref=1.0.5"
-  depends_on              = [module.eks]
+  depends_on              = [module.eks.cluster]
   cluster_name            = terraform.workspace
   eks_cluster_id          = module.eks.cluster_id
   cluster_oidc_issuer_url = replace(module.eks.cluster_oidc_issuer_url, "https://", "")


### PR DESCRIPTION
- This is for the manager and live cluster.
- Using EKS module version "v17.23.0"
- Upgrade addons using the supported version for 1.20

Related to:
https://github.com/ministryofjustice/cloud-platform/issues/3345
https://github.com/ministryofjustice/cloud-platform/issues/3346