### PR TITLE
Replace legacy dot notation with bracket notation

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
@@ -9,7 +9,7 @@ data "aws_eks_cluster" "cluster" {
 
 provider "kubernetes" {
   host                   = data.aws_eks_cluster.cluster.endpoint
-  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority[0].data)
   exec {
     api_version = "client.authentication.k8s.io/v1beta1"
     args        = ["eks", "get-token", "--cluster-name", data.aws_eks_cluster.cluster.name]

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/main.tf
@@ -117,10 +117,10 @@ resource "aws_route53_record" "parent_zone_cluster_ns" {
   ttl     = "30"
 
   records = [
-    aws_route53_zone.cluster.name_servers.0,
-    aws_route53_zone.cluster.name_servers.1,
-    aws_route53_zone.cluster.name_servers.2,
-    aws_route53_zone.cluster.name_servers.3,
+    aws_route53_zone.cluster.name_servers[0],
+    aws_route53_zone.cluster.name_servers[1],
+    aws_route53_zone.cluster.name_servers[2],
+    aws_route53_zone.cluster.name_servers[3],
   ]
 }
 

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/outputs.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/outputs.tf
@@ -11,7 +11,7 @@ output "vpc_id" {
 }
 
 output "internal_subnets" {
-  value = data.aws_subnet.private_cidrs.*.cidr_block
+  value = data.aws_subnet.private_cidrs[*].cidr_block
 }
 
 output "internal_subnets_ids" {


### PR DESCRIPTION
Dot notation (`.(*|n).`) was deprecated and removed from documentation in Terraform 0.12, in favour of square bracket notation `[(*|n)]`. This PR updates this configuration to reflect that change.