### PR TITLE
Update terraform-aws-modules/s3-bucket/aws to 3.6.0 and 2.14.0 respectively

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/account/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/main.tf
@@ -84,7 +84,7 @@ module "ecr_fluentbit" {
 
 module "s3_bucket_thanos" {
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "3.3.0"
+  version = "3.6.0"
 
   bucket = "cloud-platform-prometheus-thanos"
   acl    = "private"
@@ -110,7 +110,7 @@ module "s3_bucket_thanos" {
 
 module "s3_bucket_velero" {
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "1.18.0"
+  version = "2.14.0" # 2.15 pins to terraform-aws-provider <= 4, so this module needs to be upgraded to 3.6.0, which has some resource changes (which may require manual intervention for terraform state imports)
 
   bucket = "cloud-platform-velero-backups"
   acl    = "private"
@@ -136,7 +136,7 @@ module "s3_bucket_velero" {
 
 module "s3_bucket_kubeconfigs" {
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "3.3.0"
+  version = "3.6.0"
 
   bucket = "cloud-platform-concourse-kubeconfig"
   acl    = "private"


### PR DESCRIPTION
This PR produces `no changes` with a Terraform plan, but nonetheless:

- updates `s3_bucket_thanos` and `s3_bucket_kubeconfigs` from `v3.3.0` to `v3.6.0` of the module
- updates `s3_bucket_velero` from `v1.18.0` to `v2.14.0`, as `v2.15` pins terraform-aws-provider to <= 4; and `v3.0.0` produces changes that may require manual intervention

This PR is solely to produce no-op module updates before tackling hands-on updates.