### PR TITLE
Update module dependency and bump monitoring

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -26,7 +26,7 @@ module "concourse" {
   authorized_keys_github_token                      = var.authorized_keys_github_token
   sonarqube_token                                   = var.sonarqube_token
   sonarqube_host                                    = var.sonarqube_host
-  dependence_prometheus                             = module.monitoring.helm_prometheus_operator_eks_status
+  dependence_prometheus                             = module.monitoring.prometheus_operator_crds_status
   hoodaw_host                                       = var.hoodaw_host
   hoodaw_api_key                                    = var.hoodaw_api_key
   github_actions_secrets_token                      = var.github_actions_secrets_token
@@ -42,7 +42,7 @@ module "cert_manager" {
 
   # Requiring Prometheus taints the default cert null_resource on any monitoring upgrade, 
   # but cluster creation fails without, so will have to be temporarily disabled when upgrading
-  dependence_prometheus = module.monitoring.helm_prometheus_operator_eks_status
+  dependence_prometheus = module.monitoring.prometheus_operator_crds_status
   dependence_opa        = "ignore"
 
   eks_cluster_oidc_issuer_url = data.terraform_remote_state.cluster.outputs.cluster_oidc_issuer_url
@@ -54,7 +54,7 @@ module "external_dns" {
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   hostzone            = lookup(local.hostzones, terraform.workspace, local.hostzones["default"])
 
-  dependence_prometheus       = module.monitoring.helm_prometheus_operator_eks_status
+  dependence_prometheus       = module.monitoring.prometheus_operator_crds_status
   eks_cluster_oidc_issuer_url = data.terraform_remote_state.cluster.outputs.cluster_oidc_issuer_url
 }
 
@@ -70,7 +70,7 @@ module "ingress_controllers" {
   dependence_certmanager = module.cert_manager.helm_cert_manager_status
   dependence_opa         = "ignore"
   # It depends on complete cert-manager module
-  depends_on = [module.cert_manager]
+  //depends_on = [module.cert_manager]
 }
 
 module "modsec_ingress_controllers" {
@@ -95,7 +95,7 @@ module "ingress_controllers_v1" {
   enable_external_dns_annotation = false
   depends_on = [
     module.cert_manager,
-    module.monitoring
+    module.monitoring.prometheus_operator_crds_status
   ]
 
 }
@@ -131,11 +131,11 @@ module "logging" {
 
   elasticsearch_host       = lookup(var.elasticsearch_hosts_maps, terraform.workspace, "placeholder-elasticsearch")
   elasticsearch_audit_host = lookup(var.elasticsearch_audit_hosts_maps, terraform.workspace, "placeholder-elasticsearch")
-  dependence_prometheus    = module.monitoring.helm_prometheus_operator_eks_status
+  dependence_prometheus    = module.monitoring.prometheus_operator_crds_status
 }
 
 module "monitoring" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=2.2.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=2.2.2"
 
   alertmanager_slack_receivers               = var.alertmanager_slack_receivers
   pagerduty_config                           = var.pagerduty_config
@@ -159,7 +159,7 @@ module "monitoring" {
 
 module "opa" {
   source     = "github.com/ministryofjustice/cloud-platform-terraform-opa?ref=0.4.2"
-  depends_on = [module.monitoring, module.modsec_ingress_controllers, module.modsec_ingress_controllers_v1, module.cert_manager]
+  depends_on = [module.monitoring.prometheus_operator_crds_status, module.modsec_ingress_controllers, module.modsec_ingress_controllers_v1, module.cert_manager]
 
   cluster_domain_name            = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   enable_invalid_hostname_policy = lookup(local.prod_workspace, terraform.workspace, false) ? false : true
@@ -180,7 +180,7 @@ module "starter_pack" {
 module "velero" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-velero?ref=1.8.0"
 
-  dependence_prometheus = module.monitoring.helm_prometheus_operator_eks_status
+  dependence_prometheus = module.monitoring.prometheus_operator_crds_status
   cluster_domain_name   = data.terraform_remote_state.cluster.outputs.cluster_domain_name
 
   eks_cluster_oidc_issuer_url = data.terraform_remote_state.cluster.outputs.cluster_oidc_issuer_url


### PR DESCRIPTION
Related to: https://github.com/ministryofjustice/cloud-platform/issues/3752

The crds for existing clusters has to be imported to the terraform 
```
terraform import  'module.monitoring.kubectl_manifest.prometheus_operator_crds["alertmanager_configs"]' apiextensions.k8s.io/v1//CustomResourceDefinition//alertmanagerconfigs.monitoring.coreos.com//monitoring

terraform import 'module.monitoring.kubectl_manifest.prometheus_operator_crds["alertmanagers"]' apiextensions.k8s.io/v1//CustomResourceDefinition//alertmanagers.monitoring.coreos.com//monitoring

terraform import 'module.monitoring.kubectl_manifest.prometheus_operator_crds["podmonitors"]' apiextensions.k8s.io/v1//CustomResourceDefinition//podmonitors.monitoring.coreos.com//monitoring

terraform import 'module.monitoring.kubectl_manifest.prometheus_operator_crds["probes"]' apiextensions.k8s.io/v1//CustomResourceDefinition//probes.monitoring.coreos.com//monitoring

terraform import 'module.monitoring.kubectl_manifest.prometheus_operator_crds["prometheuses"]' apiextensions.k8s.io/v1//CustomResourceDefinition//prometheuses.monitoring.coreos.com//monitoring

terraform import 'module.monitoring.kubectl_manifest.prometheus_operator_crds["prometheusrules"]' apiextensions.k8s.io/v1//CustomResourceDefinition//prometheusrules.monitoring.coreos.com//monitoring

terraform import 'module.monitoring.kubectl_manifest.prometheus_operator_crds["servicemonitors"]' apiextensions.k8s.io/v1//CustomResourceDefinition//servicemonitors.monitoring.coreos.com//monitoring

terraform import 'module.monitoring.kubectl_manifest.prometheus_operator_crds["thanosrulers"] ' apiextensions.k8s.io/v1//CustomResourceDefinition//thanosrulers.monitoring.coreos.com//monitoring```
