### PR TITLE
Add TXT record for google search console ownership verification

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/account/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/main.tf
@@ -62,6 +62,14 @@ resource "aws_route53_zone" "cloud_platform_justice_gov_uk" {
   name = "cloud-platform.service.justice.gov.uk."
 }
 
+resource "aws_route53_record" "cloud_platform_justice_gov_uk_TXT" {
+  zone_id = aws_route53_zone.cloud_platform_justice_gov_uk.zone_id
+  name    = aws_route53_zone.cloud_platform_justice_gov_uk.name
+  type    = "TXT"
+  ttl     = "300"
+  records = ["google-site-verification=IorKX8xdhHmAEnI4O1LtGPgQwQiFtRJpPFABmzyCN1E"]
+}
+
 module "ecr_fluentbit" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials?ref=4.8"
 


### PR DESCRIPTION
This is needed for setting up google search console for domain: cloud-platform.service.justice.gov.uk.
