### PR TITLE
Add live-2 cluster to the production standard clusters list

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/.terraform.lock.hcl
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "4.26.0"
   constraints = ">= 3.63.0, 4.26.0"
   hashes = [
+    "h1:jt8jLpFFhaapdbBqw4WQpDuLN8y7zF8/iLyCzypDxSQ=",
     "h1:q0QTY+O5L//LGGkmlUlEvTLnNSsdV91Tqm7BFqwpSII=",
     "zh:0579b105ae471894846fbd740bc9f10b2bd8a48860d8e640b4a9b53fb7d63ffe",
     "zh:0ce445cfbffb6c0eee9e0e2a95850b5749d56aa8211b95a686c24dc2847a36ea",

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
@@ -22,23 +22,27 @@ locals {
   # https://github.com/terraform-aws-modules/terraform-aws-eks/issues/835
   node_groups_count = {
     live    = "54"
+    live-2  = "7"
     manager = "4"
     default = "3"
   }
   # To manage different cluster versions
   cluster_version = {
     live    = "1.21"
+    live-2  = "1.21"
     manager = "1.21"
     default = "1.21"
   }
   node_size = {
     live    = ["r5.xlarge", "r5.2xlarge", "r5a.xlarge"]
+    live-2  = ["r5.xlarge", "r5.2xlarge", "r5a.xlarge"]
     manager = ["m5.xlarge", "m5.2xlarge", "m5a.xlarge"]
     default = ["m5.large", "m5.xlarge", "m5a.large"]
   }
 
   monitoring_node_size = {
     live    = ["r4.2xlarge", "r5.2xlarge"]
+    live-2  = ["r4.2xlarge", "r5.2xlarge"]
     manager = ["t3.medium", "t2.medium"]
     default = ["t3.medium", "t2.medium"]
   }

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -1,5 +1,5 @@
 module "concourse" {
-  count  = lookup(local.manager_workspace, terraform.workspace, false)
+  count  = lookup(local.manager_workspace, terraform.workspace, false) ? 1 : 0
   source = "github.com/ministryofjustice/cloud-platform-terraform-concourse?ref=1.10.2"
 
   concourse_hostname                                = data.terraform_remote_state.cluster.outputs.cluster_domain_name

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -62,7 +62,7 @@ module "ingress_controllers" {
 
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   # To allow 'live' cluster to create hosts under *.cloud-platform.service.justice..
-  is_live_cluster     = terraform.workspace == "live" ? true : false
+  is_live_cluster     = lookup(local.prod_workspace, terraform.workspace, false)
   live1_cert_dns_name = lookup(local.live1_cert_dns_name, terraform.workspace, "")
 
   # This module requires prometheus and cert-manager
@@ -89,7 +89,7 @@ module "ingress_controllers_v1" {
   controller_name     = "default"
   enable_latest_tls   = true
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
-  is_live_cluster     = terraform.workspace == "live" ? true : false
+  is_live_cluster     = lookup(local.prod_workspace, terraform.workspace, false)
   live1_cert_dns_name = lookup(local.live1_cert_dns_name, terraform.workspace, "")
 
   # Enable this when we remove the module "ingress_controllers"
@@ -106,7 +106,7 @@ module "modsec_ingress_controllers_v1" {
   replica_count       = "6"
   controller_name     = "modsec"
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
-  is_live_cluster     = terraform.workspace == "live" ? true : false
+  is_live_cluster     = lookup(local.prod_workspace, terraform.workspace, false)
   live1_cert_dns_name = lookup(local.live1_cert_dns_name, terraform.workspace, "")
   enable_modsec       = true
   enable_owasp        = true
@@ -171,8 +171,8 @@ module "opa" {
 
   cluster_domain_name            = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   enable_invalid_hostname_policy = lookup(local.prod_workspace, terraform.workspace, false) ? false : true
-  enable_external_dns_weight     = terraform.workspace == "live" ? true : false
-  cluster_color                  = terraform.workspace == "live" ? "green" : "black"
+  enable_external_dns_weight     = lookup(local.live_workspace, terraform.workspace, false)
+  cluster_color                  = lookup(local.live_cluster_colors, terraform.workspace, "black")
   integration_test_zone          = data.aws_route53_zone.integrationtest.name
 }
 

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -62,7 +62,7 @@ module "ingress_controllers" {
 
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   # To allow 'live' cluster to create hosts under *.cloud-platform.service.justice..
-  is_live_cluster     = terraform.workspace == "live" ? 1 : 0
+  is_live_cluster     = terraform.workspace == "live" ? true : false
   live1_cert_dns_name = lookup(local.live1_cert_dns_name, terraform.workspace, "")
 
   # This module requires prometheus and cert-manager
@@ -89,7 +89,7 @@ module "ingress_controllers_v1" {
   controller_name     = "default"
   enable_latest_tls   = true
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
-  is_live_cluster     = terraform.workspace == "live" ? 1 : 0
+  is_live_cluster     = terraform.workspace == "live" ? true : false
   live1_cert_dns_name = lookup(local.live1_cert_dns_name, terraform.workspace, "")
 
   # Enable this when we remove the module "ingress_controllers"
@@ -106,7 +106,7 @@ module "modsec_ingress_controllers_v1" {
   replica_count       = "6"
   controller_name     = "modsec"
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
-  is_live_cluster     = terraform.workspace == "live" ? 1 : 0
+  is_live_cluster     = terraform.workspace == "live" ? true : false
   live1_cert_dns_name = lookup(local.live1_cert_dns_name, terraform.workspace, "")
   enable_modsec       = true
   enable_owasp        = true

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -148,13 +148,13 @@ module "monitoring" {
   oidc_components_client_id                  = data.terraform_remote_state.cluster.outputs.oidc_components_client_id
   oidc_components_client_secret              = data.terraform_remote_state.cluster.outputs.oidc_components_client_secret
   oidc_issuer_url                            = data.terraform_remote_state.cluster.outputs.oidc_issuer_url
-  enable_thanos_sidecar                      = lookup(local.prod_workspace, terraform.workspace, false)
+  enable_thanos_sidecar                      = lookup(local.prod_2_workspace, terraform.workspace, false)
   enable_large_nodesgroup                    = lookup(local.live_workspace, terraform.workspace, false)
   enable_prometheus_affinity_and_tolerations = true
   enable_kibana_audit_proxy                  = terraform.workspace == "live" ? true : false
   enable_kibana_proxy                        = terraform.workspace == "live" ? true : false
 
-  enable_thanos_helm_chart = lookup(local.prod_workspace, terraform.workspace, false)
+  enable_thanos_helm_chart = lookup(local.prod_2_workspace, terraform.workspace, false)
   enable_thanos_compact    = lookup(local.manager_workspace, terraform.workspace, false)
 
   enable_ecr_exporter           = lookup(local.live_workspace, terraform.workspace, false)
@@ -170,7 +170,7 @@ module "opa" {
   depends_on = [module.monitoring, module.modsec_ingress_controllers, module.modsec_ingress_controllers_v1, module.cert_manager]
 
   cluster_domain_name            = data.terraform_remote_state.cluster.outputs.cluster_domain_name
-  enable_invalid_hostname_policy = lookup(local.prod_workspace, terraform.workspace, false) ? false : true
+  enable_invalid_hostname_policy = lookup(local.prod_2_workspace, terraform.workspace, false) ? false : true
   enable_external_dns_weight     = lookup(local.live_workspace, terraform.workspace, false)
   cluster_color                  = lookup(local.live_cluster_colors, terraform.workspace, "black")
   integration_test_zone          = data.aws_route53_zone.integrationtest.name
@@ -179,7 +179,7 @@ module "opa" {
 module "starter_pack" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-starter-pack?ref=0.1.7"
 
-  enable_starter_pack = lookup(local.prod_workspace, terraform.workspace, false) ? false : true
+  enable_starter_pack = lookup(local.prod_2_workspace, terraform.workspace, false) ? false : true
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
 
   depends_on = [
@@ -191,7 +191,7 @@ module "starter_pack" {
 module "velero" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-velero?ref=1.8.2"
 
-  enable_velero               = lookup(local.prod_workspace, terraform.workspace, false)
+  enable_velero               = lookup(local.prod_2_workspace, terraform.workspace, false)
   dependence_prometheus       = module.monitoring.prometheus_operator_crds_status
   cluster_domain_name         = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   eks_cluster_oidc_issuer_url = data.terraform_remote_state.cluster.outputs.cluster_oidc_issuer_url

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/main.tf
@@ -91,7 +91,7 @@ locals {
   # live_workspace refer to all production workspaces which have users workload in it
   live_workspace = {
     live    = true
-    live-1  = true
+    live-2  = true
     default = false
   }
 

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/main.tf
@@ -87,7 +87,8 @@ locals {
     default = false
   }
 
-  # prod_2_workspace is a temporary workspace covering all prod std clusters until live-2 is build
+  # prod_2_workspace is a temporary workspace to include live-2 on the modules that are tested.
+  # Once all the modules are tested, this list will replace the prod_workspace
   prod_2_workspace = {
     manager = true
     live    = true

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/main.tf
@@ -118,9 +118,9 @@ locals {
   # live_cluster_colors refer to the color for external-dns set-identifier annotation 
   # set on all production cluster which have users workload in it
   live_cluster_colors = {
-    live    = green
-    live-2 = blue
-    default = black
+    live    = "green"
+    live-2 = "blue"
+    default = "black"
   }
 
   

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/main.tf
@@ -91,7 +91,7 @@ locals {
   prod_2_workspace = {
     manager = true
     live    = true
-    live-2 = true
+    live-2  = true
     default = false
   }
 

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/main.tf
@@ -90,7 +90,7 @@ locals {
   # live_workspace refer to all production workspaces which have users workload in it
   live_workspace = {
     live    = true
-    live-2 = true
+    live-2  = true
     default = false
   }
 
@@ -105,7 +105,7 @@ locals {
       "arn:aws:route53:::hostedzone/${data.aws_route53_zone.cloud_platform.zone_id}",
       "arn:aws:route53:::hostedzone/${data.aws_route53_zone.integrationtest.zone_id}"
     ]
-    live   = ["arn:aws:route53:::hostedzone/*"]
+    live = ["arn:aws:route53:::hostedzone/*"]
     default = [
       "arn:aws:route53:::hostedzone/${data.aws_route53_zone.selected.zone_id}",
       "arn:aws:route53:::hostedzone/${data.aws_route53_zone.integrationtest.zone_id}"
@@ -119,11 +119,11 @@ locals {
   # set on all production cluster which have users workload in it
   live_cluster_colors = {
     live    = "green"
-    live-2 = "blue"
+    live-2  = "blue"
     default = "black"
   }
 
-  
+
 }
 
 #####################################

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/main.tf
@@ -80,14 +80,16 @@ data "aws_route53_zone" "cloud_platform" {
 ##########
 
 locals {
+  # prod_workspace refer to all production workspaces which have active monitoring set and followed
   prod_workspace = {
     manager = true
     live    = true
+    live-2    = true
     default = false
   }
 
-  cloudwatch_workspace = {
-    manager = false
+  # live_workspace refer to all production workspaces which have users workload in it
+  live_workspace = {
     live    = true
     live-1  = true
     default = false
@@ -95,7 +97,6 @@ locals {
 
   manager_workspace = {
     manager = true
-    live    = false
     default = false
   }
 
@@ -106,6 +107,7 @@ locals {
       "arn:aws:route53:::hostedzone/${data.aws_route53_zone.integrationtest.zone_id}"
     ]
     live = ["arn:aws:route53:::hostedzone/*"]
+    live-2 = ["arn:aws:route53:::hostedzone/*"]
     default = [
       "arn:aws:route53:::hostedzone/${data.aws_route53_zone.selected.zone_id}",
       "arn:aws:route53:::hostedzone/${data.aws_route53_zone.integrationtest.zone_id}"

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/main.tf
@@ -84,14 +84,13 @@ locals {
   prod_workspace = {
     manager = true
     live    = true
-    live-2  = true
     default = false
   }
 
   # live_workspace refer to all production workspaces which have users workload in it
   live_workspace = {
     live    = true
-    live-2  = true
+    live-2 = true
     default = false
   }
 
@@ -107,7 +106,6 @@ locals {
       "arn:aws:route53:::hostedzone/${data.aws_route53_zone.integrationtest.zone_id}"
     ]
     live   = ["arn:aws:route53:::hostedzone/*"]
-    live-2 = ["arn:aws:route53:::hostedzone/*"]
     default = [
       "arn:aws:route53:::hostedzone/${data.aws_route53_zone.selected.zone_id}",
       "arn:aws:route53:::hostedzone/${data.aws_route53_zone.integrationtest.zone_id}"
@@ -116,6 +114,17 @@ locals {
   live1_cert_dns_name = {
     live = format("- '*.apps.%s'", var.live1_domain)
   }
+
+
+  # live_cluster_colors refer to the color for external-dns set-identifier annotation 
+  set on all production cluster which have users workload in it
+  live_cluster_colors = {
+    live    = green
+    live-2 = blue
+    default = black
+  }
+
+  
 }
 
 #####################################

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/main.tf
@@ -87,6 +87,14 @@ locals {
     default = false
   }
 
+  # prod_2_workspace is a temporary workspace covering all prod std clusters until live-2 is build
+  prod_2_workspace = {
+    manager = true
+    live    = true
+    live-2 = true
+    default = false
+  }
+
   # live_workspace refer to all production workspaces which have users workload in it
   live_workspace = {
     live    = true

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/main.tf
@@ -115,9 +115,8 @@ locals {
     live = format("- '*.apps.%s'", var.live1_domain)
   }
 
-
   # live_cluster_colors refer to the color for external-dns set-identifier annotation 
-  set on all production cluster which have users workload in it
+  # set on all production cluster which have users workload in it
   live_cluster_colors = {
     live    = green
     live-2 = blue

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/main.tf
@@ -84,7 +84,7 @@ locals {
   prod_workspace = {
     manager = true
     live    = true
-    live-2    = true
+    live-2  = true
     default = false
   }
 
@@ -106,7 +106,7 @@ locals {
       "arn:aws:route53:::hostedzone/${data.aws_route53_zone.cloud_platform.zone_id}",
       "arn:aws:route53:::hostedzone/${data.aws_route53_zone.integrationtest.zone_id}"
     ]
-    live = ["arn:aws:route53:::hostedzone/*"]
+    live   = ["arn:aws:route53:::hostedzone/*"]
     live-2 = ["arn:aws:route53:::hostedzone/*"]
     default = [
       "arn:aws:route53:::hostedzone/${data.aws_route53_zone.selected.zone_id}",

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/storage.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/storage.tf
@@ -44,7 +44,7 @@ resource "kubernetes_storage_class" "io1" {
 
   parameters = {
     type      = "io1"
-    iopsPerGB = "10000"
+    iopsPerGB = "26"
     fsType    = "ext4"
   }
 }

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/variables.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/variables.tf
@@ -20,11 +20,13 @@ variable "elasticsearch_hosts_maps" {
   default = {
     manager = "search-cloud-platform-live-dibidbfud3uww3lpxnhj2jdws4.eu-west-2.es.amazonaws.com"
     live    = "search-cloud-platform-live-dibidbfud3uww3lpxnhj2jdws4.eu-west-2.es.amazonaws.com"
+    live-2    = "search-cloud-platform-live-dibidbfud3uww3lpxnhj2jdws4.eu-west-2.es.amazonaws.com"
   }
 
   type = object({
     manager = string
     live    = string
+    live-2 = string
   })
 }
 
@@ -34,11 +36,13 @@ variable "elasticsearch_audit_hosts_maps" {
   default = {
     manager = "search-cloud-platform-audit-live-hfclvgaq73cul7ku362rvigti4.eu-west-2.es.amazonaws.com"
     live    = "search-cloud-platform-audit-live-hfclvgaq73cul7ku362rvigti4.eu-west-2.es.amazonaws.com"
+    live-2    = "search-cloud-platform-audit-live-hfclvgaq73cul7ku362rvigti4.eu-west-2.es.amazonaws.com"
   }
 
   type = object({
     manager = string
     live    = string
+    live-2 = string
   })
 }
 

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/variables.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/variables.tf
@@ -20,13 +20,13 @@ variable "elasticsearch_hosts_maps" {
   default = {
     manager = "search-cloud-platform-live-dibidbfud3uww3lpxnhj2jdws4.eu-west-2.es.amazonaws.com"
     live    = "search-cloud-platform-live-dibidbfud3uww3lpxnhj2jdws4.eu-west-2.es.amazonaws.com"
-    live-2    = "search-cloud-platform-live-dibidbfud3uww3lpxnhj2jdws4.eu-west-2.es.amazonaws.com"
+    live-2  = "search-cloud-platform-live-dibidbfud3uww3lpxnhj2jdws4.eu-west-2.es.amazonaws.com"
   }
 
   type = object({
     manager = string
     live    = string
-    live-2 = string
+    live-2  = string
   })
 }
 
@@ -36,13 +36,13 @@ variable "elasticsearch_audit_hosts_maps" {
   default = {
     manager = "search-cloud-platform-audit-live-hfclvgaq73cul7ku362rvigti4.eu-west-2.es.amazonaws.com"
     live    = "search-cloud-platform-audit-live-hfclvgaq73cul7ku362rvigti4.eu-west-2.es.amazonaws.com"
-    live-2    = "search-cloud-platform-audit-live-hfclvgaq73cul7ku362rvigti4.eu-west-2.es.amazonaws.com"
+    live-2  = "search-cloud-platform-audit-live-hfclvgaq73cul7ku362rvigti4.eu-west-2.es.amazonaws.com"
   }
 
   type = object({
     manager = string
     live    = string
-    live-2 = string
+    live-2  = string
   })
 }
 

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/main.tf
@@ -38,7 +38,6 @@ locals {
 
   # Some clusters (like manager) need extra callbacks URLs in auth0
   auth0_extra_callbacks = {
-    manager = ["https://sonarqube.cloud-platform.service.justice.gov.uk/oauth2/callback/oidc"]
     live = concat([for i in ["prometheus", "alertmanager", "thanos"] : "https://${i}.${local.fqdn}/oauth2/callback"],
     ["https://grafana.${local.fqdn}/login/generic_oauth"])
   }

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/main.tf
@@ -31,6 +31,12 @@ locals {
   vpc_tags = merge({
     "kubernetes.io/cluster/${local.vpc_name}" = "shared"
   }, local.cluster_tags)
+
+  prod_workspace = {
+    live-1  = true
+    live-2  = true
+    default = false
+  }
 }
 
 #######
@@ -72,6 +78,6 @@ module "vpc" {
 ### 
 module "flowlogs" {
   source     = "github.com/ministryofjustice/cloud-platform-terraform-flow-logs?ref=1.3.2"
-  is_enabled = terraform.workspace == "live-1" ? true : false
+  is_enabled = lookup(local.prod_workspace, terraform.workspace, false)
   vpc_id     = module.vpc.vpc_id
 }

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/main.tf
@@ -78,6 +78,6 @@ module "vpc" {
 ### 
 module "flowlogs" {
   source     = "github.com/ministryofjustice/cloud-platform-terraform-flow-logs?ref=1.3.2"
-  is_enabled = lookup(local.prod_workspace, terraform.workspace, false)
+  is_enabled = terraform.workspace == "live-1" ? true : false
   vpc_id     = module.vpc.vpc_id
 }


### PR DESCRIPTION
-  add `live-2` to the list of production clusters listed in this repo. This PR include live-2 as production for monitoring and opa modules which differ from test clusters.
- does-not include `live-2` to production list for ingress-controllers, cert-manager, and external-dns modules

Related to: https://github.com/ministryofjustice/cloud-platform/issues/4101