### PR TITLE
update versions.tf to 1.2.5 in vpc, eks, components

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/versions.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/versions.tf
@@ -25,5 +25,5 @@ terraform {
       version = "3.2.1"
     }
   }
-  required_version = ">= 0.14"
+  required_version = ">= 1.2.5"
 }

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/versions.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/versions.tf
@@ -13,5 +13,5 @@ terraform {
       version = "2.16.1"
     }
   }
-  required_version = ">= 0.14"
+  required_version = ">= 1.2.5"
 }

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/versions.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/versions.tf
@@ -5,5 +5,5 @@ terraform {
       version = "4.48.0"
     }
   }
-  required_version = ">= 0.14"
+  required_version = ">= 1.2.5"
 }


### PR DESCRIPTION
This PR covers step 1 in terraform upgrade for cloud-platform-infrastructure repo as per:

1) PR for versions.tf update vpc/eks/components
2) merge all module terraform version update PRs and set new releases
3) PR for module version updates across vpc/eks/components