### PR TITLE
Revert terraform version

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/main.tf
@@ -95,7 +95,7 @@ module "vpc" {
 
 ### 
 module "flowlogs" {
-  source     = "github.com/ministryofjustice/cloud-platform-terraform-flow-logs?ref=1.3.3"
+  source     = "github.com/ministryofjustice/cloud-platform-terraform-flow-logs?ref=1.3.2"
   is_enabled = terraform.workspace == "live-1" ? true : false
   vpc_id     = module.vpc.vpc_id
 }

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/versions.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/versions.tf
@@ -5,5 +5,5 @@ terraform {
       version = "4.48.0"
     }
   }
-  required_version = ">= 1.2.5"
+  required_version = ">=0.14"
 }

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/versions.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/versions.tf
@@ -5,5 +5,5 @@ terraform {
       version = "4.48.0"
     }
   }
-  required_version = ">=0.14"
+  required_version = "> =0.14"
 }

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/versions.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/versions.tf
@@ -5,5 +5,5 @@ terraform {
       version = "4.48.0"
     }
   }
-  required_version = "> =0.14"
+  required_version = ">= 0.14"
 }


### PR DESCRIPTION
versions.tf terraform version reverted to 0.14 for vpc and flow logs module to fix failing create cluster concourse pipelines whilst upgrade testing is in progress