### PR TITLE
Validation for external_dns_weight annotation

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-TAG := 2.2.3
+TAG := 2.2.6
 TOOLS_IMAGE := ministryofjustice/cloud-platform-tools
 TEST_IMAGE := ministryofjustice/cloud-platform-infrastructure
 

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -179,8 +179,9 @@ module "opa" {
 
   cluster_domain_name            = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   enable_invalid_hostname_policy = lookup(local.prod_2_workspace, terraform.workspace, false) ? false : true
-  enable_external_dns_weight     = lookup(local.live_workspace, terraform.workspace, false)
-  cluster_color                  = lookup(local.live_cluster_colors, terraform.workspace, "black")
+  # Validation for external_dns_weight annotation is enabled only on the "live" cluster
+  enable_external_dns_weight     = terraform.workspace == "live" ? true : false
+  cluster_color                  = terraform.workspace == "live" ? "green" : "black"
   integration_test_zone          = data.aws_route53_zone.integrationtest.name
 }
 

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -180,9 +180,9 @@ module "opa" {
   cluster_domain_name            = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   enable_invalid_hostname_policy = lookup(local.prod_2_workspace, terraform.workspace, false) ? false : true
   # Validation for external_dns_weight annotation is enabled only on the "live" cluster
-  enable_external_dns_weight     = terraform.workspace == "live" ? true : false
-  cluster_color                  = terraform.workspace == "live" ? "green" : "black"
-  integration_test_zone          = data.aws_route53_zone.integrationtest.name
+  enable_external_dns_weight = terraform.workspace == "live" ? true : false
+  cluster_color              = terraform.workspace == "live" ? "green" : "black"
+  integration_test_zone      = data.aws_route53_zone.integrationtest.name
 }
 
 module "starter_pack" {

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/main.tf
@@ -123,16 +123,6 @@ locals {
   live1_cert_dns_name = {
     live = format("- '*.apps.%s'", var.live1_domain)
   }
-
-  # live_cluster_colors refer to the color for external-dns set-identifier annotation 
-  # set on all production cluster which have users workload in it
-  live_cluster_colors = {
-    live    = "green"
-    live-2  = "blue"
-    default = "black"
-  }
-
-
 }
 
 #####################################


### PR DESCRIPTION
This OPA policy is enabled only on the "live" cluster, all other clusters will not have this check