### PR TITLE
test: 💍 system:seviceaccounts:* -> system:authenticated

### DIFF
--- a/test/fixtures/namespace.yaml.tmpl
+++ b/test/fixtures/namespace.yaml.tmpl
@@ -23,9 +23,6 @@ subjects:
   - kind: Group
     name: "system:authenticated"
     apiGroup: rbac.authorization.k8s.io
-  - kind: Group 
-    name: system:serviceaccounts:{{ .namespace }}
-    apiGroup: rbac.authorization.k8s.io
   {{ end }}
 roleRef:
   kind: ClusterRole


### PR DESCRIPTION
both groups capture the same targets, `system:authenticated` is preferred because it reads better and is consistent with our psp rolebindings.