### PR TITLE
Bump logging module to 1.6.4

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -129,7 +129,7 @@ module "kuberos" {
 }
 
 module "logging" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-logging?ref=1.6.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-logging?ref=1.6.4"
 
   elasticsearch_host              = lookup(var.elasticsearch_hosts_maps, terraform.workspace, "placeholder-elasticsearch")
   elasticsearch_audit_host        = lookup(var.elasticsearch_audit_hosts_maps, terraform.workspace, "placeholder-elasticsearch")


### PR DESCRIPTION
Ref: https://github.com/ministryofjustice/cloud-platform-terraform-logging/releases/tag/1.6.4