### PR TITLE
perf: ⚡️ increase modsec ingress replicas from 6 to 12

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -111,7 +111,7 @@ module "ingress_controllers_v1" {
 module "modsec_ingress_controllers_v1" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.2.4"
 
-  replica_count          = "6"
+  replica_count          = "12"
   controller_name        = "modsec"
   cluster_domain_name    = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   is_live_cluster        = lookup(local.prod_workspace, terraform.workspace, false)


### PR DESCRIPTION
`hmpps-auth` raised an issue where they saw ~1 to 2% of their traffic through their modsec controllers display high latency levels. There is no pattern to the type of requests or timings.

To identify the issue, we created the team a dedicated ingress controller from which we could experiment with changing modsec settings and measuring their effect on their traffic. Without changing any modsec values, the team immediately reported results following load testing. Just by introducing a dedicated ingress controller with no changes we saw results suggesting the fault doesn't lie with our modsec config.

Whilst load testing we would sporadically see `SSL handshakes failed`. The theory modsec ingress controllers are running out of TCP connections (maybe due to keep-alives keeping the socket open longer with modsec compared with the default ingress) and thus failing the SSL handshakes. The theory is hard to verify without turning on debugging logs on prod ingresses but seems plausible given the success of the ingress test with the team and the presence of handshake failures during load testing.

Further work around this has discovered we are running a version of modsec which has a [known memory leak](https://gitlab.com/gitlab-org/gitlab/-/issues/39140) and upgrading our ingress controllers would also to a modsec version where this has been fixed.
