### PR TITLE
update trivy-operator module version

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -204,7 +204,7 @@ module "kuberhealthy" {
 }
 
 module "trivy-operator" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-trivy-operator?ref=0.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-trivy-operator?ref=0.2.3"
 
   depends_on = [
     module.monitoring.prometheus_operator_crds_status


### PR DESCRIPTION
this will reduce concurrent scan job limit in Helm values from 10 to 5