### PR TITLE
Run go-vet-lint workflow, when workflow is updated

### DIFF
--- a/.github/workflows/go-vet-lint-deps.yaml
+++ b/.github/workflows/go-vet-lint-deps.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "**.go"
+      - ".github/workflows/go-vet-lint-deps.yaml"
 
 jobs:
   build:


### PR DESCRIPTION
This PR will enable the running of the `go-vet-lint` workflow, when the workflow is updated. It's useful to be able to test _workflow updates_ without having to use the manual workflow-dispatch.