### PR TITLE
Remove Dependabot for terraform/cross-account-IAM and cloud-platform-aws/vpc/kops/components

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,11 +39,6 @@ updates:
       interval: "weekly"
       day: "sunday"
   - package-ecosystem: "terraform"
-    directory: "/terraform/aws-accounts/cloud-platform-aws/vpc/kops/components"
-    schedule:
-      interval: "weekly"
-      day: "sunday"
-  - package-ecosystem: "terraform"
     directory: "/terraform/aws-accounts/cloud-platform-dsd"
     schedule:
       interval: "weekly"
@@ -65,11 +60,6 @@ updates:
       day: "sunday"
   - package-ecosystem: "terraform"
     directory: "/terraform/aws-accounts/cloud-platform-ephemeral-test/vpc/eks/components"
-    schedule:
-      interval: "weekly"
-      day: "sunday"
-  - package-ecosystem: "terraform"
-    directory: "/terraform/cross-account-IAM"
     schedule:
       interval: "weekly"
       day: "sunday"


### PR DESCRIPTION
These configurations were removed in #1733, so we no longer need a Dependabot configuration for them.