### PR TITLE
Bumping Kuberhealthy module to 1.2.5

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -229,7 +229,7 @@ module "velero" {
 }
 
 module "kuberhealthy" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-kuberhealthy?ref=1.2.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-kuberhealthy?ref=1.2.5"
 
   dependence_prometheus = module.monitoring.prometheus_operator_crds_status
 }


### PR DESCRIPTION
New module migrates PodDisruptionBudget from v1beta1 to policy/v1