### PR TITLE
increase trivy scan concurrency

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -218,7 +218,7 @@ module "trivy-operator" {
   dockerhub_username = var.dockerhub_username
   dockerhub_password = var.dockerhub_password
 
-  job_concurrency_limit = 1
+  job_concurrency_limit = 2
   scan_job_timeout      = "10m"
   trivy_timeout         = "10m0s"
   severity_list         = "HIGH,CRITICAL"


### PR DESCRIPTION
Increasing concurrent scanner job limit to 2.