### PR TITLE
Upgrade calico to latest

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/main.tf
@@ -130,7 +130,7 @@ resource "helm_release" "calico" {
   chart      = "aws-calico"
   repository = "https://aws.github.io/eks-charts"
   namespace  = "kube-system"
-  version    = "0.3.5"
+  version    = "0.3.10"
 
   depends_on = [kubectl_manifest.calico_crds]
 }

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/main.tf
@@ -133,6 +133,24 @@ resource "helm_release" "calico" {
   version    = "0.3.10"
 
   depends_on = [kubectl_manifest.calico_crds]
+  timeout    = "900"
+
+  set {
+    name  = "calico.typha.resources.limits.memory"
+    value = "256Mi"
+  }
+  set {
+    name  = "calico.typha.resources.limits.cpu"
+    value = "200m"
+  }
+  set {
+    name  = "calico.node.resources.limits.memory"
+    value = "128Mi"
+  }
+  set {
+    name  = "calico.node.resources.limits.cpu"
+    value = "200m"
+  }
 }
 
 data "kubectl_file_documents" "calico_global_policies" {


### PR DESCRIPTION
- Update calico before cni version upgrade
    This version has this fix: Added permissions to endpointslices
    https://github.com/aws/amazon-vpc-cni-k8s/pull/1678

- Updated calico to set increased resources 
  This is to fix the OOM issue seen in typha for resources, also, calico node needs more CPU and memory
  
- Increased timeout to get the terraform apply working on more node cluster