### PR TITLE
Turn off Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ version: 2
 updates:
   - package-ecosystem: "github-actions" # See documentation for possible values
     directory: "/" # Location of package manifests
-    # open-pull-requests-limit: 0
+    open-pull-requests-limit: 0
     schedule:
       interval: "weekly"
       day: "wednesday"
@@ -21,28 +21,28 @@ updates:
       time: "09:00"
   - package-ecosystem: "terraform"
     directory: "/terraform/aws-accounts/cloud-platform-aws/account"
-    # open-pull-requests-limit: 0
+    open-pull-requests-limit: 0
     schedule:
       interval: "weekly"
       day: "wednesday"
       time: "09:00"
   - package-ecosystem: "terraform"
     directory: "/terraform/aws-accounts/cloud-platform-aws/vpc"
-    # open-pull-requests-limit: 0
+    open-pull-requests-limit: 0
     schedule:
       interval: "weekly"
       day: "wednesday"
       time: "09:00"
   - package-ecosystem: "terraform"
     directory: "/terraform/aws-accounts/cloud-platform-aws/vpc/eks"
-    # open-pull-requests-limit: 0
+    open-pull-requests-limit: 0
     schedule:
       interval: "weekly"
       day: "wednesday"
       time: "09:00"
   - package-ecosystem: "terraform"
     directory: "/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components"
-    # open-pull-requests-limit: 0
+    open-pull-requests-limit: 0
     schedule:
       interval: "weekly"
       day: "wednesday"
@@ -91,7 +91,7 @@ updates:
       time: "09:00"
   - package-ecosystem: "terraform"
     directory: "/terraform/global-resources"
-    # open-pull-requests-limit: 0
+    open-pull-requests-limit: 0
     schedule:
       interval: "weekly"
       day: "wednesday"


### PR DESCRIPTION
This PR turns off Dependabot again, as upgrades are finished for today.

Completed today (06/12/2022):
- github-actions
- terraform/aws-accounts/cloud-platform-aws/account
- terraform/aws-accounts/cloud-platform-aws/vpc
- terraform/aws-accounts/cloud-platform-aws/vpc/eks
- terraform/global-resources