### PR TITLE
Update cloud-platform-terraform-auth0 to v1.3.1

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/.terraform.lock.hcl
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/.terraform.lock.hcl
@@ -2,7 +2,8 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/alexkappa/auth0" {
-  version = "0.26.2"
+  version     = "0.26.2"
+  constraints = "0.26.2"
   hashes = [
     "h1:k8ICfvHpOEvz5nsZJirH2VF1RnOEhqIEVpowiVHuzzQ=",
     "zh:160767ad6cb0a2b176cf21fe811aedf28795e60d8cd71a4ec04e947a45b36e25",
@@ -23,7 +24,7 @@ provider "registry.terraform.io/alexkappa/auth0" {
 
 provider "registry.terraform.io/auth0/auth0" {
   version     = "0.34.0"
-  constraints = "0.34.0"
+  constraints = ">= 0.27.0, 0.34.0"
   hashes = [
     "h1:phcgf6T5SJaLSsK1X33YnrNRBiKgo5GisksYglr/fpA=",
     "zh:35f8edd313a978a582e61ae3ac547b859a36436a154d51d3a4443e841f77d97b",

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/main.tf
@@ -129,7 +129,7 @@ resource "aws_route53_record" "parent_zone_cluster_ns" {
 #########
 
 module "auth0" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-auth0?ref=1.3.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-auth0?ref=1.3.1"
 
   cluster_name         = terraform.workspace
   services_base_domain = local.services_base_domain

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/versions.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/versions.tf
@@ -12,6 +12,10 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = "2.12.1"
     }
+    alexkappa = {
+      source  = "alexkappa/auth0"
+      version = "0.26.2"
+    }
   }
   required_version = ">= 0.14"
 }


### PR DESCRIPTION
This PR updates `cloud-platform-terraform-auth0` to track the `auth0/auth0` Terraform provider rather than the deprecated `alexkappa/auth0` provider.