### PR TITLE
feat: 🎸 install gatekeeper with all constraints disabled

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -184,6 +184,16 @@ module "opa" {
   integration_test_zone      = data.aws_route53_zone.integrationtest.name
 }
 
+module "gatekeeper" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-gatekeeper?ref=1.1.0"
+
+  cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
+  # boolean expression for applying opa valid hostname for test clusters only.
+  # enable_invalid_hostname_policy = terraform.workspace == local.live_workspace ? false : true
+  enable_invalid_hostname_policy = false
+  define_constraints             = false
+}
+
 module "starter_pack" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-starter-pack?ref=0.2.1"
 


### PR DESCRIPTION
This pulls in the updated gatekeeper module, which adds gatekeeper to the cluster but in a dormant state with no constraints.