### PR TITLE
chore: 🤖 update gatekeeper vars, bump version to run gatekeeper in

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -185,13 +185,13 @@ module "opa" {
 }
 
 module "gatekeeper" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-gatekeeper?ref=1.1.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-gatekeeper?ref=1.2.0"
 
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   # boolean expression for applying opa valid hostname for test clusters only.
   # enable_invalid_hostname_policy = terraform.workspace == local.live_workspace ? false : true
+  dryrun_map                           = { service_type = true }
   enable_invalid_hostname_policy       = false
-  define_constraints                   = false
   constraint_violations_max_to_display = 25
   is_production                        = lookup(local.prod_2_workspace, terraform.workspace, false) ? "true" : "false"
   environment_name                     = lookup(local.prod_2_workspace, terraform.workspace, false) ? "production" : "development"


### PR DESCRIPTION
run gatekeeper in dryrun mode and add service_type constraint.

Once verified that everything is working as expected then we can disable the corresponding opa rule and disable dryrun for the gatekeeper rule.