### PR TITLE
Pin hashicorp/aws provider version

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/account/versions.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = "~> 3.68.0"
     }
   }

--- a/terraform/aws-accounts/cloud-platform-aws/account/versions.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/versions.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      version = "~> 3.68.0"
     }
   }
   required_version = ">= 0.14"

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/versions.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = "~> 3.68.0"
     }
     helm = {

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/versions.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/versions.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      version = "~> 3.68.0"
     }
     helm = {
       source = "hashicorp/helm"

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/versions.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/versions.tf
@@ -5,7 +5,7 @@ terraform {
       version = "= 0.19.0"
     }
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = "~> 3.68.0"
     }
     kubernetes = {

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/versions.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/versions.tf
@@ -6,6 +6,7 @@ terraform {
     }
     aws = {
       source = "hashicorp/aws"
+      version = "~> 3.68.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/versions.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = "~> 3.68.0"
     }
     helm = {

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/versions.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/versions.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      version = "~> 3.68.0"
     }
     helm = {
       source = "hashicorp/helm"

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/kops/versions.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/kops/versions.tf
@@ -5,7 +5,7 @@ terraform {
       version = "= 0.19.0"
     }
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = "~> 3.68.0"
     }
   }

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/kops/versions.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/kops/versions.tf
@@ -6,6 +6,7 @@ terraform {
     }
     aws = {
       source = "hashicorp/aws"
+      version = "~> 3.68.0"
     }
   }
   required_version = ">= 0.14"

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/versions.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = "~> 3.68.0"
     }
   }

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/versions.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/versions.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      version = "~> 3.68.0"
     }
   }
   required_version = ">= 0.14"

--- a/terraform/aws-accounts/cloud-platform-dsd/versions.tf
+++ b/terraform/aws-accounts/cloud-platform-dsd/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = "~> 3.68.0"
     }
   }

--- a/terraform/aws-accounts/cloud-platform-dsd/versions.tf
+++ b/terraform/aws-accounts/cloud-platform-dsd/versions.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      version = "~> 3.68.0"
     }
   }
   required_version = ">= 0.14"

--- a/terraform/aws-accounts/cloud-platform-ephemeral-test/cloud-platform-account/versions.tf
+++ b/terraform/aws-accounts/cloud-platform-ephemeral-test/cloud-platform-account/versions.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      version = "~> 3.68.0"
     }
     github = {
       source = "integrations/github"

--- a/terraform/aws-accounts/cloud-platform-ephemeral-test/cloud-platform-account/versions.tf
+++ b/terraform/aws-accounts/cloud-platform-ephemeral-test/cloud-platform-account/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = "~> 3.68.0"
     }
     github = {

--- a/terraform/aws-accounts/cloud-platform-ephemeral-test/cloud-platform-components/variables.tf
+++ b/terraform/aws-accounts/cloud-platform-ephemeral-test/cloud-platform-components/variables.tf
@@ -4,7 +4,7 @@ variable "pagerduty_config" {
 
 variable "alertmanager_slack_receivers" {
   description = "A list of configuration values for Slack receivers"
-  type        = list
+  type        = list(any)
 }
 
 variable "aws_master_account_id" {

--- a/terraform/aws-accounts/cloud-platform-ephemeral-test/cloud-platform-components/versions.tf
+++ b/terraform/aws-accounts/cloud-platform-ephemeral-test/cloud-platform-components/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = "~> 3.68.0"
     }
     helm = {

--- a/terraform/aws-accounts/cloud-platform-ephemeral-test/cloud-platform-components/versions.tf
+++ b/terraform/aws-accounts/cloud-platform-ephemeral-test/cloud-platform-components/versions.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      version = "~> 3.68.0"
     }
     helm = {
       source = "hashicorp/helm"

--- a/terraform/aws-accounts/cloud-platform-ephemeral-test/cloud-platform-network/versions.tf
+++ b/terraform/aws-accounts/cloud-platform-ephemeral-test/cloud-platform-network/versions.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      version = "~> 3.68.0"
     }
   }
   required_version = ">= 0.13"

--- a/terraform/aws-accounts/cloud-platform-ephemeral-test/cloud-platform-network/versions.tf
+++ b/terraform/aws-accounts/cloud-platform-ephemeral-test/cloud-platform-network/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = "~> 3.68.0"
     }
   }

--- a/terraform/aws-accounts/cloud-platform-ephemeral-test/cloud-platform/versions.tf
+++ b/terraform/aws-accounts/cloud-platform-ephemeral-test/cloud-platform/versions.tf
@@ -6,6 +6,7 @@ terraform {
     }
     aws = {
       source = "hashicorp/aws"
+      version = "~> 3.68.0"
     }
   }
   required_version = ">= 0.13"

--- a/terraform/aws-accounts/cloud-platform-ephemeral-test/cloud-platform/versions.tf
+++ b/terraform/aws-accounts/cloud-platform-ephemeral-test/cloud-platform/versions.tf
@@ -5,7 +5,7 @@ terraform {
       version = "= 0.19.0"
     }
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = "~> 3.68.0"
     }
   }

--- a/terraform/cross-account-IAM/versions.tf
+++ b/terraform/cross-account-IAM/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = "~> 3.68.0"
     }
     helm = {

--- a/terraform/cross-account-IAM/versions.tf
+++ b/terraform/cross-account-IAM/versions.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      version = "~> 3.68.0"
     }
     helm = {
       source = "hashicorp/helm"

--- a/terraform/global-resources/versions.tf
+++ b/terraform/global-resources/versions.tf
@@ -5,7 +5,7 @@ terraform {
       version = ">= 0.2.1"
     }
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = "~> 3.68.0"
     }
     external = {

--- a/terraform/global-resources/versions.tf
+++ b/terraform/global-resources/versions.tf
@@ -6,6 +6,7 @@ terraform {
     }
     aws = {
       source = "hashicorp/aws"
+      version = "~> 3.68.0"
     }
     external = {
       source = "hashicorp/external"

--- a/terraform/modules/aws_federation/versions.tf
+++ b/terraform/modules/aws_federation/versions.tf
@@ -4,6 +4,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      version = "~> 3.68.0"
     }
     template = {
       source = "hashicorp/template"

--- a/terraform/modules/aws_federation/versions.tf
+++ b/terraform/modules/aws_federation/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_version = ">= 0.14"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = "~> 3.68.0"
     }
     template = {

--- a/terraform/modules/cluster_dns/versions.tf
+++ b/terraform/modules/cluster_dns/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_version = ">= 0.14"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = "~> 3.68.0"
     }
   }

--- a/terraform/modules/cluster_dns/versions.tf
+++ b/terraform/modules/cluster_dns/versions.tf
@@ -4,6 +4,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      version = "~> 3.68.0"
     }
   }
 }

--- a/terraform/modules/cluster_ssl/versions.tf
+++ b/terraform/modules/cluster_ssl/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_version = ">= 0.14"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = "~> 3.68.0"
     }
   }

--- a/terraform/modules/cluster_ssl/versions.tf
+++ b/terraform/modules/cluster_ssl/versions.tf
@@ -4,6 +4,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      version = "~> 3.68.0"
     }
   }
 }


### PR DESCRIPTION
This is to make sure upgraded versions changes are not affected without teams notice.
 Pinned to version = "~> 3.68.0", as we notiected > v3.70, showing chagnes.