### PR TITLE
update-pin-helm-version

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/versions.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/versions.tf
@@ -4,6 +4,10 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 4.20.1"
     }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.6.0"
+    }
   }
   required_version = ">= 0.14"
 }


### PR DESCRIPTION
Why [upgrade & pin Helm provider for Infrastructure#3882](https://app.zenhub.com/workspaces/cloud-platform-team-5ccb0b8a81f66118c983c189/issues/ministryofjustice/cloud-platform/3882)