### PR TITLE
Reconfigure Dependabot to run on Wednesday 09:00 UTC, and limit to 1 pull request per directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,64 +7,92 @@ version: 2
 updates:
   - package-ecosystem: "github-actions" # See documentation for possible values
     directory: "/" # Location of package manifests
+    open-pull-requests-limit: 1
     schedule:
       interval: "weekly"
+      day: "wednesday"
+      time: "09:00" # UTC
   - package-ecosystem: "gomod"
     directory: "/"
+    open-pull-requests-limit: 1
     schedule:
       interval: "weekly"
+      day: "wednesday"
+      time: "09:00"
   - package-ecosystem: "terraform"
     directory: "/terraform/aws-accounts/cloud-platform-aws/account"
+    open-pull-requests-limit: 1
     schedule:
       interval: "weekly"
-      day: "sunday"
+      day: "wednesday"
+      time: "09:00"
   - package-ecosystem: "terraform"
     directory: "/terraform/aws-accounts/cloud-platform-aws/vpc"
+    open-pull-requests-limit: 1
     schedule:
       interval: "weekly"
-      day: "sunday"
+      day: "wednesday"
+      time: "09:00"
   - package-ecosystem: "terraform"
     directory: "/terraform/aws-accounts/cloud-platform-aws/vpc/eks"
+    open-pull-requests-limit: 1
     schedule:
       interval: "weekly"
-      day: "sunday"
+      day: "wednesday"
+      time: "09:00"
   - package-ecosystem: "terraform"
     directory: "/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components"
+    open-pull-requests-limit: 1
     schedule:
       interval: "weekly"
-      day: "sunday"
+      day: "wednesday"
+      time: "09:00"
   - package-ecosystem: "terraform"
     directory: "/terraform/aws-accounts/cloud-platform-aws/vpc/kops"
+    open-pull-requests-limit: 1
     schedule:
       interval: "weekly"
-      day: "sunday"
+      day: "wednesday"
+      time: "09:00"
   - package-ecosystem: "terraform"
     directory: "/terraform/aws-accounts/cloud-platform-dsd"
+    open-pull-requests-limit: 1
     schedule:
       interval: "weekly"
-      day: "sunday"
+      day: "wednesday"
+      time: "09:00"
   - package-ecosystem: "terraform"
     directory: "/terraform/aws-accounts/cloud-platform-ephemeral-test/account"
+    open-pull-requests-limit: 1
     schedule:
       interval: "weekly"
-      day: "sunday"
+      day: "wednesday"
+      time: "09:00"
   - package-ecosystem: "terraform"
     directory: "/terraform/aws-accounts/cloud-platform-ephemeral-test/vpc"
+    open-pull-requests-limit: 1
     schedule:
       interval: "weekly"
-      day: "sunday"
+      day: "wednesday"
+      time: "09:00"
   - package-ecosystem: "terraform"
     directory: "/terraform/aws-accounts/cloud-platform-ephemeral-test/vpc/eks"
+    open-pull-requests-limit: 1
     schedule:
       interval: "weekly"
-      day: "sunday"
+      day: "wednesday"
+      time: "09:00"
   - package-ecosystem: "terraform"
     directory: "/terraform/aws-accounts/cloud-platform-ephemeral-test/vpc/eks/components"
+    open-pull-requests-limit: 1
     schedule:
       interval: "weekly"
-      day: "sunday"
+      day: "wednesday"
+      time: "09:00"
   - package-ecosystem: "terraform"
     directory: "/terraform/global-resources"
+    open-pull-requests-limit: 1
     schedule:
       interval: "weekly"
-      day: "sunday"
+      day: "wednesday"
+      time: "09:00"


### PR DESCRIPTION
This PR updates each Dependabot configuration to:

- run on Wednesday at 09:00 UTC rather than on a Sunday at any time
- limit open pull requests for each directory to _1 (one)_ at a time

This is a result of a [team conversation](https://mojdt.slack.com/archives/C514ETYJX/p1660557207947019) to move from a Sunday, when those on-call will get an alert, and also reduces the amount of allowed open PRs from `dependabot` to allow team members to focus on one Terraform provider update at a time for each configuration.