### PR TITLE
Feat: Removing live1 for cert manager

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -35,9 +35,8 @@ module "concourse" {
 }
 
 module "cert_manager" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-certmanager?ref=1.4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-certmanager?ref=1.5.0"
 
-  iam_role_nodes      = data.aws_iam_role.nodes.arn
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   hostzone            = lookup(local.hostzones, terraform.workspace, local.hostzones["default"])
 
@@ -46,8 +45,6 @@ module "cert_manager" {
   dependence_prometheus = module.monitoring.helm_prometheus_operator_eks_status
   dependence_opa        = "ignore"
 
-  # This section is for EKS
-  eks                         = true
   eks_cluster_oidc_issuer_url = data.terraform_remote_state.cluster.outputs.cluster_oidc_issuer_url
 }
 


### PR DESCRIPTION
Updating terraform to the latest certmanager module to remove live1