### PR TITLE
Scale down kops live-1 cluster

### DIFF
--- a/kops/live-1.yaml
+++ b/kops/live-1.yaml
@@ -410,12 +410,12 @@ metadata:
   name: 2xlarge-nodes-1.18.2
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210325
-  machineType: r5.2xlarge
+  machineType: r5.xlarge
   maxSize: 2
   minSize: 2
   rootVolumeSize: 256
   nodeLabels:
-    kops.k8s.io/instancegroup: 2xlarge-nodes-1.18.2
+    kops.k8s.io/instancegroup: xlarge-nodes-1.18.2
     cloud-platform.justice.gov.uk/monitoring-ng: "true"
   cloudLabels:
     application: moj-cloud-platform
@@ -459,8 +459,8 @@ spec:
     - r5.xlarge
     - c5.xlarge
     - r4.xlarge
-  maxSize: 10
-  minSize: 10
+  maxSize: 4
+  minSize: 4
   rootVolumeSize: 256
   nodeLabels:
     kops.k8s.io/instancegroup: nodes-1.18.2-eu-west-2a
@@ -494,8 +494,8 @@ spec:
     - r5.xlarge
     - c5.xlarge
     - r4.xlarge
-  maxSize: 10
-  minSize: 10
+  maxSize: 4
+  minSize: 4
   rootVolumeSize: 256
   nodeLabels:
     kops.k8s.io/instancegroup: nodes-1.18.2-eu-west-2b
@@ -529,8 +529,8 @@ spec:
     - r5.xlarge
     - c5.xlarge
     - r4.xlarge
-  maxSize: 10
-  minSize: 10
+  maxSize: 4
+  minSize: 4
   rootVolumeSize: 256
   nodeLabels:
     kops.k8s.io/instancegroup: nodes-1.18.2-eu-west-2c

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/kops/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/kops/main.tf
@@ -65,7 +65,7 @@ locals {
 ########
 
 module "kops" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-kops?ref=0.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-kops?ref=0.2.3"
 
   vpc_name            = local.vpc
   cluster_domain_name = trimsuffix(local.cluster_base_domain_name, ".")

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/kops/variables.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/kops/variables.tf
@@ -29,7 +29,7 @@ variable "availability_zones" {
 variable "cluster_node_count_a" {
   description = "The number of worker node in the cluster in Availability Zone eu-west-2a"
   default = {
-    live-1  = "10"
+    live-1  = "4"
     default = "1"
   }
 }
@@ -37,7 +37,7 @@ variable "cluster_node_count_a" {
 variable "cluster_node_count_b" {
   description = "The number of worker node in the cluster in Availability Zone eu-west-2b"
   default = {
-    live-1  = "10"
+    live-1  = "4"
     default = "1"
   }
 }
@@ -45,7 +45,7 @@ variable "cluster_node_count_b" {
 variable "cluster_node_count_c" {
   description = "The number of worker node in the cluster in Availability Zone eu-west-2c"
   default = {
-    live-1  = "10"
+    live-1  = "4"
     default = "1"
   }
 }


### PR DESCRIPTION
As most of the migration to live is completed, scaling down live-1

This is related to:
https://github.com/ministryofjustice/cloud-platform/issues/3574