### PR TITLE
Update  cert-manger test to user v1

### DIFF
--- a/smoke-tests/spec/cert_manager_spec.rb
+++ b/smoke-tests/spec/cert_manager_spec.rb
@@ -48,7 +48,7 @@ end
 def create_certificate(namespace, host)
   json = <<~EOF
     {
-      "apiVersion": "cert-manager.io/v1alpha3",
+      "apiVersion": "cert-manager.io/v1",
       "kind": "Certificate",
       "metadata": {
         "name": "cert-manager-integration-test",


### PR DESCRIPTION
As v1apha3 cannot be used in current cert-manger