### PR TITLE
Disable add-github-teams-to-oidc-group-claim rule

### DIFF
--- a/terraform/global-resources/auth0.tf
+++ b/terraform/global-resources/auth0.tf
@@ -13,7 +13,7 @@ resource "auth0_rule" "add-github-teams-to-oidc-group-claim" {
     "${path.module}/resources/auth0-rules/add-github-teams-to-oidc-group-claim.js",
   )
   order   = 30
-  enabled = true
+  enabled = false
 }
 
 resource "auth0_rule_config" "aws-account-id" {


### PR DESCRIPTION
This is to use action converted from the rule