### PR TITLE
Use nginxinc/nginx-unprivileged for logging test

### DIFF
--- a/test/fixtures/logging-job.yaml.tmpl
+++ b/test/fixtures/logging-job.yaml.tmpl
@@ -9,5 +9,5 @@ spec:
       restartPolicy: Never
       containers:
       - name: smoketest-logging
-        image: bitnami/nginx
+        image: nginxinc/nginx-unprivileged
         command: ["curl", "-s", "-XGET", "{{ .searchTerm }}", "-H", 'Content-Type: application/json', "-d", '{ "query": { "bool": { "must": [ { "match": { "kubernetes.namespace_name.keyword": "{{ .namespace }}" } } ] } } }']


### PR DESCRIPTION
This is to fix the error using bitnami:nginx

OCI runtime create failed: container_linux.go:380: starting container process caused: exec: "curl":
executable file not found in $PATH: unknown