### PR TITLE
Bump logging module to 1.5.0

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -129,12 +129,13 @@ module "kuberos" {
 }
 
 module "logging" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-logging?ref=1.4.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-logging?ref=1.5.0"
 
-  elasticsearch_host       = lookup(var.elasticsearch_hosts_maps, terraform.workspace, "placeholder-elasticsearch")
-  elasticsearch_audit_host = lookup(var.elasticsearch_audit_hosts_maps, terraform.workspace, "placeholder-elasticsearch")
-  dependence_prometheus    = module.monitoring.prometheus_operator_crds_status
-  enable_curator_cronjob   = terraform.workspace == "live" ? true : false
+  elasticsearch_host              = lookup(var.elasticsearch_hosts_maps, terraform.workspace, "placeholder-elasticsearch")
+  elasticsearch_audit_host        = lookup(var.elasticsearch_audit_hosts_maps, terraform.workspace, "placeholder-elasticsearch")
+  elasticsearch_modsec_audit_host = lookup(var.elasticsearch_modsec_audit_hosts_maps, terraform.workspace, "placeholder-elasticsearch")
+  dependence_prometheus           = module.monitoring.prometheus_operator_crds_status
+  enable_curator_cronjob          = terraform.workspace == "live" ? true : false
 }
 
 module "monitoring" {

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/variables.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/variables.tf
@@ -44,6 +44,22 @@ variable "elasticsearch_audit_hosts_maps" {
   })
 }
 
+
+variable "elasticsearch_modsec_audit_hosts_maps" {
+  description = "Cloud Platform ModSec audit Opensearch hosts for each Terraform workspace"
+
+  default = {
+    manager = "search-cp-live-modsec-audit-nuhzlrjwxrmdd6op3mvj2k5mye.eu-west-2.es.amazonaws.com"
+    live    = "search-cp-live-modsec-audit-nuhzlrjwxrmdd6op3mvj2k5mye.eu-west-2.es.amazonaws.com"
+  }
+
+  type = object({
+    manager = string
+    live    = string
+  })
+}
+
+
 # Concourse vars
 variable "github_auth_client_id" {
   type        = string

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/variables.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/variables.tf
@@ -49,11 +49,11 @@ variable "elasticsearch_modsec_audit_hosts_maps" {
   description = "Cloud Platform ModSec audit Opensearch hosts for each Terraform workspace"
 
   default = {
-    live    = "search-cp-live-modsec-audit-nuhzlrjwxrmdd6op3mvj2k5mye.eu-west-2.es.amazonaws.com"
+    live = "search-cp-live-modsec-audit-nuhzlrjwxrmdd6op3mvj2k5mye.eu-west-2.es.amazonaws.com"
   }
 
   type = object({
-    live    = string
+    live = string
   })
 }
 

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/variables.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/variables.tf
@@ -49,12 +49,10 @@ variable "elasticsearch_modsec_audit_hosts_maps" {
   description = "Cloud Platform ModSec audit Opensearch hosts for each Terraform workspace"
 
   default = {
-    manager = "search-cp-live-modsec-audit-nuhzlrjwxrmdd6op3mvj2k5mye.eu-west-2.es.amazonaws.com"
     live    = "search-cp-live-modsec-audit-nuhzlrjwxrmdd6op3mvj2k5mye.eu-west-2.es.amazonaws.com"
   }
 
   type = object({
-    manager = string
     live    = string
   })
 }


### PR DESCRIPTION
This module streams logs from ingress-controllers filtered for modsec logs to `cp-live-modsec-audit` Opensearch cluster