### PR TITLE
Resolve ElasticSearch domain drift in global-resources

### DIFF
--- a/terraform/global-resources/elasticsearch.tf
+++ b/terraform/global-resources/elasticsearch.tf
@@ -107,6 +107,7 @@ resource "aws_elasticsearch_domain" "live_1" {
 
   advanced_options = {
     "rest.action.multi.allow_explicit_index" = "true"
+    "indices.query.bool.max_clause_count"    = 3000
   }
 
   access_policies = data.aws_iam_policy_document.live_1.json


### PR DESCRIPTION
This PR resolves drift in the ElasticSearch domains advanced options. Without this, `terraform plan` outputs:

```sh
  # aws_elasticsearch_domain.live_1 will be updated in-place
  ~ resource "aws_elasticsearch_domain" "live_1" {
      ~ advanced_options      = {
          - "indices.query.bool.max_clause_count"    = "3000" -> null
            # (1 unchanged element hidden)
        }
```