### PR TITLE
Discard k8s output from logger

### DIFF
--- a/test/certmanager_test.go
+++ b/test/certmanager_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/ministryofjustice/cloud-platform-infrastructure/test/helpers"
 	. "github.com/onsi/ginkgo/v2"
@@ -34,6 +35,8 @@ type DefaultCert struct {
 // Check if the default ingress-controller certificate exists
 var _ = Describe("Default ingress-controller certificate", func() {
 	options := k8s.NewKubectlOptions("", "", "ingress-controllers")
+	oldLogger := options.Logger
+	options.Logger = logger.Discard
 
 	// Get the default ingress-controller certificate
 	certificate, err := k8s.RunKubectlAndGetOutputE(GinkgoT(), options, "get", "certificate", "default", "-o", "json")
@@ -51,6 +54,7 @@ var _ = Describe("Default ingress-controller certificate", func() {
 		Expect(cert.Spec.IssuerRef.Kind).To(Equal("ClusterIssuer"))
 		Expect(cert.Spec.IssuerRef.Name).To(Equal("letsencrypt-production"))
 	})
+	options.Logger = oldLogger
 })
 
 // This test checks if a staging let's encrypt cert is assigned to an app

--- a/test/psa_priv_ephemeral_test.go
+++ b/test/psa_priv_ephemeral_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/ministryofjustice/cloud-platform-infrastructure/test/helpers"
 	. "github.com/onsi/ginkgo/v2"
@@ -17,11 +18,14 @@ var _ = Describe("GIVEN PRIVILEGED pod security admission", func() {
 		var (
 			namespace string
 			options   *k8s.KubectlOptions
+			oldLogger *logger.Logger
 		)
 		BeforeEach(func() {
 			Skip("Skipping ephemeral PSA tests we don't currently have any ephemeral containers in live")
 			namespace = fmt.Sprintf("%s-psa-%s", c.Prefix, strings.ToLower(random.UniqueId()))
 			options = k8s.NewKubectlOptions("", "", namespace)
+			oldLogger = options.Logger
+			options.Logger = logger.Discard
 
 			tpl, err := helpers.TemplateFile("./fixtures/namespace.yaml.tmpl", "namespace.yaml.tmpl", template.FuncMap{
 				"namespace": namespace,
@@ -37,10 +41,10 @@ var _ = Describe("GIVEN PRIVILEGED pod security admission", func() {
 		AfterEach(func() {
 			err := k8s.DeleteNamespaceE(GinkgoT(), options, namespace)
 			Expect(err).NotTo(HaveOccurred())
+			defer func() { options.Logger = oldLogger }()
 		})
 
 		It("THEN ALLOW `spec.ephemeralContainers.securityContext.runAsNonRoot: false`", func() {
-			options := k8s.NewKubectlOptions("", "", namespace)
 			tpl, err := helpers.TemplateFile("./fixtures/dynamic-deploy.yaml.tmpl", "dynamic-deploy.yaml.tmpl", template.FuncMap{
 				"namespace":             namespace,
 				"deploymentName":        "app-" + strings.ToLower(random.UniqueId()),
@@ -54,7 +58,6 @@ var _ = Describe("GIVEN PRIVILEGED pod security admission", func() {
 		})
 
 		It("THEN ALLOW `spec.ephemeralContainers.securityContext.runAsNonRoot: true` values", func() {
-			options := k8s.NewKubectlOptions("", "", namespace)
 			tpl, err := helpers.TemplateFile("./fixtures/dynamic-deploy.yaml.tmpl", "dynamic-deploy.yaml.tmpl", template.FuncMap{
 				"namespace":             namespace,
 				"deploymentName":        "app-" + strings.ToLower(random.UniqueId()),
@@ -68,7 +71,6 @@ var _ = Describe("GIVEN PRIVILEGED pod security admission", func() {
 		})
 
 		It("THEN ALLOW `spec.ephemeralContainers.securityContext.allowPrivilegeEscalation: false`", func() {
-			options := k8s.NewKubectlOptions("", "", namespace)
 			deploymentName := "app-" + strings.ToLower(random.UniqueId())
 			tpl, err := helpers.TemplateFile("./fixtures/dynamic-deploy.yaml.tmpl", "dynamic-deploy.yaml.tmpl", template.FuncMap{
 				"namespace":      namespace,
@@ -92,7 +94,6 @@ var _ = Describe("GIVEN PRIVILEGED pod security admission", func() {
 		})
 
 		It("THEN ALLOW `spec.ephemeralContainers.securityContext.allowPrivilegeEscalation: true`", func() {
-			options := k8s.NewKubectlOptions("", "", namespace)
 			tpl, err := helpers.TemplateFile("./fixtures/dynamic-deploy.yaml.tmpl", "dynamic-deploy.yaml.tmpl", template.FuncMap{
 				"namespace":                         namespace,
 				"deploymentName":                    "app-" + strings.ToLower(random.UniqueId()),
@@ -106,7 +107,6 @@ var _ = Describe("GIVEN PRIVILEGED pod security admission", func() {
 		})
 
 		It("THEN ALLOW `spec.ephemeralcontainers.securityContext.capabilities.drop: ['ALL']`", func() {
-			options := k8s.NewKubectlOptions("", "", namespace)
 			tpl, err := helpers.TemplateFile("./fixtures/dynamic-deploy.yaml.tmpl", "dynamic-deploy.yaml.tmpl", template.FuncMap{
 				"namespace":                 namespace,
 				"deploymentName":            "app-" + strings.ToLower(random.UniqueId()),
@@ -120,7 +120,6 @@ var _ = Describe("GIVEN PRIVILEGED pod security admission", func() {
 		})
 
 		It("THEN ALLOW `spec.ephemeralcontainers.securityContext.capabilities.drop: ['NET_RAW']`", func() {
-			options := k8s.NewKubectlOptions("", "", namespace)
 			tpl, err := helpers.TemplateFile("./fixtures/dynamic-deploy.yaml.tmpl", "dynamic-deploy.yaml.tmpl", template.FuncMap{
 				"namespace":                 namespace,
 				"deploymentName":            "app-" + strings.ToLower(random.UniqueId()),
@@ -134,7 +133,6 @@ var _ = Describe("GIVEN PRIVILEGED pod security admission", func() {
 		})
 
 		It("THEN ALLOW `spec.ephemeralcontainers.securityContext.capabilities.add: ['NET_RAW']`", func() {
-			options := k8s.NewKubectlOptions("", "", namespace)
 			tpl, err := helpers.TemplateFile("./fixtures/dynamic-deploy.yaml.tmpl", "dynamic-deploy.yaml.tmpl", template.FuncMap{
 				"namespace":                namespace,
 				"deploymentName":           "app-" + strings.ToLower(random.UniqueId()),

--- a/test/psa_priv_init_test.go
+++ b/test/psa_priv_init_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/ministryofjustice/cloud-platform-infrastructure/test/helpers"
 	. "github.com/onsi/ginkgo/v2"
@@ -17,10 +18,13 @@ var _ = Describe("GIVEN PRIVILEGED pod security admission", func() {
 		var (
 			namespace string
 			options   *k8s.KubectlOptions
+			oldLogger *logger.Logger
 		)
 		BeforeEach(func() {
 			namespace = fmt.Sprintf("%s-psa-%s", c.Prefix, strings.ToLower(random.UniqueId()))
 			options = k8s.NewKubectlOptions("", "", namespace)
+			oldLogger = options.Logger
+			options.Logger = logger.Discard
 
 			tpl, err := helpers.TemplateFile("./fixtures/namespace.yaml.tmpl", "namespace.yaml.tmpl", template.FuncMap{
 				"namespace":         namespace,
@@ -37,10 +41,10 @@ var _ = Describe("GIVEN PRIVILEGED pod security admission", func() {
 		AfterEach(func() {
 			err := k8s.DeleteNamespaceE(GinkgoT(), options, namespace)
 			Expect(err).NotTo(HaveOccurred())
+			defer func() { options.Logger = oldLogger }()
 		})
 
 		It("THEN ALLOW `spec.initContainers.securityContext.runAsNonRoot: false`", func() {
-			options := k8s.NewKubectlOptions("", "", namespace)
 			tpl, err := helpers.TemplateFile("./fixtures/dynamic-deploy.yaml.tmpl", "dynamic-deploy.yaml.tmpl", template.FuncMap{
 				"namespace":        namespace,
 				"deploymentName":   "app-" + strings.ToLower(random.UniqueId()),
@@ -54,7 +58,6 @@ var _ = Describe("GIVEN PRIVILEGED pod security admission", func() {
 		})
 
 		It("THEN ALLOW `spec.initContainers.securityContext.runAsNonRoot: true` values", func() {
-			options := k8s.NewKubectlOptions("", "", namespace)
 			tpl, err := helpers.TemplateFile("./fixtures/dynamic-deploy.yaml.tmpl", "dynamic-deploy.yaml.tmpl", template.FuncMap{
 				"namespace":        namespace,
 				"deploymentName":   "app-" + strings.ToLower(random.UniqueId()),
@@ -72,7 +75,6 @@ var _ = Describe("GIVEN PRIVILEGED pod security admission", func() {
 		})
 
 		It("THEN ALLOW `spec.initContainers.securityContext.allowPrivilegeEscalation: false`", func() {
-			options := k8s.NewKubectlOptions("", "", namespace)
 			tpl, err := helpers.TemplateFile("./fixtures/dynamic-deploy.yaml.tmpl", "dynamic-deploy.yaml.tmpl", template.FuncMap{
 				"namespace":                    namespace,
 				"deploymentName":               "app-" + strings.ToLower(random.UniqueId()),
@@ -90,7 +92,6 @@ var _ = Describe("GIVEN PRIVILEGED pod security admission", func() {
 		})
 
 		It("THEN ALLOW `spec.initContainers.securityContext.allowPrivilegeEscalation: true`", func() {
-			options := k8s.NewKubectlOptions("", "", namespace)
 			tpl, err := helpers.TemplateFile("./fixtures/dynamic-deploy.yaml.tmpl", "dynamic-deploy.yaml.tmpl", template.FuncMap{
 				"namespace":                    namespace,
 				"deploymentName":               "app-" + strings.ToLower(random.UniqueId()),
@@ -108,7 +109,6 @@ var _ = Describe("GIVEN PRIVILEGED pod security admission", func() {
 		})
 
 		It("THEN ALLOW `spec.initContainers.securityContext.capabilities.drop: ['ALL']`", func() {
-			options := k8s.NewKubectlOptions("", "", namespace)
 			tpl, err := helpers.TemplateFile("./fixtures/dynamic-deploy.yaml.tmpl", "dynamic-deploy.yaml.tmpl", template.FuncMap{
 				"namespace":            namespace,
 				"deploymentName":       "app-" + strings.ToLower(random.UniqueId()),
@@ -126,7 +126,6 @@ var _ = Describe("GIVEN PRIVILEGED pod security admission", func() {
 		})
 
 		It("THEN ALLOW `spec.initContainers.securityContext.capabilities.drop: ['NET_RAW']`", func() {
-			options := k8s.NewKubectlOptions("", "", namespace)
 			tpl, err := helpers.TemplateFile("./fixtures/dynamic-deploy.yaml.tmpl", "dynamic-deploy.yaml.tmpl", template.FuncMap{
 				"namespace":            namespace,
 				"deploymentName":       "app-" + strings.ToLower(random.UniqueId()),
@@ -144,7 +143,6 @@ var _ = Describe("GIVEN PRIVILEGED pod security admission", func() {
 		})
 
 		It("THEN ALLOW `spec.initContainers.securityContext.capabilities.add: ['SYS_TIME']`", func() {
-			options := k8s.NewKubectlOptions("", "", namespace)
 			tpl, err := helpers.TemplateFile("./fixtures/dynamic-deploy.yaml.tmpl", "dynamic-deploy.yaml.tmpl", template.FuncMap{
 				"namespace":           namespace,
 				"deploymentName":      "app-" + strings.ToLower(random.UniqueId()),
@@ -162,7 +160,6 @@ var _ = Describe("GIVEN PRIVILEGED pod security admission", func() {
 		})
 
 		It("THEN ALLOW `spec.initContainers.securityContext.runAsUser: 0`", func() {
-			options := k8s.NewKubectlOptions("", "", namespace)
 			tpl, err := helpers.TemplateFile("./fixtures/dynamic-deploy.yaml.tmpl", "dynamic-deploy.yaml.tmpl", template.FuncMap{
 				"namespace":      namespace,
 				"deploymentName": "app-" + strings.ToLower(random.UniqueId()),
@@ -180,7 +177,6 @@ var _ = Describe("GIVEN PRIVILEGED pod security admission", func() {
 		})
 
 		It("THEN ALLOW `spec.initContainers.securityContext.runAsUser: 1001`", func() {
-			options := k8s.NewKubectlOptions("", "", namespace)
 			tpl, err := helpers.TemplateFile("./fixtures/dynamic-deploy.yaml.tmpl", "dynamic-deploy.yaml.tmpl", template.FuncMap{
 				"namespace":      namespace,
 				"deploymentName": "app-" + strings.ToLower(random.UniqueId()),

--- a/test/psa_restricted_init_test.go
+++ b/test/psa_restricted_init_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/ministryofjustice/cloud-platform-infrastructure/test/helpers"
 	. "github.com/onsi/ginkgo/v2"
@@ -17,10 +18,13 @@ var _ = Describe("GIVEN RESTRICTED pod security admission", func() {
 		var (
 			namespace string
 			options   *k8s.KubectlOptions
+			oldLogger *logger.Logger
 		)
 		BeforeEach(func() {
 			namespace = fmt.Sprintf("%s-restricted-psa-%s", c.Prefix, strings.ToLower(random.UniqueId()))
 			options = k8s.NewKubectlOptions("", "", namespace)
+			oldLogger = options.Logger
+			options.Logger = logger.Discard
 
 			tpl, err := helpers.TemplateFile("./fixtures/namespace.yaml.tmpl", "namespace.yaml.tmpl", template.FuncMap{
 				"namespace":         namespace,
@@ -36,10 +40,10 @@ var _ = Describe("GIVEN RESTRICTED pod security admission", func() {
 		AfterEach(func() {
 			err := k8s.DeleteNamespaceE(GinkgoT(), options, namespace)
 			Expect(err).NotTo(HaveOccurred())
+			defer func() { options.Logger = oldLogger }()
 		})
 
 		It("THEN ALLOW `spec.initContainers.securityContext.runAsNonRoot: false`, mutation corrects value", func() {
-			options := k8s.NewKubectlOptions("", "", namespace)
 			tpl, err := helpers.TemplateFile("./fixtures/dynamic-deploy.yaml.tmpl", "dynamic-deploy.yaml.tmpl", template.FuncMap{
 				"namespace":        namespace,
 				"deploymentName":   "app-" + strings.ToLower(random.UniqueId()),
@@ -57,7 +61,6 @@ var _ = Describe("GIVEN RESTRICTED pod security admission", func() {
 		})
 
 		It("THEN ALLOW `spec.initContainers.securityContext.runAsNonRoot: true` values", func() {
-			options := k8s.NewKubectlOptions("", "", namespace)
 			tpl, err := helpers.TemplateFile("./fixtures/dynamic-deploy.yaml.tmpl", "dynamic-deploy.yaml.tmpl", template.FuncMap{
 				"namespace":        namespace,
 				"deploymentName":   "app-" + strings.ToLower(random.UniqueId()),
@@ -75,7 +78,6 @@ var _ = Describe("GIVEN RESTRICTED pod security admission", func() {
 		})
 
 		It("THEN ALLOW `spec.initContainers.securityContext.allowPrivilegeEscalation: false`", func() {
-			options := k8s.NewKubectlOptions("", "", namespace)
 			tpl, err := helpers.TemplateFile("./fixtures/dynamic-deploy.yaml.tmpl", "dynamic-deploy.yaml.tmpl", template.FuncMap{
 				"namespace":                    namespace,
 				"deploymentName":               "app-" + strings.ToLower(random.UniqueId()),
@@ -93,7 +95,6 @@ var _ = Describe("GIVEN RESTRICTED pod security admission", func() {
 		})
 
 		It("THEN ALLOW `spec.initContainers.securityContext.allowPrivilegeEscalation: true`, mutation corrects value", func() {
-			options := k8s.NewKubectlOptions("", "", namespace)
 			tpl, err := helpers.TemplateFile("./fixtures/dynamic-deploy.yaml.tmpl", "dynamic-deploy.yaml.tmpl", template.FuncMap{
 				"namespace":                    namespace,
 				"deploymentName":               "app-" + strings.ToLower(random.UniqueId()),
@@ -111,7 +112,6 @@ var _ = Describe("GIVEN RESTRICTED pod security admission", func() {
 		})
 
 		It("THEN ALLOW `spec.initContainers.securityContext.capabilities.drop: ['ALL']`", func() {
-			options := k8s.NewKubectlOptions("", "", namespace)
 			tpl, err := helpers.TemplateFile("./fixtures/dynamic-deploy.yaml.tmpl", "dynamic-deploy.yaml.tmpl", template.FuncMap{
 				"namespace":            namespace,
 				"deploymentName":       "app-" + strings.ToLower(random.UniqueId()),
@@ -129,7 +129,6 @@ var _ = Describe("GIVEN RESTRICTED pod security admission", func() {
 		})
 
 		It("THEN ALLOW `securityContext.capabilities.drop: ['NET_RAW']`, mutation corrects value", func() {
-			options := k8s.NewKubectlOptions("", "", namespace)
 			tpl, err := helpers.TemplateFile("./fixtures/dynamic-deploy.yaml.tmpl", "dynamic-deploy.yaml.tmpl", template.FuncMap{
 				"namespace":            namespace,
 				"deploymentName":       "app-" + strings.ToLower(random.UniqueId()),
@@ -147,7 +146,6 @@ var _ = Describe("GIVEN RESTRICTED pod security admission", func() {
 		})
 
 		It("THEN DENY `spec.initContainers.securityContext.capabilities.add: ['NET_RAW']`", func() {
-			options := k8s.NewKubectlOptions("", "", namespace)
 			tpl, err := helpers.TemplateFile("./fixtures/dynamic-deploy.yaml.tmpl", "dynamic-deploy.yaml.tmpl", template.FuncMap{
 				"namespace":           namespace,
 				"deploymentName":      "app-" + strings.ToLower(random.UniqueId()),
@@ -164,7 +162,6 @@ var _ = Describe("GIVEN RESTRICTED pod security admission", func() {
 
 		It("THEN DENY `spec.initContainers.securityContext.runAsUser: 0`", func() {
 			Skip("This case is not restricted by psa, skip until we implement the equivalent constraint in gatekeeper")
-			options := k8s.NewKubectlOptions("", "", namespace)
 			tpl, err := helpers.TemplateFile("./fixtures/dynamic-deploy.yaml.tmpl", "dynamic-deploy.yaml.tmpl", template.FuncMap{
 				"namespace":      namespace,
 				"deploymentName": "app-" + strings.ToLower(random.UniqueId()),
@@ -188,7 +185,6 @@ var _ = Describe("GIVEN RESTRICTED pod security admission", func() {
 		})
 
 		It("THEN ALLOW `spec.initContainers.securityContext.runAsUser: 1001`", func() {
-			options := k8s.NewKubectlOptions("", "", namespace)
 			tpl, err := helpers.TemplateFile("./fixtures/dynamic-deploy.yaml.tmpl", "dynamic-deploy.yaml.tmpl", template.FuncMap{
 				"namespace":      namespace,
 				"deploymentName": "app-" + strings.ToLower(random.UniqueId()),


### PR DESCRIPTION
This PR mask kubernetes output when doing kubernetes specific operations stopping the test logs to display serviceaccount tokens and the yaml when performing KubectlApplyFromStringE and RunKubectlAndGetOutputE
Also,  tidy-up so the tests output is readable.