### PR TITLE
bump gatekeeper for enabling psp migrated mutations

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -175,7 +175,7 @@ module "monitoring" {
 }
 
 module "gatekeeper" {
-  source     = "github.com/ministryofjustice/cloud-platform-terraform-gatekeeper?ref=1.5.4"
+  source     = "github.com/ministryofjustice/cloud-platform-terraform-gatekeeper?ref=1.6.0"
   depends_on = [module.monitoring, module.modsec_ingress_controllers_v1, module.cert_manager]
 
   dryrun_map = {


### PR DESCRIPTION
This PR bumps gatekeeper to latest release with psp migrated mutations enabled.