### PR TITLE
Enable Dependabot for cross-account-IAM

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,7 @@ updates:
     directory: "/terraform/global-resources"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "terraform"
+    directory: "/terraform/cross-account-IAM"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This PR enables Dependabot for the Terraform configuration in `/terraform/cross-account-IAM`.