### PR TITLE
Handle missing annotations on a namespace

### DIFF
--- a/test/namespaces_test.go
+++ b/test/namespaces_test.go
@@ -155,7 +155,10 @@ var _ = Describe("Namespaces", func() {
 
 				// Get the annotations
 				annotations := namespace.GetAnnotations()
-				Expect(annotations).ShouldNot(BeEmpty())
+				if len(annotations) == 0 {
+					// Handle empty namepsaces by printing the offending namespace and failing the test
+					Fail("Namespace " + namespace.Name + " has no annotations")
+				}
 			}
 		})
 	})


### PR DESCRIPTION
Previously a failure in the 'it must have appropriate annotations' test would fail and not inform the viewer of how it failed. This commit fails with a custom message, outlining the offending namespace.

An example of this is shown here:
https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/reporting/jobs/live-integration-tests/builds/4895#L62cb9718:136:158
