### PR TITLE
bump trivy-operator release

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -204,7 +204,7 @@ module "kuberhealthy" {
 }
 
 module "trivy-operator" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-trivy-operator?ref=0.4.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-trivy-operator?ref=0.4.1"
 
   depends_on = [
     module.monitoring.prometheus_operator_crds_status


### PR DESCRIPTION
Turn off clusterComplianceEnabled reporting which defaults to true (we are only interested in vulnerability scanning at this time)

as per trivy PR:
https://github.com/ministryofjustice/cloud-platform-terraform-trivy-operator/pull/24