### PR TITLE
use-latest-exteranal-dns-release

### DIFF
--- a/terraform/aws-accounts/cloud-platform-ephemeral-test/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-ephemeral-test/vpc/eks/components/components.tf
@@ -70,7 +70,7 @@ module "cert_manager" {
 }
 
 module "external_dns" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-external-dns?ref=1.11.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-external-dns?ref=1.11.1"
 
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   hostzones           = lookup(local.hostzones, terraform.workspace, local.hostzones["default"])


### PR DESCRIPTION
Use latest external-dns module release 1.11.1:
Why: bump up update interval to 10m:
[Investigate Route53 rate limit error on external-dns#4608](https://app.zenhub.com/workspaces/cloud-platform-team-5ccb0b8a81f66118c983c189/issues/gh/ministryofjustice/cloud-platform/4608)