### PR TITLE
Update monitoring to fix alerts for test cluster

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -155,8 +155,8 @@ module "logging" {
 module "monitoring" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=2.3.8"
 
-  alertmanager_slack_receivers               = local.enable_alerts ? var.alertmanager_slack_receivers : []
-  pagerduty_config                           = local.enable_alerts ? var.pagerduty_config : ""
+  alertmanager_slack_receivers               = local.enable_alerts ? var.alertmanager_slack_receivers : [{ severity = "dummy", webhook = "https://dummy.slack.com", channel = "#dummy-alarms" }]
+  pagerduty_config                           = local.enable_alerts ? var.pagerduty_config : "dummy"
   cluster_domain_name                        = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   oidc_components_client_id                  = data.terraform_remote_state.cluster.outputs.oidc_components_client_id
   oidc_components_client_secret              = data.terraform_remote_state.cluster.outputs.oidc_components_client_secret


### PR DESCRIPTION
This is to fix alertmanager for test cluster, by passin g dummy values, as there is a "count = length(var.alertmanager_slack_receivers)", to create resources