### PR TITLE
Disable alerts for test clusters by default

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -155,8 +155,8 @@ module "logging" {
 module "monitoring" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=2.3.8"
 
-  alertmanager_slack_receivers               = var.alertmanager_slack_receivers
-  pagerduty_config                           = var.pagerduty_config
+  alertmanager_slack_receivers               = local.enable_alerts ? var.alertmanager_slack_receivers : []
+  pagerduty_config                           = local.enable_alerts ? var.pagerduty_config : ""
   cluster_domain_name                        = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   oidc_components_client_id                  = data.terraform_remote_state.cluster.outputs.oidc_components_client_id
   oidc_components_client_secret              = data.terraform_remote_state.cluster.outputs.oidc_components_client_secret

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/main.tf
@@ -96,6 +96,9 @@ locals {
     default = false
   }
 
+  # Disable alerts to test clusters by default
+  enable_alerts = lookup(local.prod_2_workspace, terraform.workspace, false)
+
   # live_workspace refer to all production workspaces which have users workload in it
   live_workspace = {
     live    = true


### PR DESCRIPTION
- This will avoid high-priority alerts for test clusters

While building test clusters we replace tokens with dummy values, but applying changes from main to test clusters will add them back and cause accidental alerts to be a high and low priority.

This change will build test clusters without enabling alerts by default and if needed in test clusters, it has an option to enable it.