### PR TITLE
Replace deprecated `aws_subnet_ids` resource to `aws_subnets`

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
@@ -47,7 +47,7 @@ locals {
     desired_capacity     = lookup(local.node_groups_count, terraform.workspace, local.node_groups_count["default"])
     max_capacity         = 60
     min_capacity         = 1
-    subnets              = data.aws_subnet_ids.private.ids
+    subnets              = data.aws_subnets.private.ids
     bootstrap_extra_args = "--use-max-pods false"
     kubelet_extra_args   = "--max-pods=110"
 
@@ -73,7 +73,7 @@ locals {
     desired_capacity = 2
     max_capacity     = 3
     min_capacity     = 1
-    subnets          = data.aws_subnet_ids.private_zone_2b.ids
+    subnets          = data.aws_subnets.private_zone_2b.ids
 
     create_launch_template = true
     pre_userdata = templatefile("${path.module}/templates/user-data.tpl", {
@@ -114,7 +114,7 @@ module "eks" {
   version = "v17.23.0"
 
   cluster_name                  = terraform.workspace
-  subnets                       = concat(tolist(data.aws_subnet_ids.private.ids), tolist(data.aws_subnet_ids.public.ids))
+  subnets                       = concat(tolist(data.aws_subnets.private.ids), tolist(data.aws_subnets.public.ids))
   vpc_id                        = data.aws_vpc.selected.id
   write_kubeconfig              = false
   cluster_version               = lookup(local.cluster_version, terraform.workspace, local.cluster_version["default"])

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/main.tf
@@ -55,8 +55,11 @@ data "aws_vpc" "selected" {
   }
 }
 
-data "aws_subnet_ids" "private" {
-  vpc_id = data.aws_vpc.selected.id
+data "aws_subnets" "private" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.selected.id]
+  }
 
   tags = {
     SubnetType = "Private"
@@ -64,20 +67,27 @@ data "aws_subnet_ids" "private" {
 }
 
 # This is to get subnet_id, to create a separate node group for monitoring with 2 nodes in "eu-west-2b".
-data "aws_subnet_ids" "private_zone_2b" {
-  vpc_id = data.aws_vpc.selected.id
-
-  tags = {
-    SubnetType = "Private"
+data "aws_subnets" "private_zone_2b" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.selected.id]
   }
+
   filter {
     name   = "availability-zone"
     values = ["eu-west-2b"]
   }
+
+  tags = {
+    SubnetType = "Private"
+  }
 }
 
-data "aws_subnet_ids" "public" {
-  vpc_id = data.aws_vpc.selected.id
+data "aws_subnets" "public" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.selected.id]
+  }
 
   tags = {
     SubnetType = "Utility"
@@ -87,8 +97,8 @@ data "aws_subnet_ids" "public" {
 # This required by an output (internal_subnets) which is used by
 # concourse.
 data "aws_subnet" "private_cidrs" {
-  count = length(tolist(data.aws_subnet_ids.private.ids))
-  id    = tolist(data.aws_subnet_ids.private.ids)[count.index]
+  count = length(tolist(data.aws_subnets.private.ids))
+  id    = tolist(data.aws_subnets.private.ids)[count.index]
 }
 
 # #################

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/outputs.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/outputs.tf
@@ -15,11 +15,11 @@ output "internal_subnets" {
 }
 
 output "internal_subnets_ids" {
-  value = tolist(data.aws_subnet_ids.private.ids)
+  value = sort(tolist(data.aws_subnets.private.ids))
 }
 
 output "external_subnets_ids" {
-  value = tolist(data.aws_subnet_ids.public.ids)
+  value = sort(tolist(data.aws_subnets.public.ids))
 }
 
 output "cluster_domain_name" {


### PR DESCRIPTION
This PR removes the deprecated `aws_subnet_ids` resource and replaces it with `aws_subnets`. The only change in a `terraform plan` from this is that the `outputs` for `internal_subnet_ids` has been re-ordered but are the same values.

The upstream PR for this is hashicorp/terraform-provider-aws#22743.