### PR TITLE
Fix flaky test retry from 3 to 2

### DIFF
--- a/test/certmanager_test.go
+++ b/test/certmanager_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Default ingress-controller certificate", func() {
 
 // It includes FlakeAttempts to ensure that the test doesn't fail on the chance
 // of a slow acme response.
-var _ = Describe("cert-manager", FlakeAttempts(3), func() {
+var _ = Describe("cert-manager", FlakeAttempts(2), func() {
 	Context("when the namespace has a certificate resource", func() {
 		var (
 			namespace, host string


### PR DESCRIPTION
This means we don't fail by timing out (25mins), but rather fail because of the test failing.
