### PR TITLE
Bump aws-sso module to 1.3.2 allowing apigateway permissions

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/account/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/main.tf
@@ -53,7 +53,7 @@ module "iam" {
 
 # Github SSO
 module "sso" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-aws-sso?ref=1.3.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-aws-sso?ref=1.3.2"
 
   auth0_tenant_domain = "justice-cloud-platform.eu.auth0.com"
 }


### PR DESCRIPTION
https://github.com/ministryofjustice/cloud-platform-terraform-aws-sso/releases/tag/1.3.2