### PR TITLE
Set minimum number of nodes 2 for node groups 

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
@@ -50,7 +50,7 @@ locals {
   default_ng = {
     desired_capacity     = lookup(local.node_groups_count, terraform.workspace, local.node_groups_count["default"])
     max_capacity         = 60
-    min_capacity         = 1
+    min_capacity         = 2
     subnets              = data.aws_subnets.private.ids
     bootstrap_extra_args = "--use-max-pods false"
     kubelet_extra_args   = "--max-pods=110"
@@ -76,7 +76,7 @@ locals {
   monitoring_ng = {
     desired_capacity = 2
     max_capacity     = 3
-    min_capacity     = 1
+    min_capacity     = 2
     subnets          = data.aws_subnets.private_zone_2b.ids
 
     create_launch_template = true


### PR DESCRIPTION
Set a minimum of nodes to 2 to not have a single point of failure for monitoring nodes which can get scaled down to 1 node group by cluster-autoscaler  