### PR TITLE
update-external-dns latest release  to not list cp and yy route53

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -72,7 +72,7 @@ module "cert_manager" {
 }
 
 module "external_dns" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-external-dns?ref=1.11.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-external-dns?ref=1.11.4"
 
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   hostzones           = lookup(local.hostzones, terraform.workspace, local.hostzones["default"])

--- a/terraform/aws-accounts/cloud-platform-ephemeral-test/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-ephemeral-test/vpc/eks/components/components.tf
@@ -70,7 +70,7 @@ module "cert_manager" {
 }
 
 module "external_dns" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-external-dns?ref=1.11.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-external-dns?ref=1.11.4"
 
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   hostzones           = lookup(local.hostzones, terraform.workspace, local.hostzones["default"])


### PR DESCRIPTION
Why - latest:
reference latest external-dns release https://github.com/ministryofjustice/cloud-platform-terraform-external-dns/releases/tag/v1.11.4