### PR TITLE
Enable Dependabot for github-actions, as these aren't particularly noisy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,6 @@ version: 2
 updates:
   - package-ecosystem: "github-actions" # See documentation for possible values
     directory: "/" # Location of package manifests
-    open-pull-requests-limit: 0
     schedule:
       interval: "weekly"
       day: "wednesday"


### PR DESCRIPTION
This PR re-enables Dependabot for GitHub actions, as they aren't particularly noisy and should be kept up to date.