### PR TITLE
refactor: 💡 add throw away rolebinding for super-privileged psp

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/psp.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/psp.tf
@@ -1,4 +1,3 @@
-
 ## Pod Security Policy: 0-super-privileged
 resource "kubernetes_pod_security_policy" "super_privileged" {
   metadata {
@@ -123,6 +122,24 @@ resource "kubernetes_pod_security_policy" "privileged" {
     }
   }
 }
+
+## ClusterRoleBinding: super-privileged
+resource "kubernetes_cluster_role_binding" "super_privileged" {
+  metadata {
+    name = "default:0-super-privileged"
+  }
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = "psp:0-super-privileged"
+  }
+  subject {
+    kind      = "ServiceAccount"
+    name      = "temp-access"
+    namespace = "not-required"
+  }
+}
+
 
 
 ## ClusterRole: privileged


### PR DESCRIPTION
This is needed for the psp bypass which we will carry out next sprint. The bypass works by escalating privilege to the `0-super-privilege` PSP on a per namespace level which triggers PSA a takeover.