### PR TITLE
Add external-dns variables to before block

### DIFF
--- a/test/external_dns_test.go
+++ b/test/external_dns_test.go
@@ -18,10 +18,9 @@ import (
 
 var _ = Describe("external-DNS checks", func() {
 	var (
-		namespaceName = fmt.Sprintf("%s-external-dns-%s", c.Prefix, strings.ToLower(random.UniqueId()))
-		options       = k8s.NewKubectlOptions("", "", namespaceName)
-		domain        = fmt.Sprintf("%s.%s", namespaceName, testDomain)
-		tpl           string
+		namespaceName, domain string
+		options               *k8s.KubectlOptions
+		tpl                   string
 	)
 
 	BeforeEach(func() {
@@ -29,6 +28,9 @@ var _ = Describe("external-DNS checks", func() {
 			Skip("AWS environment variable not defined. Skipping test.")
 		}
 
+		namespaceName = fmt.Sprintf("%s-external-dns-%s", c.Prefix, strings.ToLower(random.UniqueId()))
+		options = k8s.NewKubectlOptions("", "", namespaceName)
+		domain = fmt.Sprintf("%s.%s", namespaceName, testDomain)
 		k8s.CreateNamespace(GinkgoT(), options, namespaceName)
 	})
 


### PR DESCRIPTION
Now we've added [flake-attempts](https://github.com/ministryofjustice/cloud-platform-terraform-concourse/blob/main/pipelines/manager/main/reporting.yaml#L193) to our pipeline, it means failed tests will attempt to rerun. The rerun will use whatever namespace, domain and host are defined in the spec, but this means it'll attempt to use resources that are destroyed in the AfterAll block. This commit adds the namespace, host and domain to the before block, but still make them available to all specs in the suite.
