### PR TITLE
Use 1.2.1 version to debug ingress logs output

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -99,7 +99,7 @@ module "ingress_controllers_v1" {
 }
 
 module "modsec_ingress_controllers_v1" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.2.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.2.1"
 
   replica_count          = "6"
   controller_name        = "modsec"


### PR DESCRIPTION
- Use 1.2.1 version to debug ingress logs output

Fluent-bit errors with `failed to flush chunk` and debug logs with `version_conflict_engine_exception` and invalid `upstream_status`. Reverting to 1.2.1 to see if the log formatting has introduced these errors