### PR TITLE
Increase vulnerability report TTL from 24 to 48hrs

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -222,10 +222,10 @@ module "trivy-operator" {
   # ensure report completeness across the cluster
   job_concurrency_limit = 2
   scanner_report_ttl    = "48h"
-  
-  scan_job_timeout      = "10m"
-  trivy_timeout         = "10m0s"
-  severity_list         = "HIGH,CRITICAL"
-  enable_trivy_server   = "true"
+
+  scan_job_timeout    = "10m"
+  trivy_timeout       = "10m0s"
+  severity_list       = "HIGH,CRITICAL"
+  enable_trivy_server = "true"
 }
 

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -218,7 +218,11 @@ module "trivy-operator" {
   cluster_domain_name         = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   eks_cluster_oidc_issuer_url = data.terraform_remote_state.cluster.outputs.cluster_oidc_issuer_url
 
+  # job concurrency limit and scanner report ttl need balancing to
+  # ensure report completeness across the cluster
   job_concurrency_limit = 2
+  scanner_report_ttl    = "48h"
+  
   scan_job_timeout      = "10m"
   trivy_timeout         = "10m0s"
   severity_list         = "HIGH,CRITICAL"


### PR DESCRIPTION
24hrs not long enough for the operator to scan all images across cluster