### PR TITLE
Remove velero from expected namespaces, not installed by default

### DIFF
--- a/test/config/config.go
+++ b/test/config/config.go
@@ -125,7 +125,7 @@ func (c *Config) ExpectedPromRules() {
 // ExpectedNamespaces returns a slice of all the namespaces
 // that are expected to be in the cluster.
 func (c *Config) ExpectedNamespaces() {
-	c.Namespaces = append(c.Namespaces, "cert-manager", "ingress-controllers", "logging", "monitoring", "opa", "velero")
+	c.Namespaces = append(c.Namespaces, "cert-manager", "ingress-controllers", "logging", "monitoring", "opa")
 }
 
 // ExpectedServices returns a slice of all the Services


### PR DESCRIPTION
This will fix the integration tests running on test cluster which expects velero to exists