### PR TITLE
Update replica count for modsec ingress controller

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -85,7 +85,7 @@ module "modsec_ingress_controllers" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-modsec-ingress-controller?ref=0.3.3"
 
   controller_name = "modsec01"
-  replica_count   = "6"
+  replica_count   = terraform.workspace == "live" ? "6" : "2"
 
   depends_on = [module.ingress_controllers]
 }


### PR DESCRIPTION
This is for 0.3.3 module version modsec ingress controller, to have 2 replica for non live cluster