### PR TITLE
Upgrade manger node type to r5.xlarge

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
@@ -33,7 +33,7 @@ locals {
   }
   node_size = {
     live    = ["r5.xlarge", "r4.xlarge"]
-    manager = ["m5.xlarge", "m4.xlarge"]
+    manager = ["r5.xlarge", "r4.xlarge"]
     default = ["m5.large", "m4.large"]
   }
 


### PR DESCRIPTION
This is to fix the OOM issue for concourse, which is running on manger cluster