### PR TITLE
Upgrade calico to use the latest chart version

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/main.tf
@@ -130,7 +130,7 @@ resource "helm_release" "calico" {
   chart      = "aws-calico"
   repository = "https://aws.github.io/eks-charts"
   namespace  = "kube-system"
-  version    = "0.3.5"
+  version    = "0.3.10"
 
   depends_on = [kubectl_manifest.calico_crds]
 }


### PR DESCRIPTION
Update calico before cni version upgrade
This version have this fix: Added permissions to endpointslices
https://github.com/aws/amazon-vpc-cni-k8s/pull/1678