### PR TITLE
Install cluster-autoscaler

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -33,6 +33,14 @@ module "concourse" {
   depends_on = [module.ingress_controllers]
 }
 
+module "cluster_autoscaler" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-cluster-autoscaler?ref=1.0.2"
+
+  enable_overprovision        = lookup(local.prod_workspace, terraform.workspace, false)
+  cluster_domain_name         = data.terraform_remote_state.cluster.outputs.cluster_domain_name
+  eks_cluster_id              = data.terraform_remote_state.cluster.outputs.cluster_id
+  eks_cluster_oidc_issuer_url = data.terraform_remote_state.cluster.outputs.cluster_oidc_issuer_url
+}
 module "cert_manager" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-certmanager?ref=1.5.1"
 


### PR DESCRIPTION
This PR installs the cloud-platform-terraform-cluster-autoscaler module which includes:

cluster-autoscaler
cluster-overprovisioner
cluster-proportional-autoscaler