### PR TITLE
Remove unused root module providers; add missing var types and descriptions

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/.terraform.lock.hcl
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/.terraform.lock.hcl
@@ -3,7 +3,7 @@
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "4.23.0"
-  constraints = ">= 3.63.0, ~> 4.23.0"
+  constraints = ">= 3.63.0, 4.23.0"
   hashes = [
     "h1:j6RGCfnoLBpzQVOKUbGyxf4EJtRvQClKplO+WdXL5O0=",
     "zh:17adbedc9a80afc571a8de7b9bfccbe2359e2b3ce1fffd02b456d92248ec9294",
@@ -18,25 +18,5 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:b4608aab78b4dbb32c629595797107fc5a84d1b8f0682f183793d13837f0ecf0",
     "zh:ed2c791c2354764b565f9ba4be7fc845c619c1a32cefadd3154a5665b312ab00",
     "zh:f94ac0072a8545eebabf417bc0acbdc77c31c006ad8760834ee8ee5cdb64e743",
-  ]
-}
-
-provider "registry.terraform.io/hashicorp/helm" {
-  version     = "2.6.0"
-  constraints = "~> 2.6.0"
-  hashes = [
-    "h1:QZcB0CGaRloxrq1JjHF4ZLauaoJ8fHF2MsXFezR0COw=",
-    "zh:0ac248c28acc1a4fd11bd26a85e48ab78dd6abf0f7ac842bf1cd7edd05ac6cf8",
-    "zh:3d32c8deae3740d8c5310136cc11c8afeffc350fbf88afaca0c34a223a5246f5",
-    "zh:4055a27489733d19ca7fa2dfce14d323fe99ae9dede7d0fea21ee6db0b9ca74b",
-    "zh:58a8ed39653fd4c874a2ecb128eccfa24c94266a00e349fd7fb13e22ad81f381",
-    "zh:6c81508044913f25083de132d0ff81d083732aba07c506cc2db05aa0cefcde2c",
-    "zh:7db5d18093047bfc4fe597f79610c0a281b21db0d61b0bacb3800585e976f814",
-    "zh:8269207b7422db99e7be80a5352d111966c3dfc7eb98511f11c8ff7b2e813456",
-    "zh:b1d7ababfb2374e72532308ff442cc906b79256b66b3fe7a98d42c68c4ddf9c5",
-    "zh:ca63e226cbdc964a5d63ef21189f059ce45c3fa4a5e972204d6916a9177d2b44",
-    "zh:d205a72d60e8cc362943d66f5bcdd6b6aaaa9aab2b89fd83bf6f1978ac0b1e4c",
-    "zh:db47dc579a0e68e5bfe3a61f2e950e6e2af82b1f388d1069de014a937962b56a",
-    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/outputs.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/outputs.tf
@@ -1,51 +1,64 @@
 output "vpc_name" {
-  value = local.vpc_name
+  value       = local.vpc_name
+  description = "VPC name (also terraform workspace)"
 }
 
 output "vpc_domain_name" {
-  value = local.vpc_base_domain_name
+  value       = local.vpc_base_domain_name
+  description = "VPC base domain name"
 }
 
 output "network_id" {
-  value = module.vpc.vpc_id
+  value       = module.vpc.vpc_id
+  description = "VPC ID"
 }
 
 output "network_cidr_block" {
-  value = module.vpc.vpc_cidr_block
+  value       = module.vpc.vpc_cidr_block
+  description = "VPC CIDR range"
 }
 
 output "availability_zones" {
-  value = var.availability_zones
+  value       = var.availability_zones
+  description = "Used availability zones"
 }
 
 output "vpc_id" {
-  value = module.vpc.vpc_id
+  value       = module.vpc.vpc_id
+  description = "VPC ID"
 }
 
 output "internal_subnets" {
-  value = var.internal_subnets
+  value       = var.internal_subnets
+  description = "List of subnet CIDR blocks that are not publicly accessible"
 }
 
 output "internal_subnets_ids" {
-  value = module.vpc.private_subnets
+  value       = module.vpc.private_subnets
+  description = "Private subnet IDs"
 }
 
 output "external_subnets" {
-  value = var.external_subnets
+  description = "List of subnet CIDR blocks that are publicly accessible"
+  value       = var.external_subnets
 }
 
 output "external_subnets_ids" {
-  value = module.vpc.public_subnets
+  value       = module.vpc.public_subnets
+  description = "Public subnet IDs"
 }
 
 output "nat_gateway_ips" {
-  value = module.vpc.nat_public_ips
+  value       = module.vpc.nat_public_ips
+  description = "List of public Elastic IPs created for AWS NAT Gateway"
 }
 
 output "private_route_tables" {
-  value = module.vpc.private_route_table_ids
+  value       = module.vpc.private_route_table_ids
+  description = "List of IDs of private route tables"
 }
 
 output "public_route_tables" {
-  value = module.vpc.public_route_table_ids
+  value       = module.vpc.public_route_table_ids
+  description = "List of IDs of public route tables"
 }

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/variables.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/variables.tf
@@ -1,34 +1,25 @@
 variable "vpc_cidr" {
   description = "CIDR block for the VPC"
   default     = "172.20.0.0/16"
+  type        = string
 }
 
 variable "internal_subnets" {
   type        = list(string)
-  description = "list of subnet CIDR blocks that are not publicly acceessibly"
+  description = "List of subnet CIDR blocks that are not publicly accessible"
   default     = ["172.20.32.0/19", "172.20.64.0/19", "172.20.96.0/19"]
 }
 
 variable "external_subnets" {
   type        = list(string)
-  description = "list of subnet CIDR blocks that are publicly acceessibly"
+  description = "List of subnet CIDR blocks that are publicly accessible"
   default     = ["172.20.0.0/22", "172.20.4.0/22", "172.20.8.0/22"]
 }
 
 variable "availability_zones" {
   type        = list(string)
-  description = "a list of EC2 availability zones"
+  description = "List of EC2 availability zones"
   default     = ["eu-west-2a", "eu-west-2b", "eu-west-2c"]
-}
-
-variable "cluster_node_count" {
-  description = "The number of worker node in the cluster"
-  default     = "21"
-}
-
-variable "worker_node_machine_type" {
-  description = "The AWS EC2 instance types to use for worker nodes"
-  default     = "r5.2xlarge"
 }
 
 variable "cluster_names" {
@@ -36,4 +27,7 @@ variable "cluster_names" {
   default = {
     live-1 = ["live-1.cloud-platform.service.justice.gov.uk", "manager", "live"]
   }
+  type = object({
+    live-1 = list(string)
+  })
 }

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/versions.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/versions.tf
@@ -2,11 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.23.0"
-    }
-    helm = {
-      source  = "hashicorp/helm"
-      version = "~> 2.6.0"
+      version = "4.23.0"
     }
   }
   required_version = ">= 0.14"


### PR DESCRIPTION
This PR updates `terraform/aws-accounts/cloud-platform-aws/account/vpc` to:

- add missing variable/output types and descriptions
- removes providers from `versions.tf` that are unused _directly_ in this root module (as the modules that define them will define version constraints themselves)
- removes unused variables