### PR TITLE
Add external-dns annotation check policy in live-1

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -135,7 +135,7 @@ module "monitoring" {
 }
 
 module "opa" {
-  source     = "github.com/ministryofjustice/cloud-platform-terraform-opa?ref=0.2.2"
+  source     = "github.com/ministryofjustice/cloud-platform-terraform-opa?ref=0.2.3"
   depends_on = [module.monitoring, module.ingress_controllers, module.velero, module.cert_manager]
 
   cluster_domain_name            = data.terraform_remote_state.cluster.outputs.cluster_domain_name

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/components.tf
@@ -102,12 +102,15 @@ module "ingress_controllers" {
 }
 
 module "opa" {
-  source     = "github.com/ministryofjustice/cloud-platform-terraform-opa?ref=0.2.1"
+  source     = "github.com/ministryofjustice/cloud-platform-terraform-opa?ref=0.2.3"
   depends_on = [module.prometheus, module.ingress_controllers, module.velero, module.kiam, module.cert_manager]
 
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   # boolean expression for applying opa valid hostname for test clusters only.
   enable_invalid_hostname_policy = terraform.workspace == local.live_workspace ? false : true
+  enable_external_dns_weight     = terraform.workspace == "live-1" ? true : false
+  cluster_color                  = terraform.workspace == "live-1" ? "blue" : "black"
+  integration_test_zone          = data.aws_route53_zone.integrationtest.name
 }
 
 module "starter_pack" {

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/kops/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/kops/main.tf
@@ -30,6 +30,9 @@ provider "auth0" {
   domain = local.auth0_tenant_domain
 }
 
+##################
+# Data Resources #
+##################
 data "aws_s3_bucket" "kops_state" {
   bucket   = "cloud-platform-kops-state"
   provider = aws.ireland
@@ -37,6 +40,10 @@ data "aws_s3_bucket" "kops_state" {
 
 data "aws_route53_zone" "cloud_platform" {
   name = "cloud-platform.service.justice.gov.uk"
+}
+
+data "aws_route53_zone" "integrationtest" {
+  name = "integrationtest.service.justice.gov.uk"
 }
 
 ###########################


### PR DESCRIPTION
This is to restrict applying ingress with out right annotation