### PR TITLE
Upgrade logging to use latest version

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -131,7 +131,7 @@ module "kuberos" {
 }
 
 module "logging" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-logging?ref=1.2.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-logging?ref=1.2.1"
 
   elasticsearch_host       = lookup(var.elasticsearch_hosts_maps, terraform.workspace, "placeholder-elasticsearch")
   elasticsearch_audit_host = lookup(var.elasticsearch_audit_hosts_maps, terraform.workspace, "placeholder-elasticsearch")

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -131,7 +131,7 @@ module "kuberos" {
 }
 
 module "logging" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-logging?ref=1.1.8"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-logging?ref=1.2.0"
 
   elasticsearch_host       = lookup(var.elasticsearch_hosts_maps, terraform.workspace, "placeholder-elasticsearch")
   elasticsearch_audit_host = lookup(var.elasticsearch_audit_hosts_maps, terraform.workspace, "placeholder-elasticsearch")


### PR DESCRIPTION
Update fluent-bit to the latest version, as the stable chart is not supported, used:
https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/Chart.yaml

Pinned app version to "1.8.4", as we see this issue in the latest version
https://github.com/fluent/fluent-bit/issues/4260