### PR TITLE
Upgrade monitoring components

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -137,7 +137,7 @@ module "logging" {
 }
 
 module "monitoring" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=2.4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=2.5.0"
 
   alertmanager_slack_receivers               = local.enable_alerts ? var.alertmanager_slack_receivers : [{ severity = "dummy", webhook = "https://dummy.slack.com", channel = "#dummy-alarms" }]
   pagerduty_config                           = local.enable_alerts ? var.pagerduty_config : "dummy"


### PR DESCRIPTION
This has the following.

- Upgrade cloudwatch-exporter and iam-assumable-role-with-oidc used by cloudwatch-exporter
- Maintain IRSA(iam-assumable-role-with-oidc) module locally as the latest self assumed role has a dependency on terraform version
- Upgrade grafana
- Move grafana to the manager node group
- Upgrade grafana sidecar.