### PR TITLE
Ignore docker registry rspec test in live-1

### DIFF
--- a/smoke-tests/spec/docker_registry_cache_spec.rb
+++ b/smoke-tests/spec/docker_registry_cache_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe "docker-registry-cache", kops: true do
+xdescribe "docker-registry-cache", kops: true do
   let(:namespace) { "docker-registry-cache" }
 
   context "pod" do


### PR DESCRIPTION
The test is failing, as we are going to delete live-1 skipping the test, as we are not using this in "live"