### PR TITLE
Increasing search period to decrease monitor firing so often

### DIFF
--- a/terraform/global-resources/kibana-alerts.tf
+++ b/terraform/global-resources/kibana-alerts.tf
@@ -295,7 +295,7 @@ resource "elasticsearch_opensearch_monitor" "grafana_dashboard_fail" {
                         "range": {
                            "@timestamp": {
                               "boost": 1,
-                              "from": "{{period_end}}||-20m",
+                              "from": "{{period_end}}||-65m",
                               "to": "{{period_end}}",
                               "include_lower": true,
                               "include_upper": true,


### PR DESCRIPTION
The monitor will instead remain firing, this will decrease the message spam into the lower-priority-alerts channel