### PR TITLE
Remove elasticsearch_hosts_maps for live-2

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/variables.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/variables.tf
@@ -25,7 +25,6 @@ variable "elasticsearch_hosts_maps" {
   type = object({
     manager = string
     live    = string
-    live-2  = string
   })
 }
 
@@ -40,7 +39,6 @@ variable "elasticsearch_audit_hosts_maps" {
   type = object({
     manager = string
     live    = string
-    live-2  = string
   })
 }
 

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/variables.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/variables.tf
@@ -20,7 +20,6 @@ variable "elasticsearch_hosts_maps" {
   default = {
     manager = "search-cloud-platform-live-dibidbfud3uww3lpxnhj2jdws4.eu-west-2.es.amazonaws.com"
     live    = "search-cloud-platform-live-dibidbfud3uww3lpxnhj2jdws4.eu-west-2.es.amazonaws.com"
-    live-2  = "search-cloud-platform-live-dibidbfud3uww3lpxnhj2jdws4.eu-west-2.es.amazonaws.com"
   }
 
   type = object({
@@ -36,7 +35,6 @@ variable "elasticsearch_audit_hosts_maps" {
   default = {
     manager = "search-cloud-platform-audit-live-hfclvgaq73cul7ku362rvigti4.eu-west-2.es.amazonaws.com"
     live    = "search-cloud-platform-audit-live-hfclvgaq73cul7ku362rvigti4.eu-west-2.es.amazonaws.com"
-    live-2  = "search-cloud-platform-audit-live-hfclvgaq73cul7ku362rvigti4.eu-west-2.es.amazonaws.com"
   }
 
   type = object({

--- a/test/logging_test.go
+++ b/test/logging_test.go
@@ -98,7 +98,7 @@ var _ = Describe("logging", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		FIt("should be able to retrieve the log message", func() {
+		It("should be able to retrieve the log message", func() {
 			var podName string
 
 			// To get the pod name, we need to first get all pods in the namespace.

--- a/test/logging_test.go
+++ b/test/logging_test.go
@@ -32,7 +32,7 @@ var _ = Describe("logging", func() {
 		)
 
 		BeforeEach(func() {
-			if !strings.HasPrefix(c.ClusterName, "live") {
+			if !strings.Contains(strings.ToLower(c.ClusterName), "live") {
 				Skip("Only live logs go to the Elasticsearch cluster")
 			}
 

--- a/test/logging_test.go
+++ b/test/logging_test.go
@@ -28,12 +28,12 @@ var _ = Describe("logging", func() {
 		var (
 			elasticSearch = "https://search-cloud-platform-live-dibidbfud3uww3lpxnhj2jdws4.eu-west-2.es.amazonaws.com"
 			date          = time.Now().Format("2006.01.02")
-			search        = elasticSearch + "/live_kubernetes_cluster" + "-" + date + "/_search"
+			search        = elasticSearch + "/" + c.ClusterName + "_kubernetes_cluster" + "-" + date + "/_search"
 		)
 
 		BeforeEach(func() {
-			if !strings.Contains(strings.ToLower(c.ClusterName), "live") {
-				Skip("Only live logs go to the Elasticsearch cluster")
+			if !(c.ClusterName == "live") && !(c.ClusterName == "manager") {
+				Skip(fmt.Sprintf("Logs don't go to elasticsearch for cluster: %s", c.ClusterName))
 			}
 
 			// Create a helloworld app
@@ -98,7 +98,7 @@ var _ = Describe("logging", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("should be able to retrieve the log message", func() {
+		FIt("should be able to retrieve the log message", func() {
 			var podName string
 
 			// To get the pod name, we need to first get all pods in the namespace.


### PR DESCRIPTION
live-2 don't have permission to write to the existing "live" elastic search, as it is not on the same VPC.

This will be added once a new OpenSearch ES cluster is created for live-2