### PR TITLE
Enable Dependabot for cloud-platform-aws/vpc/eks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,7 @@ updates:
     directory: "/terraform/aws-accounts/cloud-platform-aws/account"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "terraform"
+    directory: "/terraform/aws-accounts/cloud-platform-aws/vpc/eks"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Requires #1639.