### PR TITLE
Use client-go interface to talk to API

### DIFF
--- a/test/config/config.go
+++ b/test/config/config.go
@@ -4,16 +4,17 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"path/filepath"
 	"strings"
 
 	"github.com/ministryofjustice/cloud-platform-go-library/client"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/util/homedir"
 )
 
 // Config holds the basic structure of test's YAML file
 type Config struct {
+	// Client is a cloud-platform-go-library struct that essentially gives you a kubernetes.Interface
+	// to interact with the cluster.
+	Client client.KubeClient
 	// ClusterName is obtained either by argument or interpolation from a node label.
 	ClusterName string `yaml:"clusterName"`
 	// Services is a slice of services names only. There is no requirement
@@ -48,13 +49,8 @@ func NewConfig(clusterName string, services []string, daemonsets []string, servi
 
 // SetClusterName is a setter method to define the name of the cluster to work on.
 func (c *Config) SetClusterName(cluster string) error {
-	var kubeconfig string
-	if home := homedir.HomeDir(); home != "" {
-		kubeconfig = filepath.Join(home, ".kube", "config")
-	}
-
 	if cluster == "" {
-		k, err := client.NewKubeClientWithValues(kubeconfig, "")
+		k, err := client.NewKubeClientWithValues(c.Client.Path, "")
 		if err != nil {
 			return fmt.Errorf("Unable to create kubeclient: %e", err)
 		}

--- a/test/config/config.go
+++ b/test/config/config.go
@@ -50,12 +50,7 @@ func NewConfig(clusterName string, services []string, daemonsets []string, servi
 // SetClusterName is a setter method to define the name of the cluster to work on.
 func (c *Config) SetClusterName(cluster string) error {
 	if cluster == "" {
-		k, err := client.NewKubeClientWithValues(c.Client.Path, "")
-		if err != nil {
-			return fmt.Errorf("Unable to create kubeclient: %e", err)
-		}
-
-		nodes, err := k.Clientset.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+		nodes, err := c.Client.Clientset.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
 		if err != nil {
 			return fmt.Errorf("Unable to fetch node name: %e", err)
 		}

--- a/test/tests_suite_test.go
+++ b/test/tests_suite_test.go
@@ -4,13 +4,16 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/sirupsen/logrus"
+	"k8s.io/client-go/util/homedir"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/ministryofjustice/cloud-platform-go-library/client"
 	"github.com/ministryofjustice/cloud-platform-infrastructure/test/config"
 )
 
@@ -27,18 +30,29 @@ var c config.Config
 // Create a new instance of the logger. You can have any number of instances.
 var log = logrus.New()
 
-// cluster lets you select which cluster to run the tests on
-var cluster = flag.String("cluster", "", "Set the cluster name")
-
 // TestMain controls pre/post test logic
 func TestMain(m *testing.M) {
+	var kubeconfig *string
+	if home := homedir.HomeDir(); home != "" {
+		kubeconfig = flag.String("kubeconfig", filepath.Join(home, ".kube", "config"), "(optional) absolute path to the kubeconfig file")
+	} else {
+		kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
+	}
+
+	var cluster = flag.String("cluster", "", "(optional) set the cluster name")
 	flag.Parse()
+
+	client, err := client.NewKubeClientWithValues(*kubeconfig, "")
+	if err != nil {
+		Fail(fmt.Sprintf("Failed to create kube client: %v", err))
+	}
 
 	c = config.Config{
 		Prefix: "smoketest",
+		Client: *client,
 	}
 
-	err := c.SetClusterName(*cluster)
+	err = c.SetClusterName(*cluster)
 	if err != nil {
 		Fail(fmt.Sprintf("Failed to set cluster name: %s", err))
 	}


### PR DESCRIPTION
Overview
---

The following adds a new field in the `config` struct. It allows the creation of a cloud-platform client wrapper, which enables us to use the kubernetes client-go interface to communicate with the kubernetes API. Using this client replaces the need for terratest, which essentially just calls the `kubectl` binary and executes commands on its behalf. By using the client we can be more efficient with calls and control the output in a less verbose way.
