### PR TITLE
Implement URLs for monitoring stack

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -122,14 +122,14 @@ module "modsec_ingress_controllers_v1" {
 }
 
 module "kuberos" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-kuberos?ref=0.3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-kuberos?ref=0.4.0"
 
   cluster_domain_name           = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   oidc_kubernetes_client_id     = data.terraform_remote_state.cluster.outputs.oidc_kubernetes_client_id
   oidc_kubernetes_client_secret = data.terraform_remote_state.cluster.outputs.oidc_kubernetes_client_secret
   oidc_issuer_url               = data.terraform_remote_state.cluster.outputs.oidc_issuer_url
   cluster_address               = data.terraform_remote_state.cluster.outputs.cluster_endpoint
-  create_aws_redirect           = false
+  create_aws_redirect           = terraform.workspace == "live" ? true : false
 }
 
 module "logging" {

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -142,7 +142,7 @@ module "logging" {
 }
 
 module "monitoring" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=2.0.8"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=2.1.0"
 
   alertmanager_slack_receivers               = var.alertmanager_slack_receivers
   iam_role_nodes                             = data.aws_iam_role.nodes.arn
@@ -154,6 +154,8 @@ module "monitoring" {
   enable_thanos_sidecar                      = lookup(local.prod_workspace, terraform.workspace, false)
   enable_large_nodesgroup                    = terraform.workspace == "live" ? true : false
   enable_prometheus_affinity_and_tolerations = true
+  enable_kibana_audit_proxy                  = terraform.workspace == "live" ? true : false
+  enable_kibana_proxy                        = terraform.workspace == "live" ? true : false
 
   enable_thanos_helm_chart = lookup(local.prod_workspace, terraform.workspace, false)
   enable_thanos_compact    = lookup(local.manager_workspace, terraform.workspace, false)

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/main.tf
@@ -40,7 +40,7 @@ locals {
   # Some clusters (like manager) need extra callbacks URLs in auth0
   auth0_extra_callbacks = {
     manager = ["https://sonarqube.cloud-platform.service.justice.gov.uk/oauth2/callback/oidc"]
-    live    = concat([for i in ["prometheus", "alertmanager"] : "https://${i}.${local.fqdn}/oauth2/callback"],
+    live = concat([for i in ["prometheus", "alertmanager"] : "https://${i}.${local.fqdn}/oauth2/callback"],
     ["https://grafana.${local.fqdn}/login/generic_oauth"])
   }
 }

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/components.tf
@@ -33,14 +33,14 @@ module "kiam" {
 }
 
 module "kuberos" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-kuberos?ref=0.3.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-kuberos?ref=0.4.0"
 
   cluster_domain_name           = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   oidc_kubernetes_client_id     = data.terraform_remote_state.cluster.outputs.oidc_kubernetes_client_id
   oidc_kubernetes_client_secret = data.terraform_remote_state.cluster.outputs.oidc_kubernetes_client_secret
   oidc_issuer_url               = data.terraform_remote_state.cluster.outputs.oidc_issuer_url
   cluster_address               = "https://api.${data.terraform_remote_state.cluster.outputs.cluster_domain_name}"
-  create_aws_redirect           = terraform.workspace == local.live_workspace ? true : false
+  create_aws_redirect           = false
 }
 
 

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components/components.tf
@@ -58,7 +58,7 @@ module "logging" {
 }
 
 module "prometheus" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=2.0.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=2.0.1.1"
 
   alertmanager_slack_receivers               = var.alertmanager_slack_receivers
   iam_role_nodes                             = data.aws_iam_role.nodes.arn
@@ -68,8 +68,8 @@ module "prometheus" {
   enable_thanos_helm_chart                   = terraform.workspace == local.live_workspace ? true : false
   enable_thanos_sidecar                      = terraform.workspace == local.live_workspace ? true : false
   enable_prometheus_affinity_and_tolerations = terraform.workspace == local.live_workspace ? true : false
-  enable_kibana_audit_proxy                  = terraform.workspace == local.live_workspace ? true : false
-  enable_kibana_proxy                        = terraform.workspace == local.live_workspace ? true : false
+  enable_kibana_audit_proxy                  = false
+  enable_kibana_proxy                        = false
 
   cluster_domain_name           = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   oidc_components_client_id     = data.terraform_remote_state.cluster.outputs.oidc_components_client_id

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/kops/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/kops/main.tf
@@ -53,11 +53,6 @@ locals {
   is_live_cluster      = terraform.workspace == "live-1"
   services_base_domain = local.is_live_cluster ? "cloud-platform.service.justice.gov.uk" : local.cluster_base_domain_name
 
-  # This is to maintain multiple URLs for monitoring stack, in light of the EKS migration
-  auth0_extra_callbacks = {
-    live-1 = concat([for i in ["prometheus", "alertmanager"] : "https://${i}.${local.cluster_base_domain_name}/oauth2/callback"],
-    ["https://grafana.${local.cluster_base_domain_name}/login/generic_oauth"])
-  }
 }
 
 ########
@@ -116,6 +111,5 @@ module "auth0" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-auth0?ref=1.2.2"
 
   cluster_name         = local.cluster_name
-  services_base_domain = local.services_base_domain
-  extra_callbacks      = lookup(local.auth0_extra_callbacks, terraform.workspace, [""])
+  services_base_domain = local.cluster_base_domain_name
 }


### PR DESCRIPTION
- These will be routed to the live cluster:
    Prometheus: https://prometheus.cloud-platform.service.justice.gov.uk/
    AlertManager: https://alertmanager.cloud-platform.service.justice.gov.uk/
    Grafana: https://grafana.cloud-platform.service.justice.gov.uk/
    
    This is related to step4, after migration to eks completed to live:
    
    https://github.com/ministryofjustice/cloud-platform/issues/3007
   
 - Disable kibana proxy on live-1
      Created new release from 2.0.1, to have "cloud-platform.service.justice.gov.uk" URLs for live cluster

