### PR TITLE
global-resources: remove use of deprecated template provider

### DIFF
--- a/terraform/global-resources/.terraform.lock.hcl
+++ b/terraform/global-resources/.terraform.lock.hcl
@@ -89,23 +89,6 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
   ]
 }
 
-provider "registry.terraform.io/hashicorp/template" {
-  version = "2.2.0"
-  hashes = [
-    "h1:0wlehNaxBX7GJQnPfQwTNvvAf38Jm0Nv7ssKGMaG6Og=",
-    "zh:01702196f0a0492ec07917db7aaa595843d8f171dc195f4c988d2ffca2a06386",
-    "zh:09aae3da826ba3d7df69efeb25d146a1de0d03e951d35019a0f80e4f58c89b53",
-    "zh:09ba83c0625b6fe0a954da6fbd0c355ac0b7f07f86c91a2a97849140fea49603",
-    "zh:0e3a6c8e16f17f19010accd0844187d524580d9fdb0731f675ffcf4afba03d16",
-    "zh:45f2c594b6f2f34ea663704cc72048b212fe7d16fb4cfd959365fa997228a776",
-    "zh:77ea3e5a0446784d77114b5e851c970a3dde1e08fa6de38210b8385d7605d451",
-    "zh:8a154388f3708e3df5a69122a23bdfaf760a523788a5081976b3d5616f7d30ae",
-    "zh:992843002f2db5a11e626b3fc23dc0c87ad3729b3b3cff08e32ffb3df97edbde",
-    "zh:ad906f4cebd3ec5e43d5cd6dc8f4c5c9cc3b33d2243c89c5fc18f97f7277b51d",
-    "zh:c979425ddb256511137ecd093e23283234da0154b7fa8b21c2687182d9aea8b2",
-  ]
-}
-
 provider "registry.terraform.io/phillbaker/elasticsearch" {
   version     = "2.0.7"
   constraints = "2.0.7"

--- a/terraform/global-resources/elasticsearch.tf
+++ b/terraform/global-resources/elasticsearch.tf
@@ -146,12 +146,7 @@ resource "aws_elasticsearch_domain" "live_1" {
 
 resource "elasticsearch_opensearch_ism_policy" "ism-policy" {
   policy_id = "hot-warm-cold-delete"
-  body      = data.template_file.ism_policy.rendered
-}
-
-data "template_file" "ism_policy" {
-  template = templatefile("${path.module}/resources/opensearch/ism-policy.json.tpl", {
-
+  body = templatefile("${path.module}/resources/opensearch/ism-policy.json.tpl", {
     timestamp_field   = var.timestamp_field
     warm_transition   = var.warm_transition
     cold_transition   = var.cold_transition
@@ -286,36 +281,25 @@ resource "aws_elasticsearch_domain" "live-2" {
 
 resource "elasticsearch_opensearch_ism_policy" "ism-policy_live_2" {
   policy_id = "hot-warm-cold-delete"
-  body      = data.template_file.ism_policy_live_2.rendered
-
-  provider = elasticsearch.live-2
-}
-
-data "template_file" "ism_policy_live_2" {
-  template = templatefile("${path.module}/resources/opensearch/ism-policy.json.tpl", {
-
+  body = templatefile("${path.module}/resources/opensearch/ism-policy.json.tpl", {
     timestamp_field   = var.timestamp_field
     warm_transition   = var.warm_transition
     cold_transition   = var.cold_transition
     delete_transition = var.delete_transition
     index_pattern     = jsonencode(var.index_pattern_live_2)
   })
+
+  provider = elasticsearch.live-2
 }
 
 # Create an index template	
-
-data "template_file" "template_index_kubernetes" {
-  template = templatefile("${path.module}/resources/opensearch/mapping-template.json.tpl", {
-    no_of_shards = "1"
-  })
-}
-
 resource "elasticsearch_index_template" "template_index_kubernetes" {
   name = "test_template"
-  body = data.template_file.template_index_kubernetes.rendered
+  body = templatefile("${path.module}/resources/opensearch/mapping-template.json.tpl", {
+    no_of_shards = "1"
+  })
 
   depends_on = [aws_elasticsearch_domain.live-2]
 
   provider = elasticsearch.live-2
-
 }

--- a/terraform/global-resources/versions.tf
+++ b/terraform/global-resources/versions.tf
@@ -1,4 +1,5 @@
 terraform {
+  required_version = ">= 1.2.5"
   required_providers {
     auth0 = {
       source  = "auth0/auth0"
@@ -16,10 +17,5 @@ terraform {
       source  = "phillbaker/elasticsearch"
       version = "2.0.7"
     }
-    template = {
-      source  = "hashicorp/template"
-      version = "2.2.0"
-    }
   }
-  required_version = ">= 1.2.5"
 }


### PR DESCRIPTION
This PR removes the deprecated [`hashicorp/template`](https://github.com/hashicorp/terraform-provider-template) provider in favour of the built-in `templatefile()` function.