### PR TITLE
Move worker security group outside of eks module

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
@@ -135,7 +135,7 @@ module "eks" {
   cluster_log_retention_in_days = var.cluster_log_retention_in_days
   wait_for_cluster_timeout      = "900"
   worker_create_security_group  = false
-  worker_security_group_id      = aws_security_group.workers.id
+  worker_security_group_id      = aws_security_group.node.id
 
   node_groups = {
     default_ng_12_22 = local.default_ng_12_22

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
@@ -134,6 +134,9 @@ module "eks" {
   cluster_enabled_log_types     = var.cluster_enabled_log_types
   cluster_log_retention_in_days = var.cluster_log_retention_in_days
   wait_for_cluster_timeout      = "900"
+  worker_create_security_group  = false
+  worker_security_group_id      = aws_security_group.workers.id
+
 
   node_groups = {
     default_ng_12_22 = local.default_ng_12_22

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
@@ -137,7 +137,6 @@ module "eks" {
   worker_create_security_group  = false
   worker_security_group_id      = aws_security_group.workers.id
 
-
   node_groups = {
     default_ng_12_22 = local.default_ng_12_22
     monitoring_ng    = local.monitoring_ng

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/security-group.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/security-group.tf
@@ -41,7 +41,7 @@ resource "aws_security_group_rule" "node_ingress_self" {
 }
 
 resource "aws_security_group_rule" "node_ingress_cluster" {
-  description              = "Allow node pods to receive communication from the cluster control plane."
+  description              = "Allow workers pods to receive communication from the cluster control plane."
   protocol                 = "tcp"
   security_group_id        = aws_security_group.node.id
   source_security_group_id = module.eks.cluster_security_group_id

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/security-group.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/security-group.tf
@@ -7,53 +7,53 @@
 
 # Ref: https://github.com/terraform-aws-modules/terraform-aws-eks/blob/v17.24.0/workers.tf#L377
 
-resource "aws_security_group" "workers" {
+resource "aws_security_group" "node" {
   name_prefix = terraform.workspace
   description = "Security group for all nodes in the cluster."
   vpc_id      = data.aws_vpc.selected.id
   tags = merge(
     local.tags,
     {
-      "Name"                                         = "${terraform.workspace}-eks_worker_sg"
+      "Name"                                         = "${terraform.workspace}-eks_node_sg"
       "kubernetes.io/cluster/${terraform.workspace}" = "owned"
     },
   )
 }
 
-resource "aws_security_group_rule" "workers_egress_internet" {
+resource "aws_security_group_rule" "node_egress_internet" {
   description       = "Allow nodes all egress to the Internet."
   protocol          = "-1"
-  security_group_id = aws_security_group.workers.id
+  security_group_id = aws_security_group.node.id
   cidr_blocks       = ["0.0.0.0/0"]
   from_port         = 0
   to_port           = 0
   type              = "egress"
 }
 
-resource "aws_security_group_rule" "workers_ingress_self" {
+resource "aws_security_group_rule" "node_ingress_self" {
   description              = "Allow node to communicate with each other."
   protocol                 = "-1"
-  security_group_id        = aws_security_group.workers.id
-  source_security_group_id = aws_security_group.workers.id
+  security_group_id        = aws_security_group.node.id
+  source_security_group_id = aws_security_group.node.id
   from_port                = 0
   to_port                  = 65535
   type                     = "ingress"
 }
 
-resource "aws_security_group_rule" "workers_ingress_cluster" {
-  description              = "Allow workers pods to receive communication from the cluster control plane."
+resource "aws_security_group_rule" "node_ingress_cluster" {
+  description              = "Allow node pods to receive communication from the cluster control plane."
   protocol                 = "tcp"
-  security_group_id        = aws_security_group.workers.id
+  security_group_id        = aws_security_group.node.id
   source_security_group_id = module.eks.cluster_security_group_id
   from_port                = 1025
   to_port                  = 65535
   type                     = "ingress"
 }
 
-resource "aws_security_group_rule" "workers_ingress_cluster_https" {
+resource "aws_security_group_rule" "node_ingress_cluster_https" {
   description              = "Allow pods running extension API servers on port 443 to receive communication from cluster control plane."
   protocol                 = "tcp"
-  security_group_id        = aws_security_group.workers.id
+  security_group_id        = aws_security_group.node.id
   source_security_group_id = module.eks.cluster_security_group_id
   from_port                = 443
   to_port                  = 443
@@ -61,11 +61,11 @@ resource "aws_security_group_rule" "workers_ingress_cluster_https" {
 }
 
 # Cluster security group rule for worker node security group - https://github.com/terraform-aws-modules/terraform-aws-eks/blob/v17.24.0/main.tf#L90C1-L100C2
-resource "aws_security_group_rule" "cluster_https_worker_ingress" {
+resource "aws_security_group_rule" "cluster_https_node_ingress" {
   description              = "Allow pods to communicate with the EKS cluster API."
   protocol                 = "tcp"
   security_group_id        = module.eks.cluster_security_group_id
-  source_security_group_id = aws_security_group.workers.id
+  source_security_group_id = aws_security_group.node.id
   from_port                = 443
   to_port                  = 443
   type                     = "ingress"

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/security-group.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/security-group.tf
@@ -1,0 +1,115 @@
+# # moved worker node security group out of eks module
+
+# moved { 
+#     from = module.eks.aws_security_group.workers
+#     to = aws_security_group.workers
+# }
+
+
+resource "aws_security_group" "workers" {
+
+  name_prefix = terraform.workspace
+  description = "Security group for all nodes in the cluster."
+  vpc_id      = data.aws_vpc.selected.id
+  tags = merge(
+    local.tags,
+    {
+      "Name"                                      = "${terraform.workspace}-eks_worker_sg"
+      "kubernetes.io/cluster/${terraform.workspace}" = "owned"
+    },
+  )
+}
+
+resource "aws_security_group_rule" "workers_egress_internet" {
+
+  description       = "Allow nodes all egress to the Internet."
+  protocol          = "-1"
+  security_group_id = aws_security_group.workers.id
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = 0
+  to_port           = 0
+  type              = "egress"
+}
+
+resource "aws_security_group_rule" "workers_ingress_self" {
+
+  description              = "Allow node to communicate with each other."
+  protocol                 = "-1"
+  security_group_id = aws_security_group.workers.id
+  source_security_group_id = aws_security_group.workers.id
+  from_port                = 0
+  to_port                  = 65535
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "workers_ingress_cluster" {
+
+  description              = "Allow workers pods to receive communication from the cluster control plane."
+  protocol                 = "tcp"
+  security_group_id = aws_security_group.workers.id
+  source_security_group_id = module.eks.cluster_security_group_id
+  from_port                = 1025
+  to_port                  = 65535
+  type                     = "ingress"
+}
+
+# resource "aws_security_group_rule" "workers_ingress_cluster_kubelet" {
+
+
+#   description              = "Allow workers Kubelets to receive communication from the cluster control plane."
+#   protocol                 = "tcp"
+#   security_group_id = aws_security_group.workers.id
+#   source_security_group_id = module.eks.cluster_security_group_id
+#   from_port                = 10250
+#   to_port                  = 10250
+#   type                     = "ingress"
+# }
+
+resource "aws_security_group_rule" "workers_ingress_cluster_https" {
+
+
+  description              = "Allow pods running extension API servers on port 443 to receive communication from cluster control plane."
+  protocol                 = "tcp"
+  security_group_id = aws_security_group.workers.id
+  source_security_group_id = module.eks.cluster_security_group_id
+  from_port                = 443
+  to_port                  = 443
+  type                     = "ingress"
+}
+
+#  cluster security group rule for worker node security group - https://github.com/terraform-aws-modules/terraform-aws-eks/blob/v17.24.0/main.tf#L90C1-L100C2
+
+resource "aws_security_group_rule" "cluster_https_worker_ingress" {
+
+  description              = "Allow pods to communicate with the EKS cluster API."
+  protocol                 = "tcp"
+  security_group_id        = module.eks.cluster_security_group_id
+  source_security_group_id = aws_security_group.workers.id
+  from_port                = 443
+  to_port                  = 443
+  type                     = "ingress"
+}
+# resource "aws_security_group_rule" "workers_ingress_cluster_primary" {
+
+
+#   description              = "Allow pods running on workers to receive communication from cluster primary security group (e.g. Fargate pods)."
+#   protocol                 = "all"
+#   security_group_id = aws_security_group.workers.id
+#   source_security_group_id = local.cluster_primary_security_group_id
+#   from_port                = 0
+#   to_port                  = 65535
+#   type                     = "ingress"
+# }
+
+# resource "aws_security_group_rule" "cluster_primary_ingress_workers" {
+
+
+#   description              = "Allow pods running on workers to send communication to cluster primary security group (e.g. Fargate pods)."
+#   protocol                 = "all"
+#   security_group_id = aws_security_group.workers.id
+#   source_security_group_id = local.worker_security_group_id
+#   from_port                = 0
+#   to_port                  = 65535
+#   type                     = "ingress"
+# }
+

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/security-group.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/security-group.tf
@@ -14,7 +14,7 @@ resource "aws_security_group" "workers" {
   tags = merge(
     local.tags,
     {
-      "Name"                                      = "${terraform.workspace}-eks_worker_sg"
+      "Name"                                         = "${terraform.workspace}-eks_worker_sg"
       "kubernetes.io/cluster/${terraform.workspace}" = "owned"
     },
   )
@@ -33,7 +33,7 @@ resource "aws_security_group_rule" "workers_egress_internet" {
 resource "aws_security_group_rule" "workers_ingress_self" {
   description              = "Allow node to communicate with each other."
   protocol                 = "-1"
-  security_group_id = aws_security_group.workers.id
+  security_group_id        = aws_security_group.workers.id
   source_security_group_id = aws_security_group.workers.id
   from_port                = 0
   to_port                  = 65535
@@ -43,7 +43,7 @@ resource "aws_security_group_rule" "workers_ingress_self" {
 resource "aws_security_group_rule" "workers_ingress_cluster" {
   description              = "Allow workers pods to receive communication from the cluster control plane."
   protocol                 = "tcp"
-  security_group_id = aws_security_group.workers.id
+  security_group_id        = aws_security_group.workers.id
   source_security_group_id = module.eks.cluster_security_group_id
   from_port                = 1025
   to_port                  = 65535
@@ -53,7 +53,7 @@ resource "aws_security_group_rule" "workers_ingress_cluster" {
 resource "aws_security_group_rule" "workers_ingress_cluster_https" {
   description              = "Allow pods running extension API servers on port 443 to receive communication from cluster control plane."
   protocol                 = "tcp"
-  security_group_id = aws_security_group.workers.id
+  security_group_id        = aws_security_group.workers.id
   source_security_group_id = module.eks.cluster_security_group_id
   from_port                = 443
   to_port                  = 443

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/security-group.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/security-group.tf
@@ -1,13 +1,13 @@
-# # moved worker node security group out of eks module
+##########################################
+# EKS Worker node Security Group & Rules #
+##########################################
 
-# moved { 
-#     from = module.eks.aws_security_group.workers
-#     to = aws_security_group.workers
-# }
+# As of EKS module upgrade 17.24.0 > 18.31.2 we are managing worker node security group & associated rules outside of the EKS module
+# in order to retain control of additional rules required for node communication.
 
+# Ref: https://github.com/terraform-aws-modules/terraform-aws-eks/blob/v17.24.0/workers.tf#L377
 
 resource "aws_security_group" "workers" {
-
   name_prefix = terraform.workspace
   description = "Security group for all nodes in the cluster."
   vpc_id      = data.aws_vpc.selected.id
@@ -21,7 +21,6 @@ resource "aws_security_group" "workers" {
 }
 
 resource "aws_security_group_rule" "workers_egress_internet" {
-
   description       = "Allow nodes all egress to the Internet."
   protocol          = "-1"
   security_group_id = aws_security_group.workers.id
@@ -32,7 +31,6 @@ resource "aws_security_group_rule" "workers_egress_internet" {
 }
 
 resource "aws_security_group_rule" "workers_ingress_self" {
-
   description              = "Allow node to communicate with each other."
   protocol                 = "-1"
   security_group_id = aws_security_group.workers.id
@@ -43,7 +41,6 @@ resource "aws_security_group_rule" "workers_ingress_self" {
 }
 
 resource "aws_security_group_rule" "workers_ingress_cluster" {
-
   description              = "Allow workers pods to receive communication from the cluster control plane."
   protocol                 = "tcp"
   security_group_id = aws_security_group.workers.id
@@ -53,21 +50,7 @@ resource "aws_security_group_rule" "workers_ingress_cluster" {
   type                     = "ingress"
 }
 
-# resource "aws_security_group_rule" "workers_ingress_cluster_kubelet" {
-
-
-#   description              = "Allow workers Kubelets to receive communication from the cluster control plane."
-#   protocol                 = "tcp"
-#   security_group_id = aws_security_group.workers.id
-#   source_security_group_id = module.eks.cluster_security_group_id
-#   from_port                = 10250
-#   to_port                  = 10250
-#   type                     = "ingress"
-# }
-
 resource "aws_security_group_rule" "workers_ingress_cluster_https" {
-
-
   description              = "Allow pods running extension API servers on port 443 to receive communication from cluster control plane."
   protocol                 = "tcp"
   security_group_id = aws_security_group.workers.id
@@ -77,10 +60,8 @@ resource "aws_security_group_rule" "workers_ingress_cluster_https" {
   type                     = "ingress"
 }
 
-#  cluster security group rule for worker node security group - https://github.com/terraform-aws-modules/terraform-aws-eks/blob/v17.24.0/main.tf#L90C1-L100C2
-
+# Cluster security group rule for worker node security group - https://github.com/terraform-aws-modules/terraform-aws-eks/blob/v17.24.0/main.tf#L90C1-L100C2
 resource "aws_security_group_rule" "cluster_https_worker_ingress" {
-
   description              = "Allow pods to communicate with the EKS cluster API."
   protocol                 = "tcp"
   security_group_id        = module.eks.cluster_security_group_id
@@ -89,27 +70,3 @@ resource "aws_security_group_rule" "cluster_https_worker_ingress" {
   to_port                  = 443
   type                     = "ingress"
 }
-# resource "aws_security_group_rule" "workers_ingress_cluster_primary" {
-
-
-#   description              = "Allow pods running on workers to receive communication from cluster primary security group (e.g. Fargate pods)."
-#   protocol                 = "all"
-#   security_group_id = aws_security_group.workers.id
-#   source_security_group_id = local.cluster_primary_security_group_id
-#   from_port                = 0
-#   to_port                  = 65535
-#   type                     = "ingress"
-# }
-
-# resource "aws_security_group_rule" "cluster_primary_ingress_workers" {
-
-
-#   description              = "Allow pods running on workers to send communication to cluster primary security group (e.g. Fargate pods)."
-#   protocol                 = "all"
-#   security_group_id = aws_security_group.workers.id
-#   source_security_group_id = local.worker_security_group_id
-#   from_port                = 0
-#   to_port                  = 65535
-#   type                     = "ingress"
-# }
-

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/security-group.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/security-group.tf
@@ -14,7 +14,7 @@ resource "aws_security_group" "node" {
   tags = merge(
     local.tags,
     {
-      "Name"                                         = "${terraform.workspace}-eks_node_sg"
+      "Name"                                         = "${terraform.workspace}-eks_worker_sg"
       "kubernetes.io/cluster/${terraform.workspace}" = "owned"
     },
   )


### PR DESCRIPTION
This PR moves our worker node security group and rules config outside of EKS  module in preparation for 17.24.0 > 18.31.2 EKS module upgrade.