### PR TITLE
Remove unused root module providers; add missing var types and descriptions

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/.terraform.lock.hcl
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/.terraform.lock.hcl
@@ -1,27 +1,6 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/alexkappa/auth0" {
-  version     = "0.26.2"
-  constraints = "0.26.2"
-  hashes = [
-    "h1:k8ICfvHpOEvz5nsZJirH2VF1RnOEhqIEVpowiVHuzzQ=",
-    "zh:160767ad6cb0a2b176cf21fe811aedf28795e60d8cd71a4ec04e947a45b36e25",
-    "zh:4fcfba389d6f6e460f09e9b164c05cc8f0abb902d58cc0fa30358ae1a64d7ba2",
-    "zh:5a9e3d743e47bc3f11183dbbbf0ce9452778b0a83e2b35dd7ddd505824593a40",
-    "zh:631b857b509d2906f9df2267d361a87771ee682c70c1766f7e52f44991f31ca6",
-    "zh:653abb7dde6c5b172411ddd0939b0ea9497eb636348520ee68365a523f4f0698",
-    "zh:6d1f68280ba51278987de66dfa58151449e3433f2df194b98933717aa4fd5dcb",
-    "zh:7dada33247253a47b9151eb919539ecf46b57cadceb1216b1e39f71e38652585",
-    "zh:90c925e8cb3eecffe2d36891e74918b3e5e1f9b8db72ff378939fa1d588a52eb",
-    "zh:b210c1538d132d38b45e81f497ea0bd58ed096316024fe0707a1f21f3f0f3bfe",
-    "zh:b480fbccf35268f64832c0d82fd99991d3ca3e89bab6489dafc0e734589b1640",
-    "zh:d361ce3f8423f07c1d881eb4da854b06b06302e69b10f739892656a439c5f304",
-    "zh:da2333b98a61ae66d6da33c9558215c581e066e57ce5f9bb17f6e843636ca293",
-    "zh:eb8d027c67258d442eecd45e94251322153fe177d30a6c3851d826acee29cb56",
-  ]
-}
-
 provider "registry.terraform.io/auth0/auth0" {
   version     = "0.34.0"
   constraints = ">= 0.27.0, 0.34.0"

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/outputs.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/outputs.tf
@@ -1,61 +1,76 @@
 output "eks_worker_iam_role_arn" {
-  value = module.eks.worker_iam_role_arn
+  value       = module.eks.worker_iam_role_arn
+  description = "Default IAM role ARN for EKS worker groups"
 }
 
 output "eks_worker_iam_role_name" {
-  value = module.eks.worker_iam_role_name
+  value       = module.eks.worker_iam_role_name
+  description = "Default IAM role name for EKS worker groups"
 }
 
 output "vpc_id" {
-  value = data.aws_vpc.selected.id
+  value       = data.aws_vpc.selected.id
+  description = "VPC ID for current cluster/terraform workspace"
 }
 
 output "internal_subnets" {
-  value = data.aws_subnet.private_cidrs[*].cidr_block
+  value       = data.aws_subnet.private_cidrs[*].cidr_block
+  description = "Private subnet CIDR ranges"
 }
 
 output "internal_subnets_ids" {
-  value = sort(tolist(data.aws_subnets.private.ids))
+  value       = sort(tolist(data.aws_subnets.private.ids))
+  description = "Private subnet IDs"
 }
 
 output "external_subnets_ids" {
-  value = sort(tolist(data.aws_subnets.public.ids))
+  value       = sort(tolist(data.aws_subnets.public.ids))
+  description = "Public subnet IDs"
 }
 
 output "cluster_domain_name" {
-  value = local.fqdn
+  value       = local.fqdn
+  description = "FQDN for the cluster"
 }
 
 output "oidc_issuer_url" {
-  value = "https://justice-cloud-platform.eu.auth0.com/"
+  value       = "https://justice-cloud-platform.eu.auth0.com/"
+  description = "OIDC URL for authentication"
 }
 
 output "oidc_kubernetes_client_id" {
-  value = module.auth0.oidc_kubernetes_client_id
+  value       = module.auth0.oidc_kubernetes_client_id
+  description = "Kubernetes OIDC Client ID"
 }
 
 output "oidc_kubernetes_client_secret" {
-  value     = module.auth0.oidc_kubernetes_client_secret
-  sensitive = true
+  value       = module.auth0.oidc_kubernetes_client_secret
+  sensitive   = true
+  description = "Kubernetes OIDC Client Secret"
 }
 
 output "oidc_components_client_id" {
-  value = module.auth0.oidc_components_client_id
+  value       = module.auth0.oidc_components_client_id
+  description = "Kubernetes OIDC Client ID"
 }
 
 output "oidc_components_client_secret" {
-  value     = module.auth0.oidc_components_client_secret
-  sensitive = true
+  value       = module.auth0.oidc_components_client_secret
+  sensitive   = true
+  description = "Components OIDC Client Secret"
 }
 
 # EKS
 output "cluster_oidc_issuer_url" {
-  value = replace(module.eks.cluster_oidc_issuer_url, "https://", "")
+  value       = replace(module.eks.cluster_oidc_issuer_url, "https://", "")
+  description = "URL on the EKS cluster OIDC Issuer"
 }
 
 output "cluster_id" {
-  value = module.eks.cluster_id
+  value       = module.eks.cluster_id
+  description = "The name/id of the EKS cluster. Will block on cluster creation until the cluster is really ready."
 }
 output "cluster_endpoint" {
-  value = module.eks.cluster_endpoint
+  value       = module.eks.cluster_endpoint
+  description = "The endpoint for your EKS Kubernetes API."
 }

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/variables.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/variables.tf
@@ -1,19 +1,24 @@
 variable "dockerhub_user" {
-  description = "Cloud platform user (see lastpass). This is required to avoid hitting limits when pulling images."
+  description = "DockerHub user for the Cloud Platform (see LastPass). This is required to avoid hitting limits when pulling images."
+  type        = string
 }
 
 variable "dockerhub_token" {
-  description = "Token for the above"
+  description = "DockerHub token for the Cloud Platform user"
+  type        = string
 }
+
 variable "auth0_issuerUrl" {
-  description = "domain IssuerURL by which Auth0 can find the OpenID Provider Configuration Document"
+  description = "Domain issuer URL by which Auth0 can find the OpenID Provider Configuration Document"
   default     = "https://justice-cloud-platform.eu.auth0.com/"
+  type        = string
 }
 
 # Set when Auth0 account is setup in here: /terraform/global-resources/auth0.tf
 variable "auth0_groupsClaim" {
   description = "OIDC Group Claim domain for justice cloud-platform account"
   default     = "https://k8s.integration.dsd.io/groups"
+  type        = string
 }
 
 variable "cluster_enabled_log_types" {

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/versions.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/versions.tf
@@ -12,10 +12,6 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = "2.12.1"
     }
-    alexkappa = {
-      source  = "alexkappa/auth0"
-      version = "0.26.2"
-    }
   }
   required_version = ">= 0.14"
 }


### PR DESCRIPTION
This PR updates `terraform/aws-accounts/cloud-platform-aws/account/vpc/eks` to:

- add missing variable/output types and descriptions
- removes providers from `versions.tf` that are unused _directly_ in this root module (as the modules that define them will define version constraints themselves)