### PR TITLE
Introduce TFSec scanning

### DIFF
--- a/.github/workflows/terraform-tools.yml
+++ b/.github/workflows/terraform-tools.yml
@@ -22,3 +22,16 @@ jobs:
       - run: tflint --version
       - run: tflint --init
       - run: tflint -f compact --recursive -c $(realpath .tflint.hcl)
+  tfsec:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: aquasecurity/tfsec-sarif-action@v0.1.4
+        with:
+          tfsec_args: --force-all-dirs --soft-fail -m=CRITICAL --no-module-downloads --exclude-path=terraform/aws-accounts/cloud-platform-ephemeral-test --exclude-path=terraform/aws-accounts/cloud-platform-dsd --exclude-path=terraform/aws-accounts/cloud-platform-aws/vpc/kops --exclude-path=terraform/modules
+          sarif_file: tfsec.sarif
+      - uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: tfsec.sarif


### PR DESCRIPTION
This PR introduces a job to run [tfsec](https://github.com/aquasecurity/tfsec) against this repository, and then upload the SARIF output to allow the team to view issues (if any) in the [Code Scanning](https://github.com/ministryofjustice/cloud-platform-infrastructure/security/code-scanning) view of the Security tab.

`tfsec` is currently configured to run with the following flags:

```sh
tfsec
--force-all-dirs # forces a full repository scan, recursively
--soft-fail # forces an exit code 0 on the workflow
-m=CRITICAL # sets the minimum severity to be reported as `CRITICAL`, to reduce the nose as we fix issues
--no-module-downloads # doesn't download modules, to reduce the noise as we fix issues
--exclude-path=terraform/aws-accounts/cloud-platform-ephemeral-test # ignores this unused directory
--exclude-path=terraform/aws-accounts/cloud-platform-dsd # ignores this limited directory
--exclude-path=terraform/aws-accounts/cloud-platform-aws/vpc/kops # ignores this unused directory
--exclude-path=terraform/modules # ignores self-defined modules unless they're used elsewhere
```

The `Code scanning results` will **always** fail if there are any _errors_ listed in the SARIF file, as you can't [turn off Only errors reporting](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#defining-the-severities-causing-pull-request-check-failure).