### PR TITLE
Add psp trivy-system group priveledges, add trivy-operator call

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -59,7 +59,7 @@ module "cert_manager" {
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   hostzone            = lookup(local.hostzones, terraform.workspace, local.hostzones["default"])
 
-  # Requiring Prometheus taints the default cert null_resource on any monitoring upgrade, 
+  # Requiring Prometheus taints the default cert null_resource on any monitoring upgrade,
   # but cluster creation fails without, so will have to be temporarily disabled when upgrading
   dependence_prometheus = module.monitoring.prometheus_operator_crds_status
   dependence_opa        = "ignore"
@@ -93,7 +93,7 @@ module "ingress_controllers_v1" {
   enable_external_dns_annotation = true
 
   # Dependency on this ingress_controllers module as IC namespace and default certificate created in this module
-  # This dependency will go away once "module.ingress_controllers" is removed. 
+  # This dependency will go away once "module.ingress_controllers" is removed.
   dependence_certmanager = module.cert_manager.helm_cert_manager_status
 }
 
@@ -204,7 +204,14 @@ module "kuberhealthy" {
 }
 
 module "trivy-operator" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-trivy-operator?ref=0.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-trivy-operator?ref=0.2.0"
+
+  cluster_domain_name         = data.terraform_remote_state.cluster.outputs.cluster_domain_name
+  eks_cluster_oidc_issuer_url = data.terraform_remote_state.cluster.outputs.cluster_oidc_issuer_url
+
+  dockerhub_username          = var.dockerhub_username
+  dockerhub_password          = var.dockerhub_password
+  github_token                = var.github_token
 
   severity_list = "MEDIUM,HIGH,CRITICAL"
 }

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -204,7 +204,7 @@ module "kuberhealthy" {
 }
 
 module "trivy-operator" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-trivy-operator"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-trivy-operator?ref=0.1"
 
   severity_list = "MEDIUM,HIGH,CRITICAL"
 }

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -209,9 +209,9 @@ module "trivy-operator" {
   cluster_domain_name         = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   eks_cluster_oidc_issuer_url = data.terraform_remote_state.cluster.outputs.cluster_oidc_issuer_url
 
-  dockerhub_username          = var.dockerhub_username
-  dockerhub_password          = var.dockerhub_password
-  github_token                = var.github_token
+  dockerhub_username = var.dockerhub_username
+  dockerhub_password = var.dockerhub_password
+  github_token       = var.github_token
 
   severity_list = "MEDIUM,HIGH,CRITICAL"
 }

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -202,3 +202,10 @@ module "kuberhealthy" {
 
   dependence_prometheus = module.monitoring.prometheus_operator_crds_status
 }
+
+module "trivy-operator" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-trivy-operator"
+
+  severity_list = "MEDIUM,HIGH,CRITICAL"
+}
+

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/psp.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/psp.tf
@@ -185,7 +185,6 @@ resource "kubernetes_cluster_role_binding" "privileged" {
     kind      = "Group"
     name      = "system:serviceaccounts:trivy-system"
     api_group = "rbac.authorization.k8s.io"
-    namespace = "trivy-system"
   }
 }
 

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/psp.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/psp.tf
@@ -181,6 +181,12 @@ resource "kubernetes_cluster_role_binding" "privileged" {
     name      = "efs-csi-node-sa"
     namespace = "kube-system"
   }
+  subject {
+    kind      = "Group"
+    name      = "system:serviceaccounts:trivy-system"
+    api_group = "rbac.authorization.k8s.io"
+    namespace = "trivy-system"
+  }
 }
 
 ## Pod Security Policy: restricted


### PR DESCRIPTION
Overview
---

This PR contains terraform config that installs trivy-operator (and all associated trimmings) into a Cloud Platform Kubernetes cluster. By calling the `cloud-platform-trivy-operator` module, we invoke a helm install which creates the deployment, etc. Users will interact with the operator by either running:

```bash
kubectl get vuln -n <my_namespace>
kubectl describe vuln -n <my_namespace> <vuln_id>
```

There's also a Prometheus metrics scrape, which should enable users and admins to visualise the results in Prometheus and Grafana.

What we do with these results is up to the team.