### PR TITLE
Bump monitoring to 2.10.6

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -149,7 +149,7 @@ module "logging" {
 }
 
 module "monitoring" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=2.10.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=2.10.6"
 
   alertmanager_slack_receivers               = local.enable_alerts ? var.alertmanager_slack_receivers : [{ severity = "dummy", webhook = "https://dummy.slack.com", channel = "#dummy-alarms" }]
   pagerduty_config                           = local.enable_alerts ? var.pagerduty_config : "dummy"


### PR DESCRIPTION
https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/releases/tag/2.10.6
