### PR TITLE
Add module for global auth0 actions

### DIFF
--- a/terraform/global-resources/auth0.tf
+++ b/terraform/global-resources/auth0.tf
@@ -25,3 +25,11 @@ resource "auth0_rule_config" "k8s-oidc-group-claim-domain" {
   key   = "K8S_OIDC_GROUP_CLAIM_DOMAIN"
   value = "https://k8s.integration.dsd.io/groups"
 }
+
+# Module for auth0 actions
+module "global_auth0" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-global-resources-auth0?ref=1.0.0"
+
+  auth0_tenant_domain = local.auth0_tenant_domain
+  auth0_groupsClaim   = local.auth0_groupsClaim
+}

--- a/terraform/global-resources/main.tf
+++ b/terraform/global-resources/main.tf
@@ -10,6 +10,7 @@ terraform {
 
 locals {
   auth0_tenant_domain = "justice-cloud-platform.eu.auth0.com"
+  auth0_groupsClaim   = "https://k8s.integration.dsd.io/groups"
 }
 
 provider "auth0" {


### PR DESCRIPTION
Convert Auth0 "rules" to "actions" for add-github-teams-to-oidc-group-claim

This is related to:
https://github.com/ministryofjustice/cloud-platform/issues/3157