### PR TITLE
Upgrade Monitoring Module to 2.0.5

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -110,7 +110,7 @@ module "logging" {
 }
 
 module "monitoring" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=2.0.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=2.0.5"
 
   alertmanager_slack_receivers               = var.alertmanager_slack_receivers
   iam_role_nodes                             = data.aws_iam_role.nodes.arn


### PR DESCRIPTION
Upgrade Monitoring Module to 2.0.5 which includes the Prometheus-Operator to v30.0.1