### PR TITLE
fix: 🐛 opensearch needs exact search (match - in teamnames!)

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/account/opensearch.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/opensearch.tf
@@ -316,7 +316,7 @@ resource "elasticsearch_opensearch_role" "all_org_members" {
     index_patterns  = ["live_k8s_modsec_ingress-*"]
     allowed_actions = ["read", "search", "data_access"]
 
-    document_level_security = "{\"terms\": { \"github_teams\": [$${user.roles}]}}"
+    document_level_security = "{\"terms\": { \"github_teams.keyword\": [$${user.roles}]}}"
   }
 
   tenant_permissions {

--- a/terraform/aws-accounts/cloud-platform-ephemeral-test/account/opensearch.tf
+++ b/terraform/aws-accounts/cloud-platform-ephemeral-test/account/opensearch.tf
@@ -316,7 +316,7 @@ resource "elasticsearch_opensearch_role" "all_org_members" {
     index_patterns  = ["live_k8s_modsec_ingress-*"]
     allowed_actions = ["read", "search", "data_access"]
 
-    document_level_security = "{\"terms\": { \"github_teams\": [$${user.roles}]}}"
+    document_level_security = "{\"terms\": { \"github_teams.keyword\": [$${user.roles}]}}"
   }
 
   tenant_permissions {


### PR DESCRIPTION
opensearch was not mapping the backend_role to the document field `github_teams` correctly, the hyphens were causing hyphenated team names to be split into separate search terms.

Using `github_teams.keyword` solves this.

https://opensearch.org/docs/2.5/field-types/keyword/