### PR TITLE
Pin Terraform provider versions in cloud-platform-aws/account

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .terraform
 *.tfstate*
 .terraform.lock.hcl
+!terraform/aws-accounts/cloud-platform-aws/account/.terraform.lock.hcl
 !terraform/global-resources/.terraform.lock.hcl
 !terraform/cross-account-IAM/.terraform.lock.hcl
 ssh/*id_rsa

--- a/terraform/aws-accounts/cloud-platform-aws/account/.terraform.lock.hcl
+++ b/terraform/aws-accounts/cloud-platform-aws/account/.terraform.lock.hcl
@@ -1,0 +1,183 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/anschoewe/curl" {
+  version     = "0.1.4"
+  constraints = "0.1.4"
+  hashes = [
+    "h1:MmihNDJ69sGITzTZy0nk40UFD9fgRtWbYMFHvjApC2Y=",
+    "zh:1e39ee6adcaebca2f97f580e401f6062ac43963149c915594da099c79b09b1cc",
+    "zh:2a58277089dcd6f807d9df6f9d9b52f88cd9ee87d9af3922aa3c602b59478253",
+    "zh:2e1b22aad46f49548bcb69098537aae468db5ab3143e76186ac3d15b2b368a40",
+    "zh:41a2b4394c35fed291190fb6f740ba4973cd5cbaad322837d8a484ad2067db1f",
+    "zh:60fa0ebc87a5173627ea510d30f263eda9bb9a7e1f779face60158a7369ef2ba",
+    "zh:6bead2394d15641e0b6ae1191ce99c68f95aea5a635ac5b085d08382134316df",
+    "zh:76f5f314a97ce8446ab9b5a8ffd76a0bcea8999e61bac776dc9e6c3f0b90f766",
+    "zh:c5775fab05920e4682d0fea6834dc6941afa25ea3317e1b6bd4c3f3b5c2ad820",
+    "zh:ca4983d638c2c9f36958c6c1af0aa5860e293cc8d84bcb724483e98731dca3b0",
+    "zh:dc9e9e9648446b3208a28934587458c49bae7bde3f9b3349561abfb6fc8bcd93",
+    "zh:e60aa4a4af6b6a0b6cba0b33625c5f6fee0984c45f2e664baa93cf19f30c66b6",
+    "zh:f21d8a839b9a59e1426a17afbb8d5d8a411a27d42e3e49a0b6c22e8cd89e84a8",
+    "zh:ff5c04091f814e1451f71fd84117c9d416c0d0e82318323245e394a6b9131055",
+  ]
+}
+
+provider "registry.terraform.io/auth0/auth0" {
+  version     = "0.30.0"
+  constraints = "0.30.0"
+  hashes = [
+    "h1:Ozt/hnqlGIvTJ4VzDaL9QRtm9lEAgBtriAxporuJ3Ig=",
+    "zh:044210572e7982a54a7b58f1d4282a46df2712669bce2293c3d5cecf5a52ad14",
+    "zh:0ea5f76b01028958feb8187f5aa14dd15bce694a781964af54ba97050ec885fe",
+    "zh:100a2343635cc9288642af066575f06291d13cba75e6cb44d9ec25c9aab5ae00",
+    "zh:1dbb51f50ca1c6dac4e03cd00ad3fb6056a936a466dbcce0cd43a576110dab9c",
+    "zh:2fd597bbb98421812598d71fdfe5f0cb85dfa8a49ab6b2c40e09115a244e2a52",
+    "zh:46f7c188f41e7015f9afdf6b85b32e3a533fef67c09d7a5af1ed0382293de02a",
+    "zh:53e6d175a043540d4fdbc71f223d7302125e12384a78e36fb113a111d952dcd3",
+    "zh:5f493e6dc2ebf66fb4237fba810f47255040a8804579b321694da3ba0878548d",
+    "zh:6648c72ac8b72b6b5e365673bde7a652139c98f3145c012ae15e7cf264d5d596",
+    "zh:7b6bffc0ec7d59c3f03c6f2961a2a4dee4e302f9d2800a163dbaf6b124d58919",
+    "zh:8119fa935878d304c25d30fca37c635b49672047803f25241218f8ef1e4206b9",
+    "zh:8682eb1c8e9571add6416aa335a5ebf7418ba43b176b37151ef30b466f182401",
+    "zh:9aab07f0661809ff171c92a8c8403972206f5221388b3489fcbb1e76f8198b45",
+    "zh:d176f822202ef448f9cf6c510c2a40b38441c52c08269a455d53d1c4da0c94f4",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.2.0"
+  hashes = [
+    "h1:2K5LQkuWRS2YN1/YoNaHn9MAzjuTX8Gaqy6i8Mbfv8Y=",
+    "zh:06bd875932288f235c16e2237142b493c2c2b6aba0e82e8c85068332a8d2a29e",
+    "zh:0c681b481372afcaefddacc7ccdf1d3bb3a0c0d4678a526bc8b02d0c331479bc",
+    "zh:100fc5b3fc01ea463533d7bbfb01cb7113947a969a4ec12e27f5b2be49884d6c",
+    "zh:55c0d7ddddbd0a46d57c51fcfa9b91f14eed081a45101dbfc7fd9d2278aa1403",
+    "zh:73a5dd68379119167934c48afa1101b09abad2deb436cd5c446733e705869d6b",
+    "zh:841fc4ac6dc3479981330974d44ad2341deada8a5ff9e3b1b4510702dfbdbed9",
+    "zh:91be62c9b41edb137f7f835491183628d484e9d6efa82fcb75cfa538c92791c5",
+    "zh:acd5f442bd88d67eb948b18dc2ed421c6c3faee62d3a12200e442bfff0aa7d8b",
+    "zh:ad5720da5524641ad718a565694821be5f61f68f1c3c5d2cfa24426b8e774bef",
+    "zh:e63f12ea938520b3f83634fc29da28d92eed5cfbc5cc8ca08281a6a9c36cca65",
+    "zh:f6542918faa115df46474a36aabb4c3899650bea036b5f8a5e296be6f8f25767",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.20.1"
+  constraints = ">= 2.23.0, >= 2.50.0, >= 3.0.0, >= 3.61.0, >= 4.5.0, 4.20.1"
+  hashes = [
+    "h1:4JtgxHHcyFAJjs/Ehtit9JaYMbO3a933bsQSXob5GOY=",
+    "zh:21d064d8fac08376c633e002e2f36e83eb7958535e251831feaf38f51c49dafd",
+    "zh:3a37912ff43d89ce8d559ec86265d7506801bccb380c7cfb896e8ff24e3fe79d",
+    "zh:795eb175c85279ec51dbe12e4d1afa0860c2c0b22e5d36a8e8869f60a93b7931",
+    "zh:8afb61a18b17f8ff249cb23e9d3b5d2530944001ef1d56c1d53f41b0890c7ab8",
+    "zh:911701040395e0e4da4b7252279e7cf1593cdd26f22835e1a9eddbdb9691a1a7",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a46d54a6a5407f569f8178e916af888b2b268f86448c64cad165dc89759c8399",
+    "zh:c5f71fd5e3519a24fd6af455ef1c26a559cfdde7f626b0afbd2a73bb79f036b1",
+    "zh:df3b69d6c9b0cdc7e3f90ee08412b22332c32e97ad8ce6ccad528f89f235a7d3",
+    "zh:e99d6a64c03549d60c2accf792fa04466cfb317f72e895c8f67eff8a02920887",
+    "zh:eea7a0df8bcb69925c9ce8e15ef403c8bbf16d46c43e8f5607b116531d1bce4a",
+    "zh:f6a26ce77f7db1d50ce311e32902fd001fb365e5e45e47a9a5cd59d734c89cb6",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/external" {
+  version     = "2.2.2"
+  constraints = ">= 1.0.0"
+  hashes = [
+    "h1:VUkgcWvCliS0HO4kt7oEQhFD2gcx/59XpwMqxfCU1kE=",
+    "zh:0b84ab0af2e28606e9c0c1289343949339221c3ab126616b831ddb5aaef5f5ca",
+    "zh:10cf5c9b9524ca2e4302bf02368dc6aac29fb50aeaa6f7758cce9aa36ae87a28",
+    "zh:56a016ee871c8501acb3f2ee3b51592ad7c3871a1757b098838349b17762ba6b",
+    "zh:719d6ef39c50e4cffc67aa67d74d195adaf42afcf62beab132dafdb500347d39",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7fbfc4d37435ac2f717b0316f872f558f608596b389b895fcb549f118462d327",
+    "zh:8ac71408204db606ce63fe8f9aeaf1ddc7751d57d586ec421e62d440c402e955",
+    "zh:a4cacdb06f114454b6ed0033add28006afa3f65a0ea7a43befe45fc82e6809fb",
+    "zh:bb5ce3132b52ae32b6cc005bc9f7627b95259b9ffe556de4dad60d47d47f21f0",
+    "zh:bb60d2976f125ffd232a7ccb4b3f81e7109578b23c9c6179f13a11d125dca82a",
+    "zh:f9540ecd2e056d6e71b9ea5f5a5cf8f63dd5c25394b9db831083a9d4ea99b372",
+    "zh:ffd998b55b8a64d4335a090b6956b4bf8855b290f7554dd38db3302de9c41809",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version     = "2.2.3"
+  constraints = ">= 1.0.0"
+  hashes = [
+    "h1:KmHz81iYgw9Xn2L3Carc2uAzvFZ1XsE7Js3qlVeC77k=",
+    "zh:04f0978bb3e052707b8e82e46780c371ac1c66b689b4a23bbc2f58865ab7d5c0",
+    "zh:6484f1b3e9e3771eb7cc8e8bab8b35f939a55d550b3f4fb2ab141a24269ee6aa",
+    "zh:78a56d59a013cb0f7eb1c92815d6eb5cf07f8b5f0ae20b96d049e73db915b238",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:8aa9950f4c4db37239bcb62e19910c49e47043f6c8587e5b0396619923657797",
+    "zh:996beea85f9084a725ff0e6473a4594deb5266727c5f56e9c1c7c62ded6addbb",
+    "zh:9a7ef7a21f48fabfd145b2e2a4240ca57517ad155017e86a30860d7c0c109de3",
+    "zh:a63e70ac052aa25120113bcddd50c1f3cfe61f681a93a50cea5595a4b2cc3e1c",
+    "zh:a6e8d46f94108e049ad85dbed60354236dc0b9b5ec8eabe01c4580280a43d3b8",
+    "zh:bb112ce7efbfcfa0e65ed97fa245ef348e0fd5bfa5a7e4ab2091a9bd469f0a9e",
+    "zh:d7bec0da5c094c6955efed100f3fe22fca8866859f87c025be1760feb174d6d9",
+    "zh:fb9f271b72094d07cef8154cd3d50e9aa818a0ea39130bc193132ad7b23076fd",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "3.1.1"
+  constraints = ">= 2.0.0"
+  hashes = [
+    "h1:Pctug/s/2Hg5FJqjYcTM0kPyx3AoYK1MpRWO0T9V2ns=",
+    "zh:063466f41f1d9fd0dd93722840c1314f046d8760b1812fa67c34de0afcba5597",
+    "zh:08c058e367de6debdad35fc24d97131c7cf75103baec8279aba3506a08b53faf",
+    "zh:73ce6dff935150d6ddc6ac4a10071e02647d10175c173cfe5dca81f3d13d8afe",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:8fdd792a626413502e68c195f2097352bdc6a0df694f7df350ed784741eb587e",
+    "zh:976bbaf268cb497400fd5b3c774d218f3933271864345f18deebe4dcbfcd6afa",
+    "zh:b21b78ca581f98f4cdb7a366b03ae9db23a73dfa7df12c533d7c19b68e9e72e5",
+    "zh:b7fc0c1615dbdb1d6fd4abb9c7dc7da286631f7ca2299fb9cd4664258ccfbff4",
+    "zh:d1efc942b2c44345e0c29bc976594cb7278c38cfb8897b344669eafbc3cddf46",
+    "zh:e356c245b3cd9d4789bab010893566acace682d7db877e52d40fc4ca34a50924",
+    "zh:ea98802ba92fcfa8cf12cbce2e9e7ebe999afbf8ed47fa45fc847a098d89468b",
+    "zh:eff8872458806499889f6927b5d954560f3d74bf20b6043409edf94d26cd906f",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.3.2"
+  hashes = [
+    "h1:Fu0IKMy46WsO5Y6KfuH9IFkkuxZjE/gIcgtB7GWkTtc=",
+    "zh:038293aebfede983e45ee55c328e3fde82ae2e5719c9bd233c324cfacc437f9c",
+    "zh:07eaeab03a723d83ac1cc218f3a59fceb7bbf301b38e89a26807d1c93c81cef8",
+    "zh:427611a4ce9d856b1c73bea986d841a969e4c2799c8ac7c18798d0cc42b78d32",
+    "zh:49718d2da653c06a70ba81fd055e2b99dfd52dcb86820a6aeea620df22cd3b30",
+    "zh:5574828d90b19ab762604c6306337e6cd430e65868e13ef6ddb4e25ddb9ad4c0",
+    "zh:7222e16f7833199dabf1bc5401c56d708ec052b2a5870988bc89ff85b68a5388",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:b1b2d7d934784d2aee98b0f8f07a8ccfc0410de63493ae2bf2222c165becf938",
+    "zh:b8f85b6a20bd264fcd0814866f415f0a368d1123cd7879c8ebbf905d370babc8",
+    "zh:c3813133acc02bbebddf046d9942e8ba5c35fc99191e3eb057957dafc2929912",
+    "zh:e7a41dbc919d1de800689a81c240c27eec6b9395564630764ebb323ea82ac8a9",
+    "zh:ee6d23208449a8eaa6c4f203e33f5176fa795b4b9ecf32903dffe6e2574732c2",
+  ]
+}
+
+provider "registry.terraform.io/integrations/github" {
+  version     = "4.14.0"
+  constraints = "4.14.0, ~> 4.14.0"
+  hashes = [
+    "h1:CvPZLHgMA4ReLeF0iJc11gsD/r7chkZdW89VkJml0HU=",
+    "zh:1c675ce700c0ebfc7ef437443fb25f912a62717b7bca60071bf9733d23db9576",
+    "zh:242362cc1b4932b80333f3f9b4dab6edfc84fd4cb9811bad81872939cf088b5a",
+    "zh:25bc76d0e8cce0b8bcee45a88810d655e1253c9001533b087f57fd223dc4881c",
+    "zh:3bce5f98e087796866ade17cfaa8b3f70018b53e8cff3cae32dac0a910d060a8",
+    "zh:3dda969761bb60c1721dac6901450be08b2d7501eda21146ba9dc172fcc05723",
+    "zh:5bf6b85ce208a113b54d70b973f81e7c7a7ea9a3f6d2b30eaa41ea641333ab25",
+    "zh:81b75b38332affb15bc9004c8c6aa746595b0879f779c4886899aef3db434645",
+    "zh:8a2310d85ecd60c079ec2db14ed338296f83b77857ae68e48b1a7a8a946a260c",
+    "zh:a9f1d55cee031c883ead6420896225806fda239374d730ed2d7446bee3224564",
+    "zh:caa1cf690c4e208847b026071567a7ee8b2e55dbc75649e7de393b5502a2418b",
+    "zh:e4a077b84a01d3c50ab0de1eb70122912c340f89be995177fb4ab0635f11527e",
+    "zh:e9e40b34915e1cfae711218976f398e3dae5c96682516dab870fc97e8048f416",
+    "zh:fadf11408f16ddf1605419a357ac53cf2dde6cc769757eacc9ae804a21c8d71e",
+  ]
+}

--- a/terraform/aws-accounts/cloud-platform-aws/account/versions.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/versions.tf
@@ -2,18 +2,19 @@ terraform {
   required_providers {
     auth0 = {
       source  = "auth0/auth0"
-      version = "~> 0.30.0"
+      version = "0.30.0"
     }
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.20.1"
+      version = "4.20.1"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "4.14.0"
     }
     curl = {
       source  = "anschoewe/curl"
-      version = "~> 0.1.4"
+      version = "0.1.4"
     }
   }
   required_version = ">= 0.14"


### PR DESCRIPTION
This PR pins Terraform provider versions in `aws-accounts/cloud-platform-aws/account` and inverses the `.gitignore` configuration for the Terraform lock file.

This ensures that on every `terraform init`, whether run manually or automatically, will always use the same Terraform provider versions as defined in this repository (rather than attempting a minor upgrade, for e.g.).

This is preparatory work for enabling Dependabot in this directory.