### PR TITLE
Remove .terraform.lock.hcl from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,5 @@
 .terraform
 *.tfstate*
-.terraform.lock.hcl
-!terraform/aws-accounts/cloud-platform-aws/account/.terraform.lock.hcl
-!terraform/global-resources/.terraform.lock.hcl
-!terraform/cross-account-IAM/.terraform.lock.hcl
 ssh/*id_rsa
 generated/*
 .bundle


### PR DESCRIPTION
This PR removes `.terraform.lock.hcl` from `.gitignore`, so as they're generated, they can be committed to this repository.