### PR TITLE
Update new ing controller to use the latest

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -90,7 +90,7 @@ module "modsec_ingress_controllers" {
 }
 
 module "ingress_controllers_v1" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.0.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.0.2"
 
   replica_count       = "2"
   controller_name     = "default"
@@ -106,7 +106,7 @@ module "ingress_controllers_v1" {
 }
 
 module "modsec_ingress_controllers_v1" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.0.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.0.2"
 
   replica_count       = "2"
   controller_name     = "modsec"


### PR DESCRIPTION
- Use ingressClass from controller name, as it is by default named as Nginx

```
More info:
  # -- For backwards compatibility with ingress.class annotation, use ingressClass.
  # Algorithm is as follows, first ingressClassName is considered, if not present, controller looks for ingress.class annotation
  ingressClass: nginx
```

- Add a condition to support tlsv1.3 along with tlsv1.2, this can be used for new ingress controllers