### PR TITLE
Bump kuberhealthy to 1.2.9

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -234,7 +234,7 @@ module "velero" {
 }
 
 module "kuberhealthy" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-kuberhealthy?ref=1.2.8"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-kuberhealthy?ref=1.2.9"
 
   dependence_prometheus = module.monitoring.prometheus_operator_crds_status
 }


### PR DESCRIPTION
https://github.com/ministryofjustice/cloud-platform-terraform-kuberhealthy/releases/tag/1.2.9
