### PR TITLE
Add dependency for new ingress controller for kuberos and starter-pack

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -125,7 +125,7 @@ module "kuberos" {
   oidc_issuer_url               = data.terraform_remote_state.cluster.outputs.oidc_issuer_url
   cluster_address               = data.terraform_remote_state.cluster.outputs.cluster_endpoint
 
-  depends_on = [module.ingress_controllers]
+  depends_on = [module.ingress_controllers_v1]
 }
 
 module "logging" {
@@ -177,7 +177,7 @@ module "starter_pack" {
   enable_starter_pack = lookup(local.prod_workspace, terraform.workspace, false) ? false : true
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
 
-  depends_on = [module.ingress_controllers]
+   depends_on = [module.ingress_controllers_v1]
 }
 
 module "velero" {


### PR DESCRIPTION
The kuberos and starter pack are switched to new ingress controllers and hence test cluster fails to create and throw error 
`Error: Internal error occurred: failed calling webhook "validate.nginx.ingress.kubernetes.io": Post "https://nginx-ingress-default-controller-admission.ingress-controllers.svc:443/networking/v1/ingresses?timeout=10s": no endpoints available for service "nginx-ingress-default-controller-admission"

Add the new ingress controllers as dependency. 