### PR TITLE
Fix ISM Policy for cp-live-modsec-audit Opensearch

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/account/variables.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/variables.tf
@@ -46,7 +46,7 @@ variable "delete_transition" {
 
 variable "index_pattern_live_modsec_audit" {
   default = [
-    "live_modsec_audit_kubernetes_ingress*",
+    "live_k8s_modsec_ingress-*",
   ]
   description = "Pattern created in Kibana, policy will apply to matching new indices"
   type        = list(string)

--- a/terraform/aws-accounts/cloud-platform-ephemeral-test/account/variables.tf
+++ b/terraform/aws-accounts/cloud-platform-ephemeral-test/account/variables.tf
@@ -41,7 +41,7 @@ variable "aws_region" {
 
 # variable "index_pattern_live_modsec_audit" {
 #   default = [
-#     "live_modsec_audit_kubernetes_ingress*",
+#     "live_k8s_modsec_ingress-*",
 #   ]
 #   description = "Pattern created in Kibana, policy will apply to matching new indices"
 #   type        = list(string)


### PR DESCRIPTION
Why:
[Fix ISM Policy for cp-live-modsec-audit Opensearch#4578](https://app.zenhub.com/workspaces/cloud-platform-team-5ccb0b8a81f66118c983c189/issues/gh/ministryofjustice/cloud-platform/4578)
Specifically to correct the index pattern to apply on the ISM policy