### PR TITLE
restore trivy job concurrency to 1

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -217,7 +217,7 @@ module "trivy-operator" {
   dockerhub_password = var.dockerhub_password
   github_token       = var.github_token
 
-  job_concurrency_limit = 2
+  job_concurrency_limit = 1
   scan_job_timeout      = "10m"
   trivy_timeout         = "10m0s"
   severity_list         = "HIGH,CRITICAL"


### PR DESCRIPTION
scaling down re OOMKilled errors for vulnerabilityreport pods