### PR TITLE
Update external-dns to use version 1.11

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -49,7 +49,7 @@ module "cert_manager" {
 }
 
 module "external_dns" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-external-dns?ref=1.9.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-external-dns?ref=1.9.1"
 
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   hostzone            = lookup(local.hostzones, terraform.workspace, local.hostzones["default"])


### PR DESCRIPTION
This is because using latest image, we have below error

Tried to delete resource record set [name='_external_dns.xxx.', type='TXT', set-identifier='xxx'] but it was not found

That caused Failure in zone