### PR TITLE
Increase retry count of ingress resolving - cert-manager test

### DIFF
--- a/test/certmanager_test.go
+++ b/test/certmanager_test.go
@@ -96,7 +96,7 @@ var _ = Describe("cert-manager", FlakeAttempts(2), func() {
 				Identifier:        "integration-test-app-ing-" + namespace + "-green",
 				Namespace:         namespace,
 				Weight:            "\"100\"",
-				IngressRetryCount: 20,
+				IngressRetryCount: 30,
 			}
 
 			err = helpers.CreateHelloWorldApp(&app, options)


### PR DESCRIPTION
This PR increases the retry count of ingress resolving to 200 OK. The certificate tests fails because of this and increase in the retry will enable to wait for long time until it get resolved.