### PR TITLE
Delete live-1 audit cluster

### DIFF
--- a/terraform/global-resources/elasticsearch.tf
+++ b/terraform/global-resources/elasticsearch.tf
@@ -232,7 +232,7 @@ resource "aws_elasticsearch_domain" "audit_live" {
   }
 
   tags = {
-    Domain = local.audit_domain
+    Domain = local.audit_live_domain
   }
 
   log_publishing_options {

--- a/terraform/global-resources/elasticsearch.tf
+++ b/terraform/global-resources/elasticsearch.tf
@@ -26,11 +26,8 @@ locals {
     "35.178.11.229"  = "live-2-c"
   }
 
-  audit_domain = "cloud-platform-audit"
-
   audit_live_domain = "cloud-platform-audit-live"
 
-  allowed_audit_1_ips = local.allowed_live_1_ips
   # for tests, use something like merge(local.allowed_live_1_ips, { "88.98.227.149" = "raz" })
 
   allowed_audit_live_ips = local.allowed_live_1_ips
@@ -162,42 +159,6 @@ data "template_file" "ism_policy" {
   })
 }
 
-data "aws_iam_policy_document" "audit_1" {
-  statement {
-    actions = [
-      "es:AddTags",
-      "es:ESHttpHead",
-      "es:DescribeElasticsearchDomain",
-      "es:ESHttpPost",
-      "es:ESHttpGet",
-      "es:ESHttpPut",
-      "es:DescribeElasticsearchDomainConfig",
-      "es:ListTags",
-      "es:DescribeElasticsearchDomains",
-      "es:ListDomainNames",
-      "es:ListElasticsearchInstanceTypes",
-      "es:DescribeElasticsearchInstanceTypeLimits",
-      "es:ListElasticsearchVersions",
-    ]
-
-    resources = [
-      "arn:aws:es:${data.aws_region.moj-cp.name}:${data.aws_caller_identity.moj-cp.account_id}:domain/${local.audit_domain}/*",
-    ]
-
-    principals {
-      type        = "AWS"
-      identifiers = ["*"]
-    }
-
-    condition {
-      test     = "IpAddress"
-      variable = "aws:SourceIp"
-
-      values = keys(local.allowed_audit_1_ips)
-    }
-  }
-}
-
 data "aws_iam_policy_document" "audit_live" {
   statement {
     actions = [
@@ -231,52 +192,6 @@ data "aws_iam_policy_document" "audit_live" {
 
       values = keys(local.allowed_audit_live_ips)
     }
-  }
-}
-
-# audit cluster for live-1
-resource "aws_elasticsearch_domain" "audit_1" {
-  domain_name           = local.audit_domain
-  provider              = aws.cloud-platform
-  elasticsearch_version = "7.10"
-
-  cluster_config {
-    instance_type            = "m6g.xlarge.elasticsearch"
-    instance_count           = "2"
-    dedicated_master_enabled = true
-    dedicated_master_type    = "r6g.large.elasticsearch"
-    dedicated_master_count   = "3"
-    zone_awareness_enabled   = true
-    warm_count               = 2
-    warm_enabled             = true
-    warm_type                = "ultrawarm1.medium.elasticsearch"
-  }
-
-  ebs_options {
-    ebs_enabled = "true"
-    volume_type = "gp3"
-    volume_size = "1536"
-    iops        = 4608
-  }
-
-  advanced_options = {
-    "rest.action.multi.allow_explicit_index" = "true"
-    "override_main_response_version"         = "true"
-  }
-
-  access_policies = data.aws_iam_policy_document.audit_1.json
-
-  snapshot_options {
-    automated_snapshot_start_hour = 23
-  }
-
-  tags = {
-    Domain = local.audit_domain
-  }
-  log_publishing_options {
-    cloudwatch_log_group_arn = "arn:aws:logs:${data.aws_region.moj-cp.name}:${data.aws_caller_identity.moj-cp.account_id}:log-group:/aws/OpenSearchService/domains/${local.audit_domain}/application-logs"
-    enabled                  = true
-    log_type                 = "ES_APPLICATION_LOGS"
   }
 }
 
@@ -364,16 +279,6 @@ module "live_elasticsearch_monitoring" {
   sns_topic         = data.terraform_remote_state.account.outputs.slack_sns_topic
 
   alarm_cluster_status_is_yellow_periods = 10
-}
-
-module "audit_elasticsearch_monitoring" {
-  source  = "dubiety/elasticsearch-cloudwatch-sns-alarms/aws"
-  version = "3.0.3"
-
-  alarm_name_prefix = "cloud-platform-audit-"
-  domain_name       = local.audit_domain
-  create_sns_topic  = false
-  sns_topic         = data.terraform_remote_state.account.outputs.slack_sns_topic
 }
 
 module "audit_live_elasticsearch_monitoring" {


### PR DESCRIPTION
Audit for EKS live cluster is maintained in cloud-watch. Also we have audit-live used for EKS live cluster currently