### PR TITLE
bump trivy-operator release

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -205,7 +205,7 @@ module "kuberhealthy" {
 }
 
 module "trivy-operator" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-trivy-operator?ref=0.4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-trivy-operator?ref=0.5.0"
 
   depends_on = [
     module.monitoring.prometheus_operator_crds_status


### PR DESCRIPTION
This PR brings trivy-operator to latest helm release, fixes `Reconciler error` issues for disabled `ClusterComplianceReport` resources:

https://github.com/aquasecurity/trivy-operator/issues/1078