### PR TITLE
chore: 🤖 double es ebs volume to 3TB

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -138,7 +138,7 @@ module "kuberos" {
 }
 
 module "logging" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-logging?ref=1.9.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-logging?ref=1.9.7"
 
   elasticsearch_host              = lookup(var.elasticsearch_hosts_maps, terraform.workspace, "placeholder-elasticsearch")
   elasticsearch_modsec_audit_host = lookup(var.elasticsearch_modsec_audit_hosts_maps, terraform.workspace, "placeholder-elasticsearch")

--- a/terraform/global-resources/elasticsearch.tf
+++ b/terraform/global-resources/elasticsearch.tf
@@ -116,7 +116,7 @@ resource "aws_elasticsearch_domain" "live_1" {
   ebs_options {
     ebs_enabled = "true"
     volume_type = "gp3"
-    volume_size = "1536"
+    volume_size = "3072"
     iops        = 4608
   }
 


### PR DESCRIPTION
We are seeing alerts triggered for no enough minimum free storage and related to the jvm memory pressure being too high. Attached shows our storage really is very low

![image](https://github.com/ministryofjustice/cloud-platform-infrastructure/assets/29051079/2aeffa38-ba5d-4e98-a8fe-55cd2f29243d)

Also bumping logging module as there was a syntax error in the limit range