### PR TITLE
reference-latest-external-dns-release

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -72,7 +72,7 @@ module "cert_manager" {
 }
 
 module "external_dns" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-external-dns?ref=1.11.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-external-dns?ref=1.11.2"
 
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   hostzones           = lookup(local.hostzones, terraform.workspace, local.hostzones["default"])

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -72,7 +72,7 @@ module "cert_manager" {
 }
 
 module "external_dns" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-external-dns?ref=1.11.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-external-dns?ref=1.11.3"
 
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   hostzones           = lookup(local.hostzones, terraform.workspace, local.hostzones["default"])

--- a/terraform/aws-accounts/cloud-platform-ephemeral-test/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-ephemeral-test/vpc/eks/components/components.tf
@@ -70,7 +70,7 @@ module "cert_manager" {
 }
 
 module "external_dns" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-external-dns?ref=1.11.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-external-dns?ref=1.11.3"
 
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   hostzones           = lookup(local.hostzones, terraform.workspace, local.hostzones["default"])

--- a/terraform/aws-accounts/cloud-platform-ephemeral-test/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-ephemeral-test/vpc/eks/components/components.tf
@@ -70,7 +70,7 @@ module "cert_manager" {
 }
 
 module "external_dns" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-external-dns?ref=1.11.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-external-dns?ref=1.11.2"
 
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   hostzones           = lookup(local.hostzones, terraform.workspace, local.hostzones["default"])


### PR DESCRIPTION
Why: reference latest external-dns release:
To address throttling issue [Investigate Route53 rate limit error on external-dns#4608](https://app.zenhub.com/workspaces/cloud-platform-team-5ccb0b8a81f66118c983c189/issues/gh/ministryofjustice/cloud-platform/4608)