### PR TITLE
upgrade trivy to latest release, add prometheus crd dependency

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -207,7 +207,7 @@ module "trivy-operator" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-trivy-operator?ref=0.2.1"
 
   depends_on = [
-    module.monitoring.prometheus.operator_crds_status
+    module.monitoring.prometheus_operator_crds_status
   ]
 
   cluster_domain_name         = data.terraform_remote_state.cluster.outputs.cluster_domain_name

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -204,7 +204,11 @@ module "kuberhealthy" {
 }
 
 module "trivy-operator" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-trivy-operator?ref=0.2.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-trivy-operator?ref=0.2.1"
+
+  depends_on = [
+    module.monitoring.prometheus.operator_crds_status
+  ]
 
   cluster_domain_name         = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   eks_cluster_oidc_issuer_url = data.terraform_remote_state.cluster.outputs.cluster_oidc_issuer_url


### PR DESCRIPTION
This PR adds the following changes:
* Trivy-operator version bump to provision the operator with increased CPU and memory requests/limits for greater workload in `live` cluster(s)
* A `depends_on` Prometheus CRDs for trivy-operator module (required for ServiceMonitor)