### PR TITLE
Bump monitoring to 2.0.8, change on metric-server

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -110,7 +110,7 @@ module "logging" {
 }
 
 module "monitoring" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=2.0.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=2.0.8"
 
   alertmanager_slack_receivers               = var.alertmanager_slack_receivers
   iam_role_nodes                             = data.aws_iam_role.nodes.arn


### PR DESCRIPTION
Related to: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/pull/122