### PR TITLE
Bump terraform module for eventrouter upgrade

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -152,7 +152,7 @@ module "kuberos" {
 }
 
 module "logging" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-logging?ref=1.3.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-logging?ref=1.3.4"
 
   elasticsearch_host       = lookup(var.elasticsearch_hosts_maps, terraform.workspace, "placeholder-elasticsearch")
   elasticsearch_audit_host = lookup(var.elasticsearch_audit_hosts_maps, terraform.workspace, "placeholder-elasticsearch")


### PR DESCRIPTION
Related to: https://github.com/ministryofjustice/cloud-platform/issues/4176

https://github.com/ministryofjustice/cloud-platform-terraform-logging/releases/tag/1.3.4