### PR TITLE
Enable Dependabot for cloud-platform-aws/vpc/eks/components

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,7 @@ updates:
     directory: "/terraform/aws-accounts/cloud-platform-aws/vpc/eks"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "terraform"
+    directory: "/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Requires #1645.