### PR TITLE
Revert "Add 2nd modsec ingress controller to test hmpps slow responses"

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -123,22 +123,6 @@ module "modsec_ingress_controllers_v1" {
   depends_on             = [module.ingress_controllers_v1]
 }
 
-module "modsec_02_ingress_controllers_v1" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=modsec-02"
-
-  replica_count          = "6"
-  controller_name        = "modsec-02"
-  cluster_domain_name    = data.terraform_remote_state.cluster.outputs.cluster_domain_name
-  is_live_cluster        = lookup(local.prod_workspace, terraform.workspace, false)
-  live1_cert_dns_name    = lookup(local.live1_cert_dns_name, terraform.workspace, "")
-  enable_modsec          = true
-  enable_owasp           = true
-  enable_latest_tls      = true
-  dependence_certmanager = "ignore"
-  depends_on             = [module.ingress_controllers_v1]
-}
-
-
 module "kuberos" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-kuberos?ref=0.5.2"
 


### PR DESCRIPTION
Reverts ministryofjustice/cloud-platform-infrastructure#2303

Removing the 2nd test modsec controller. We are seeing some missing audit logs because of too many controller logs pushing to Audit Opensearch. 
And this is not needed for weekend