### PR TITLE
modsec ingress don't log req body by default

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -83,7 +83,7 @@ module "modsec_ingress_controllers" {
 }
 
 module "ingress_controllers_v1" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.0.9"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.0.10"
 
   replica_count       = "6"
   controller_name     = "default"
@@ -102,7 +102,7 @@ module "ingress_controllers_v1" {
 }
 
 module "modsec_ingress_controllers_v1" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.0.9"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.0.10"
 
   replica_count       = "6"
   controller_name     = "modsec"


### PR DESCRIPTION
no change for the default one