### PR TITLE
Enable Dependabot for global-resources

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+  - package-ecosystem: "terraform"
+    directory: "/terraform/global-resources"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This PR enables Dependabot for the Terraform configuration in `/terraform/global-resources`.