### PR TITLE
Add modsec v1 dependency for starter_pack

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -177,7 +177,10 @@ module "starter_pack" {
   enable_starter_pack = lookup(local.prod_workspace, terraform.workspace, false) ? false : true
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
 
-  depends_on = [module.ingress_controllers_v1]
+  depends_on = [
+    module.ingress_controllers_v1,
+    module.modsec_ingress_controllers_v1
+  ]
 }
 
 module "velero" {


### PR DESCRIPTION
The starter pack module uses both default and modsec ingress controllers.