### PR TITLE
Add default priority-class

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/k8s-resources.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/k8s-resources.tf
@@ -114,6 +114,16 @@ resource "kubernetes_priority_class" "node_critical" {
   global_default = false
 }
 
+resource "kubernetes_priority_class" "default" {
+  metadata {
+    name = "default"
+  }
+
+  value          = 0
+  description    = "Default priority class for all pods."
+  global_default = true
+}
+
 ########
 # RBAC #
 ########


### PR DESCRIPTION
This PR will create a default priority class on all clusters. 

The default priority class (Value=0) will be used for all pods which do not specify any other priority class. This will be the same for the majority of user pods. 

The default class is also required before implementing overprovision pods which will be used to help manage resources for cluster autoscaling. 