### PR TITLE
Add prometheus crd dependency for kuberhealthy and autoscaler

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -40,6 +40,10 @@ module "cluster_autoscaler" {
   cluster_domain_name         = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   eks_cluster_id              = data.terraform_remote_state.cluster.outputs.cluster_id
   eks_cluster_oidc_issuer_url = data.terraform_remote_state.cluster.outputs.cluster_oidc_issuer_url
+
+  depends_on = [
+    module.monitoring.prometheus_operator_crds_status
+  ]
 }
 module "cert_manager" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-certmanager?ref=1.5.1"

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -208,4 +208,8 @@ module "velero" {
 
 module "kuberhealthy" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-kuberhealthy?ref=1.0.4"
+
+  depends_on = [
+    module.monitoring.prometheus_operator_crds_status
+  ]
 }


### PR DESCRIPTION
This is to fix the cluster creation failure.

Error: unable to build kubernetes objects from release manifest: resource mapping not found for name: "kuberhealthy" namespace: "kuberhealthy" from "": no matches for kind "ServiceMonitor" in version "monitoring.coreos.com/v1" ensure CRDs are installed first