### PR TITLE
increase modsec replica count in live to 9

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -100,7 +100,7 @@ module "ingress_controllers_v1" {
 module "modsec_ingress_controllers_v1" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.1.0"
 
-  replica_count          = "6"
+  replica_count          = terraform.workspace == "live" ? 9 : 6
   controller_name        = "modsec"
   cluster_domain_name    = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   is_live_cluster        = lookup(local.prod_workspace, terraform.workspace, false)


### PR DESCRIPTION
as part of ongoing checks into connection timeout issues for hmpps auth