### PR TITLE
fix: 🐛 override document level permissions for webops team

### DIFF
--- a/terraform/aws-accounts/cloud-platform-ephemeral-test/account/opensearch.tf
+++ b/terraform/aws-accounts/cloud-platform-ephemeral-test/account/opensearch.tf
@@ -271,6 +271,35 @@ resource "elasticsearch_opensearch_roles_mapping" "security_manager" {
   ]
 }
 
+# Prevent document security overriding webops role by explicitly allowing webops to view all
+resource "elasticsearch_opensearch_role" "webops" {
+  role_name   = "webops"
+  description = "role for all webops github users"
+
+  cluster_permissions = ["*"]
+
+  index_permissions {
+    index_patterns          = ["*"]
+    allowed_actions         = ["cluster_all", "indices_all", "unlimited"]
+    document_level_security = "{\"match_all\": {}}"
+  }
+
+  tenant_permissions {
+    tenant_patterns = ["global_tenant"]
+    allowed_actions = ["kibana_all_write"]
+  }
+}
+
+resource "elasticsearch_opensearch_roles_mapping" "webops" {
+  role_name     = "webops"
+  description   = "Mapping AWS IAM roles to ES role webops"
+  backend_roles = ["webops"]
+  depends_on = [
+    aws_opensearch_domain_saml_options.live_modsec_audit,
+    elasticsearch_opensearch_role.webops
+  ]
+}
+
 # Create a role that restricts users from viewing documents for teams they are not members of
 resource "elasticsearch_opensearch_role" "all_org_members" {
   role_name   = "all_org_members"
@@ -287,7 +316,7 @@ resource "elasticsearch_opensearch_role" "all_org_members" {
     index_patterns  = ["live_k8s_modsec_ingress-*"]
     allowed_actions = ["read", "search", "data_access"]
 
-    document_level_security = "{\"terms\": { \"github_team\": [$${user.roles}]}}"
+    document_level_security = "{\"terms\": { \"github_teams\": [$${user.roles}]}}"
   }
 
   tenant_permissions {


### PR DESCRIPTION
Fixes minor bug where the document level security permissions were also applied to the webops team