### PR TITLE
Bump account-baselines module to 0.1.0

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/account/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/main.tf
@@ -61,7 +61,7 @@ module "sso" {
 
 # Baselines: cloudtrail, cloudwatch, lambda. Everything that our accounts should have
 module "baselines" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-awsaccounts-baselines?ref=0.0.12"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-awsaccounts-baselines?ref=0.1.0"
 
   enable_logging           = true
   enable_slack_integration = true

--- a/terraform/aws-accounts/cloud-platform-ephemeral-test/account/main.tf
+++ b/terraform/aws-accounts/cloud-platform-ephemeral-test/account/main.tf
@@ -32,7 +32,7 @@ provider "aws" {
 ###########################
 
 module "baselines" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-awsaccounts-baselines?ref=0.0.12"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-awsaccounts-baselines?ref=0.1.0"
 
   enable_logging           = true
   enable_slack_integration = true


### PR DESCRIPTION
https://github.com/ministryofjustice/cloud-platform-terraform-awsaccounts-baselines/releases/tag/0.1.0

Related to: https://github.com/ministryofjustice/cloud-platform/issues/4539