### PR TITLE
Allow tflint workflow to fail

### DIFF
--- a/.github/workflows/tflint.yml
+++ b/.github/workflows/tflint.yml
@@ -21,4 +21,4 @@ jobs:
       - run: find . -type f -name "*.tfvars" -delete # remove terraform variable files before linting
       - run: tflint --version
       - run: tflint --init
-      - run: tflint -f compact --recursive -c $(realpath .tflint.hcl) --force
+      - run: tflint -f compact --recursive -c $(realpath .tflint.hcl)


### PR DESCRIPTION
This PR removes the `--force` flag from the TFLint workflow, to allow a failure in the workflow, which _should_ stop anyone merging PRs that fail linting.