### PR TITLE
pin-Helm-provider

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/versions.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "2.6.0"
+      version = "~> 2.6.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/terraform/cross-account-IAM/versions.tf
+++ b/terraform/cross-account-IAM/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "=2.6.0"
+      version = "~> 2.6.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
Why:
[upgrade & pin Helm provider for Infrastructure#3882](https://app.zenhub.com/workspaces/cloud-platform-team-5ccb0b8a81f66118c983c189/issues/ministryofjustice/cloud-platform/3882)

Helm already at “2.6.0”
"~>" to allow for minor upgrades