### PR TITLE
fix run_and_output execute function call argument syntax

### DIFF
--- a/create-cluster.rb
+++ b/create-cluster.rb
@@ -168,7 +168,7 @@ def execute(cmd, can_fail: false)
 end
 
 def run_and_output(cmd, opts = {})
-  puts execute(cmd, opts)
+  puts execute(cmd, **opts)
 end
 
 def usage


### PR DESCRIPTION
This PR addresses failing create cluster pipeline #4431
https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/eks-create-test-destroy/jobs/create-cluster-eks/builds/308#L63ffdeca:8

Caused by tools image ruby version upgrade from `2.6` to `3.1`. See:
https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/


