### PR TITLE
update tf provider in vpc, eks and components versions.tf

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/versions.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/versions.tf
@@ -25,5 +25,5 @@ terraform {
       version = "3.2.1"
     }
   }
-  required_version = ">= 0.14"
+  required_version = ">= 1.2.5"
 }

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/versions.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/versions.tf
@@ -13,5 +13,5 @@ terraform {
       version = "2.16.1"
     }
   }
-  required_version = ">= 0.14"
+  required_version = ">= 1.2.5"
 }

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/versions.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/versions.tf
@@ -5,5 +5,5 @@ terraform {
       version = "4.48.0"
     }
   }
-  required_version = ">= 0.14"
+  required_version = ">= 1.2.5"
 }


### PR DESCRIPTION
This PR updates all instances of terraform provider version constraint in `versions.tf` to `>= 1.2.5` at vpc, eks and components layer