### PR TITLE
feat: 🎸 enable document level security on modsec logs

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -129,7 +129,7 @@ module "kuberos" {
 }
 
 module "logging" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-logging?ref=1.5.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-logging?ref=1.6.1"
 
   elasticsearch_host              = lookup(var.elasticsearch_hosts_maps, terraform.workspace, "placeholder-elasticsearch")
   elasticsearch_audit_host        = lookup(var.elasticsearch_audit_hosts_maps, terraform.workspace, "placeholder-elasticsearch")


### PR DESCRIPTION
- As webops we will continue to be able to see all logs
- Users will only have access to logs which are tagged with their github team and they are also a member of that team

Part of [#4504]https://github.com/ministryofjustice/cloud-platform/issues/4504