### PR TITLE
Upgrade external-dns to latest version

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -49,7 +49,7 @@ module "cert_manager" {
 }
 
 module "external_dns" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-external-dns?ref=1.8.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-external-dns?ref=1.9.0"
 
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   hostzone            = lookup(local.hostzones, terraform.workspace, local.hostzones["default"])


### PR DESCRIPTION
This is to keep up to date and also fix the error:
Error: could not download chart: chart "external-dns" version "5.4.8" not found in
https://charts.bitnami.com/bitnami repository