### PR TITLE
adding gatekeeper dependencies to modules

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -91,7 +91,7 @@ module "external_secrets_operator" {
 
   depends_on = [
     module.gatekeeper
-  ]  
+  ]
 }
 module "ingress_controllers_v1" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.5.0"


### PR DESCRIPTION
Ensure `gatekeepe`r module is deployed before `starter_pack` and `external_secrets_operator`.

This fixes [helm deployment timeouts](https://github.com/ministryofjustice/cloud-platform/issues/4952) issue