### PR TITLE
Pin Terraform provider versions in global-resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .terraform
 *.tfstate*
 .terraform.lock.hcl
+!terraform/global-resources/.terraform.lock.hcl
 ssh/*id_rsa
 generated/*
 .bundle

--- a/terraform/global-resources/.terraform.lock.hcl
+++ b/terraform/global-resources/.terraform.lock.hcl
@@ -1,0 +1,101 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/auth0/auth0" {
+  version     = "0.30.3"
+  constraints = "~> 0.30.0"
+  hashes = [
+    "h1:ClU7rquP0168u2odw6L0Lv1Q5fyZy23JQU4uvWsQYno=",
+    "zh:156318d9872f4bbf56cd170e0170d7f23616a0767cb7fa55b70c4b446e59befd",
+    "zh:2d300a908954de305d0d5cd98eab53ee33101838d2d847090a7ce7a8c307b9e7",
+    "zh:305cc1f49a32c32b185991ea6b5df362867099abf60f3abdf26ef48b037f9c8d",
+    "zh:6407badb921a7226d3631f370ab16dfd6f50c42b77fabd65909985f6a607b6fb",
+    "zh:7916ebadc1ef38ef429792831533dad73b323a5d361869771f74abe2defdac16",
+    "zh:89c7074909a7629e674653d1c6bac3db029dc529eec817dd661f3c2ca3a31355",
+    "zh:9f6ea7ec7c7fbca58943d348713dfb1b9e327d774e73ce381a1adaf04b28f03b",
+    "zh:9fb1298b7ab092a939646b922e3b98b6c227297cc4e9ab6c13dc5eaf54ea3a79",
+    "zh:b3a5eeb9bfbb3e1369e0d32ff2e922f530d1f301d939c5d2207fe33bd401a6f0",
+    "zh:bf972f49da670e0ef765e48e6415a82c6e8b0f7bff26a13c0735d3c3c38a1420",
+    "zh:c4db0027f857f9ec8fcb556b62c7b38a136fcffb3ed849e7c831bf1a0553203c",
+    "zh:cf7a8909456b2f2d7b58315303f7791624b79c1fb84065f099cd907f572bf657",
+    "zh:e0dcce565c60dfabc5a456f85f99aa3cd92e69c3efab2747a2bccbf054c0db54",
+    "zh:e3c127070a6f4b08ca2ecc06ac9f50eaafe6eca74d8a4ce8e8e224e7522eaee3",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.20.1"
+  constraints = "~> 4.20.1"
+  hashes = [
+    "h1:4JtgxHHcyFAJjs/Ehtit9JaYMbO3a933bsQSXob5GOY=",
+    "zh:21d064d8fac08376c633e002e2f36e83eb7958535e251831feaf38f51c49dafd",
+    "zh:3a37912ff43d89ce8d559ec86265d7506801bccb380c7cfb896e8ff24e3fe79d",
+    "zh:795eb175c85279ec51dbe12e4d1afa0860c2c0b22e5d36a8e8869f60a93b7931",
+    "zh:8afb61a18b17f8ff249cb23e9d3b5d2530944001ef1d56c1d53f41b0890c7ab8",
+    "zh:911701040395e0e4da4b7252279e7cf1593cdd26f22835e1a9eddbdb9691a1a7",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a46d54a6a5407f569f8178e916af888b2b268f86448c64cad165dc89759c8399",
+    "zh:c5f71fd5e3519a24fd6af455ef1c26a559cfdde7f626b0afbd2a73bb79f036b1",
+    "zh:df3b69d6c9b0cdc7e3f90ee08412b22332c32e97ad8ce6ccad528f89f235a7d3",
+    "zh:e99d6a64c03549d60c2accf792fa04466cfb317f72e895c8f67eff8a02920887",
+    "zh:eea7a0df8bcb69925c9ce8e15ef403c8bbf16d46c43e8f5607b116531d1bce4a",
+    "zh:f6a26ce77f7db1d50ce311e32902fd001fb365e5e45e47a9a5cd59d734c89cb6",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/external" {
+  version = "2.2.2"
+  hashes = [
+    "h1:VUkgcWvCliS0HO4kt7oEQhFD2gcx/59XpwMqxfCU1kE=",
+    "zh:0b84ab0af2e28606e9c0c1289343949339221c3ab126616b831ddb5aaef5f5ca",
+    "zh:10cf5c9b9524ca2e4302bf02368dc6aac29fb50aeaa6f7758cce9aa36ae87a28",
+    "zh:56a016ee871c8501acb3f2ee3b51592ad7c3871a1757b098838349b17762ba6b",
+    "zh:719d6ef39c50e4cffc67aa67d74d195adaf42afcf62beab132dafdb500347d39",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7fbfc4d37435ac2f717b0316f872f558f608596b389b895fcb549f118462d327",
+    "zh:8ac71408204db606ce63fe8f9aeaf1ddc7751d57d586ec421e62d440c402e955",
+    "zh:a4cacdb06f114454b6ed0033add28006afa3f65a0ea7a43befe45fc82e6809fb",
+    "zh:bb5ce3132b52ae32b6cc005bc9f7627b95259b9ffe556de4dad60d47d47f21f0",
+    "zh:bb60d2976f125ffd232a7ccb4b3f81e7109578b23c9c6179f13a11d125dca82a",
+    "zh:f9540ecd2e056d6e71b9ea5f5a5cf8f63dd5c25394b9db831083a9d4ea99b372",
+    "zh:ffd998b55b8a64d4335a090b6956b4bf8855b290f7554dd38db3302de9c41809",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/http" {
+  version = "2.2.0"
+  hashes = [
+    "h1:xUwT7WL+ImYjm975l/1wu4LAQNKG+V5SIzx/24z2pfM=",
+    "zh:159add5739a597c08439318f67c440a90ce8444a009e7b8aabbcb9279da9191f",
+    "zh:1e5fbe9a4b8d3d9f167effc03bd5324ad6ef721c23a174e98c7eb2e8b85e34e8",
+    "zh:4b150790ac5948ceec4f97df4deaff835e4798049d858c20413cbdff6e610c4d",
+    "zh:4f85c6130249f45ff0dccdcfe78296382c930c288e2f8ec844d73fa48ab3c4ef",
+    "zh:74a1270db30043d9601ed70fecea568693552758f912a37b423dec1530a6f390",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:8125231d0b16283130bac7cb4b0c4972a596af10e1a7348ff905dcb02ea61dc9",
+    "zh:83f78277025d276ee6f4fd1ae93cf69b748c6601e7cfc7e30f07beca9ce4dfdd",
+    "zh:abca2c2e14ce0984a1353f03fd13e9dc19312ab7844f64129ec09628e3d5d472",
+    "zh:b5d0f58057c730aab9a0bf348a9143e8a0ae18f2a3ddfb9f56c603aa62212601",
+    "zh:bc6054404263c1d7faaffe4c27d1f93dd5a9848d515a6eae42d43828c3e10447",
+    "zh:cb9d4a0aeebd25cbbae5b7c726deb285c007079191bc43a6a8d6b951b7ef928a",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version = "2.12.1"
+  hashes = [
+    "h1:iAS9NYD0DjjmKpge74+y6nRltWkF+jkEpavWOEgq4jY=",
+    "zh:1ecb2adff52754fb4680c7cfe6143d1d8c264b00bb0c44f07f5583b1c7f978b8",
+    "zh:1fbd155088cd5818ad5874e4d59ccf1801e4e1961ac0711442b963315f1967ab",
+    "zh:29e927c7c8f112ee0e8ab70e71b498f2f2ae6f47df1a14e6fd0fdb6f14b57c00",
+    "zh:42c2f421da6b5b7c997e42aa04ca1457fceb13dd66099a057057a0812b680836",
+    "zh:522a7bccd5cd7acbb4ec3ef077d47f4888df7e59ff9f3d598b717ad3ee4fe9c9",
+    "zh:b45d8dc5dcbc5e30ae570d0c2e198505f47d09098dfd5f004871be8262e6ec1e",
+    "zh:c3ea0943f2050001c7d6a7115b9b990f148b082ebfc4ff3c2ff3463a8affcc4a",
+    "zh:f111833a64e06659d2e21864de39b7b7dec462615294d02f04c777956742a930",
+    "zh:f182dba5707b90b0952d5984c23f7a2da3baa62b4d71e78df7759f16cc88d957",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f76655a68680887daceabd947b2f68e2103f5bbec49a2bc29530f82ab8e3bca3",
+    "zh:fadb77352caa570bd3259dfb59c31db614d55bc96df0ff15a3c0cd2e685678b9",
+  ]
+}

--- a/terraform/global-resources/versions.tf
+++ b/terraform/global-resources/versions.tf
@@ -2,19 +2,19 @@ terraform {
   required_providers {
     auth0 = {
       source  = "auth0/auth0"
-      version = "~> 0.30.0"
+      version = "=0.30.3"
     }
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.20.1"
+      version = "=4.20.1"
     }
     external = {
       source  = "hashicorp/external"
-      version = "~> 2.2.2"
+      version = "=2.2.2"
     }
     http = {
       source  = "hashicorp/http"
-      version = "~> 2.2.0"
+      version = "=2.2.0"
     }
   }
   required_version = ">= 0.14"

--- a/terraform/global-resources/versions.tf
+++ b/terraform/global-resources/versions.tf
@@ -9,10 +9,12 @@ terraform {
       version = "~> 4.20.1"
     }
     external = {
-      source = "hashicorp/external"
+      source  = "hashicorp/external"
+      version = "~> 2.2.2"
     }
     http = {
-      source = "hashicorp/http"
+      source  = "hashicorp/http"
+      version = "~> 2.2.0"
     }
   }
   required_version = ">= 0.14"


### PR DESCRIPTION
This PR pins Terraform provider versions in `global-resources` and inverses the `.gitignore` configuration for the Terraform lock file in `global-resources`.

This ensures that on every `terraform init`, whether run manually or automatically, will always use the same Terraform provider versions as defined in this repository (rather than attempting a minor upgrade, for e.g.).

This is preparatory work for enabling Dependabot in this directory.