### PR TITLE
Update warm and cold transition duration, 30d needs to search in kibana

### DIFF
--- a/terraform/global-resources/variables.tf
+++ b/terraform/global-resources/variables.tf
@@ -6,13 +6,13 @@ variable "timestamp_field" {
 
 variable "warm_transition" {
   type        = string
-  default     = "7d"
+  default     = "14d"
   description = "Time until transition to warm storage"
 }
 
 variable "cold_transition" {
   type        = string
-  default     = "14d"
+  default     = "30d"
   description = "Time until transition to cold storage"
 }
 


### PR DESCRIPTION
- Update hot to warm transition from 7d to 14d. The ES has 12 hot nodes and has more disk space to store 14 days of data. Since the uneven shard distribution is resolved now, the 12 hot nodes should be able to handle 14 days of data
- Update warm to cold from 14d to 30d. This is needed so 30d logs are available to search in kibana
