### PR TITLE
change-timings-for-kh-namespace-kuberhealthy-check-use-latest-module

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -228,7 +228,7 @@ module "velero" {
 }
 
 module "kuberhealthy" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-kuberhealthy?ref=1.2.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-kuberhealthy?ref=1.2.2"
 
   dependence_prometheus = module.monitoring.prometheus_operator_crds_status
 }


### PR DESCRIPTION
Why [Kuberhealthy Alerts Review#4670](https://app.zenhub.com/workspaces/cloud-platform-team-5ccb0b8a81f66118c983c189/issues/gh/ministryofjustice/cloud-platform/4670)
To make namespace checks less frequent