### PR TITLE
Monitoring release with new PV alert

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -136,7 +136,7 @@ module "logging" {
 }
 
 module "monitoring" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=2.3.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=2.3.4"
 
   alertmanager_slack_receivers               = var.alertmanager_slack_receivers
   pagerduty_config                           = var.pagerduty_config


### PR DESCRIPTION
This release changes the PV alert to only notify on PVs owned by the CP team and not cluster wide PVs