### PR TITLE
Bump gatekeeper for 1.9.2

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -179,7 +179,7 @@ module "monitoring" {
 }
 
 module "gatekeeper" {
-  source     = "github.com/ministryofjustice/cloud-platform-terraform-gatekeeper?ref=1.9.1"
+  source     = "github.com/ministryofjustice/cloud-platform-terraform-gatekeeper?ref=1.9.2"
   depends_on = [module.monitoring, module.modsec_ingress_controllers_v1, module.cert_manager]
 
   dryrun_map = {


### PR DESCRIPTION
https://github.com/ministryofjustice/cloud-platform-terraform-gatekeeper/releases/tag/1.9.2
