### PR TITLE
Live-1 clean-up velero and OPA module

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -158,7 +158,7 @@ module "monitoring" {
 }
 
 module "opa" {
-  source     = "github.com/ministryofjustice/cloud-platform-terraform-opa?ref=0.4.1"
+  source     = "github.com/ministryofjustice/cloud-platform-terraform-opa?ref=0.4.2"
   depends_on = [module.monitoring, module.modsec_ingress_controllers, module.modsec_ingress_controllers_v1, module.cert_manager]
 
   cluster_domain_name            = data.terraform_remote_state.cluster.outputs.cluster_domain_name
@@ -178,14 +178,11 @@ module "starter_pack" {
 }
 
 module "velero" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-velero?ref=1.7.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-velero?ref=1.8.0"
 
-  iam_role_nodes        = data.aws_iam_role.nodes.arn
   dependence_prometheus = module.monitoring.helm_prometheus_operator_eks_status
   cluster_domain_name   = data.terraform_remote_state.cluster.outputs.cluster_domain_name
 
-  # This section is for EKS
-  eks                         = true
   eks_cluster_oidc_issuer_url = data.terraform_remote_state.cluster.outputs.cluster_oidc_issuer_url
 }
 


### PR DESCRIPTION
Update the module to remove any references to live-1
Related to:
https://github.com/ministryofjustice/cloud-platform/issues/3672
https://github.com/ministryofjustice/cloud-platform/issues/3673