### PR TITLE
better Elasticache metrics

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -139,7 +139,7 @@ module "logging" {
 }
 
 module "monitoring" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=2.3.6"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=2.3.7"
 
   alertmanager_slack_receivers               = var.alertmanager_slack_receivers
   pagerduty_config                           = var.pagerduty_config


### PR DESCRIPTION
Add clusterID option to allow filtering elasticache metrics by cluster by @poornima-krishnasamy in https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/pull/140