### PR TITLE
Add field_manager argument to prevent labels and annotations overwriting

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/main.tf
@@ -162,6 +162,7 @@ resource "kubernetes_annotations" "kube_system_ns" {
   metadata {
     name = "kube-system"
   }
+  field_manager = "TerraformAnnotations"
   annotations = {
     "cloud-platform.justice.gov.uk/business-unit" = "Platforms"
     "cloud-platform.justice.gov.uk/application"   = "Cloud Platform"
@@ -178,6 +179,7 @@ resource "kubernetes_labels" "kube_system_ns" {
   metadata {
     name = "kube-system"
   }
+  field_manager = "TerraformLabels"
   labels = {
     "component"                                      = "kube-system"
     "cloud-platform.justice.gov.uk/slack-channel"    = "cloud-platform"


### PR DESCRIPTION
Test cluster has missing annotations when applying components and when a terraform apply is performed, it wipes the labels from kube-system namespace.

There is a open issue and the suggestion is to add filedManager.
https://github.com/hashicorp/terraform-provider-kubernetes/issues/1791

This PR allows both annotations and labels to be managed by Terraform.