### PR TITLE
Bump monitoring module to 2.5.4

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -137,7 +137,7 @@ module "logging" {
 }
 
 module "monitoring" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=2.5.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=2.5.4"
 
   alertmanager_slack_receivers               = local.enable_alerts ? var.alertmanager_slack_receivers : [{ severity = "dummy", webhook = "https://dummy.slack.com", channel = "#dummy-alarms" }]
   pagerduty_config                           = local.enable_alerts ? var.pagerduty_config : "dummy"


### PR DESCRIPTION
Details of release: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/releases/tag/2.5.4