### PR TITLE
Update logging to use the latest version

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -131,7 +131,7 @@ module "kuberos" {
 }
 
 module "logging" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-logging?ref=1.2.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-logging?ref=1.2.2"
 
   elasticsearch_host       = lookup(var.elasticsearch_hosts_maps, terraform.workspace, "placeholder-elasticsearch")
   elasticsearch_audit_host = lookup(var.elasticsearch_audit_hosts_maps, terraform.workspace, "placeholder-elasticsearch")


### PR DESCRIPTION
Increased buffer size to 1MB, default is 32k
This is to fix the warn:
cannot increase buffer: current=32000 requested=64768 max=32000

This is fixed in release 1.8.7, but we can't go to that version yet
https://github.com/fluent/fluent-bit/issues/3900