### PR TITLE
Upgrade kubernetes provider to 2.9.0 to use kubernetes_ingress_v1 resource

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -115,7 +115,7 @@ module "modsec_ingress_controllers_v1" {
 }
 
 module "kuberos" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-kuberos?ref=ingress"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-kuberos?ref=0.4.7"
 
   cluster_domain_name           = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   oidc_kubernetes_client_id     = data.terraform_remote_state.cluster.outputs.oidc_kubernetes_client_id

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -115,7 +115,7 @@ module "modsec_ingress_controllers_v1" {
 }
 
 module "kuberos" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-kuberos?ref=0.4.6"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-kuberos?ref=ingress"
 
   cluster_domain_name           = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   oidc_kubernetes_client_id     = data.terraform_remote_state.cluster.outputs.oidc_kubernetes_client_id

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/versions.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/versions.tf
@@ -9,7 +9,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.6.1"
+      version = "~> 2.9.0"
     }
     null = {
       source = "hashicorp/null"

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/versions.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/versions.tf
@@ -10,7 +10,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.6.1"
+      version = "~> 2.9.0"
     }
     null = {
       source = "hashicorp/null"

--- a/terraform/aws-accounts/cloud-platform-ephemeral-test/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-ephemeral-test/vpc/eks/components/components.tf
@@ -57,7 +57,7 @@ module "modsec_ingress_controllers" {
 }
 
 module "kuberos" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-kuberos?ref=0.4.6"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-kuberos?ref=0.4.7"
 
   cluster_domain_name           = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   oidc_kubernetes_client_id     = data.terraform_remote_state.cluster.outputs.oidc_kubernetes_client_id

--- a/terraform/aws-accounts/cloud-platform-ephemeral-test/vpc/eks/components/versions.tf
+++ b/terraform/aws-accounts/cloud-platform-ephemeral-test/vpc/eks/components/versions.tf
@@ -9,7 +9,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.6.1"
+      version = "~> 2.9.0"
     }
     null = {
       source = "hashicorp/null"

--- a/terraform/aws-accounts/cloud-platform-ephemeral-test/vpc/eks/versions.tf
+++ b/terraform/aws-accounts/cloud-platform-ephemeral-test/vpc/eks/versions.tf
@@ -10,7 +10,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.6.1"
+      version = "~> 2.9.0"
     }
   }
   required_version = ">= 0.14"


### PR DESCRIPTION
This is to use the kubernetes_ingress_v1 resource for kuberos redirect url