### PR TITLE
Remove unused root module providers; use standard comment structure; add missing var types and descriptions

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/account/.terraform.lock.hcl
+++ b/terraform/aws-accounts/cloud-platform-aws/account/.terraform.lock.hcl
@@ -2,8 +2,7 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/anschoewe/curl" {
-  version     = "1.0.2"
-  constraints = "1.0.2"
+  version = "1.0.2"
   hashes = [
     "h1:bTTg+5g2UVq8r1dWJwQJle/q808dgRKYC39wfT3CdWU=",
     "zh:123a91ec73f16d8435e358e57f54f8e26eb34ba4fce07b2c0016d04a53e1366c",
@@ -24,8 +23,7 @@ provider "registry.terraform.io/anschoewe/curl" {
 }
 
 provider "registry.terraform.io/auth0/auth0" {
-  version     = "0.34.0"
-  constraints = "0.34.0"
+  version = "0.34.0"
   hashes = [
     "h1:phcgf6T5SJaLSsK1X33YnrNRBiKgo5GisksYglr/fpA=",
     "zh:35f8edd313a978a582e61ae3ac547b859a36436a154d51d3a4443e841f77d97b",
@@ -164,7 +162,7 @@ provider "registry.terraform.io/hashicorp/random" {
 
 provider "registry.terraform.io/integrations/github" {
   version     = "4.14.0"
-  constraints = "4.14.0, ~> 4.14.0"
+  constraints = "~> 4.14.0"
   hashes = [
     "h1:CvPZLHgMA4ReLeF0iJc11gsD/r7chkZdW89VkJml0HU=",
     "zh:1c675ce700c0ebfc7ef437443fb25f912a62717b7bca60071bf9733d23db9576",

--- a/terraform/aws-accounts/cloud-platform-aws/account/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/main.tf
@@ -151,12 +151,12 @@ module "s3_bucket_kubeconfigs" {
   }
 }
 
-// Create a DynamoDB table so we can lock the terraform state of each
-// namespace in the cloud-platform-environments repository, as we
-// `terraform apply` it.
-//
-// This table name is referenced from the environments repo, so that
-// terraform can use it to lock the state of each namespace.
+# Create a DynamoDB table so we can lock the terraform state of each
+# namespace in the cloud-platform-environments repository, as we
+# `terraform apply` it.
+#
+# This table name is referenced from the environments repo, so that
+# terraform can use it to lock the state of each namespace.
 resource "aws_dynamodb_table" "cloud_platform_environments_terraform_lock" {
   name           = "cloud-platform-environments-terraform-lock"
   hash_key       = "LockID"
@@ -183,4 +183,3 @@ resource "aws_s3_bucket_object" "kubeconfig" {
   content                = templatefile("${path.module}/templates/kubeconfig.tpl", { clusters = var.kubeconfig_clusters })
   server_side_encryption = "AES256"
 }
-

--- a/terraform/aws-accounts/cloud-platform-aws/account/outputs.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/outputs.tf
@@ -9,5 +9,6 @@ output "cp_zone_id" {
 }
 
 output "click_here_to_login" {
-  value = module.sso.saml_login_page
+  value       = module.sso.saml_login_page
+  description = "SSO login page for Cloud Platform"
 }

--- a/terraform/aws-accounts/cloud-platform-aws/account/variables.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/variables.tf
@@ -1,10 +1,12 @@
 variable "slack_config_cloudwatch_lp" {
   description = "Add Slack webhook API URL for integration with slack."
+  type        = string
 }
 
 variable "aws_region" {
   description = "Region where components and resources are going to be deployed"
   default     = "eu-west-2"
+  type        = string
 }
 
 variable "kubeconfig_clusters" {

--- a/terraform/aws-accounts/cloud-platform-aws/account/versions.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/versions.tf
@@ -1,20 +1,8 @@
 terraform {
   required_providers {
-    auth0 = {
-      source  = "auth0/auth0"
-      version = "0.34.0"
-    }
     aws = {
       source  = "hashicorp/aws"
       version = "4.23.0"
-    }
-    github = {
-      source  = "integrations/github"
-      version = "4.14.0"
-    }
-    curl = {
-      source  = "anschoewe/curl"
-      version = "1.0.2"
     }
   }
   required_version = ">= 0.14"


### PR DESCRIPTION
This PR updates `terraform/aws-accounts/cloud-platform-aws/account` to:

- use the standard `#` comment structure rather than `//`
- add missing variable/output types and descriptions
- removes providers from `versions.tf` that are unused _directly_ in this root module (as the modules that define them will define version constraints themselves)