### PR TITLE
Update node_groups_count to 42 for "live" cluster

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
@@ -21,7 +21,7 @@ locals {
   # desired_capcity change is a manual step after initial cluster creation (when no cluster-autoscaler)
   # https://github.com/terraform-aws-modules/terraform-aws-eks/issues/835
   node_groups_count = {
-    live    = "54"
+    live    = "42"
     manager = "4"
     default = "3"
   }


### PR DESCRIPTION
Now we upgraded cni to have “Support for high pod density in node”, this will enable more pods on node, so reduced node count to 42 from 54.