### PR TITLE
Add kuberhealthy to the list of exist namespaces

### DIFF
--- a/destroy-cluster.rb
+++ b/destroy-cluster.rb
@@ -15,6 +15,7 @@ EKS_SYSTEM_NAMESPACES = %w[
   monitoring
   opa
   velero
+  kuberhealthy
 ] + (0..9).map { |i| "starter-pack-#{i}" }
 
 MAX_CLUSTER_NAME_LENGTH = 12


### PR DESCRIPTION
This is for destroying script, if any namespaces exist in the cluster which is not listed , the destroy script will abort