### PR TITLE
trivy-operator module bump

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -204,7 +204,7 @@ module "kuberhealthy" {
 }
 
 module "trivy-operator" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-trivy-operator?ref=0.2.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-trivy-operator?ref=0.2.4"
 
   depends_on = [
     module.monitoring.prometheus_operator_crds_status


### PR DESCRIPTION
this trivy-operator release increases the vulnerability report scan job timeout from 5m to 10m