### PR TITLE
Update opa module dependency

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -164,7 +164,7 @@ module "monitoring" {
 
 module "opa" {
   source     = "github.com/ministryofjustice/cloud-platform-terraform-opa?ref=0.4.3"
-  depends_on = [module.monitoring.prometheus_operator_crds_status, module.modsec_ingress_controllers, module.modsec_ingress_controllers_v1, module.cert_manager]
+  depends_on = [module.monitoring, module.modsec_ingress_controllers, module.modsec_ingress_controllers_v1, module.cert_manager]
 
   cluster_domain_name            = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   enable_invalid_hostname_policy = lookup(local.prod_workspace, terraform.workspace, false) ? false : true


### PR DESCRIPTION
This is to fix the error:

Error: Internal error occurred: failed calling webhook "webhook.openpolicyagent.org":
 Post "https://opa.opa.svc:443/?timeout=10s":
 no endpoints available for service "opa"