### PR TITLE
Bump logging module to 1.9.17

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -141,7 +141,7 @@ module "kuberos" {
 }
 
 module "logging" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-logging?ref=1.9.16"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-logging?ref=1.9.17"
 
   elasticsearch_host              = lookup(var.elasticsearch_hosts_maps, terraform.workspace, "placeholder-elasticsearch")
   elasticsearch_modsec_audit_host = lookup(var.elasticsearch_modsec_audit_hosts_maps, terraform.workspace, "placeholder-elasticsearch")


### PR DESCRIPTION
https://github.com/ministryofjustice/cloud-platform-terraform-logging/releases/tag/1.9.17
Closes: https://github.com/ministryofjustice/cloud-platform/issues/4767
