### PR TITLE
Enable `gomod` in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
       time: "09:00" # UTC
   - package-ecosystem: "gomod"
     directory: "/"
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 10
     schedule:
       interval: "weekly"
       day: "wednesday"


### PR DESCRIPTION
This PR enables `gomod` in Dependabot, with an open pull request limit of 10 PRs.