### PR TITLE
Enable Dependabot for gomod

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
   - package-ecosystem: "terraform"
     directory: "/terraform/aws-accounts/cloud-platform-aws/account"
     schedule:


### PR DESCRIPTION
This PR enables Dependabot for `gomod` in the root directory of this repository.