### PR TITLE
remove github token from trivy-operator helm values

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -216,7 +216,6 @@ module "trivy-operator" {
 
   dockerhub_username = var.dockerhub_username
   dockerhub_password = var.dockerhub_password
-  github_token       = var.github_token
 
   job_concurrency_limit = 1
   scan_job_timeout      = "10m"


### PR DESCRIPTION
github token is only required for standalone mode, removed now we are in clientServer mode