### PR TITLE
Reduce ES instance count back to 5 and 3 and fix ism policy 

### DIFF
--- a/terraform/global-resources/elasticsearch.tf
+++ b/terraform/global-resources/elasticsearch.tf
@@ -99,7 +99,7 @@ resource "aws_elasticsearch_domain" "live_1" {
 
   cluster_config {
     instance_type            = "r6g.4xlarge.elasticsearch"
-    instance_count           = "7"
+    instance_count           = "5"
     dedicated_master_enabled = true
     dedicated_master_type    = "m6g.xlarge.elasticsearch"
     dedicated_master_count   = "3"
@@ -107,7 +107,7 @@ resource "aws_elasticsearch_domain" "live_1" {
     zone_awareness_config {
       availability_zone_count = 3
     }
-    warm_count   = 5
+    warm_count   = 3
     warm_enabled = true
     warm_type    = "ultrawarm1.medium.elasticsearch"
     cold_storage_options {

--- a/terraform/global-resources/variables.tf
+++ b/terraform/global-resources/variables.tf
@@ -1,6 +1,6 @@
 variable "timestamp_field" {
   type        = string
-  default     = "last_updated"
+  default     = "@timestamp"
   description = "Field Kibana identifies as Time field, when creating the index pattern"
 }
 


### PR DESCRIPTION
This PR reduces warm and hot instances count to original count. 

The instances were increases to fix the low disk space: https://github.com/ministryofjustice/cloud-platform-infrastructure/pull/1926. The issue of with the ISM policy with the warm to cold migration is fixed, so the count can be reduced.