### PR TITLE
chore: 🤖 bump modsec fluent bit

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -125,7 +125,7 @@ module "modsec_ingress_controllers_v1" {
   enable_latest_tls            = true
   opensearch_modsec_audit_host = lookup(var.elasticsearch_modsec_audit_hosts_maps, terraform.workspace, "placeholder-elasticsearch")
   cluster                      = terraform.workspace
-  fluent_bit_version           = "2.1.8-amd64"
+  fluent_bit_version           = "2.2.1-amd64"
   dependence_certmanager       = "ignore"
   depends_on                   = [module.ingress_controllers_v1]
 }


### PR DESCRIPTION
We are seeing SEGV faults which is causing the fluent bit container to restart

```
[2024/01/09 06:38:39] [engine] caught signal (SIGSEGV)
#0  0x55d90465c427      in  __mk_list_del() at lib/monkey/include/monkey/mk_core/mk_list.h:141
#1  0x55d90465c45e      in  mk_list_del() at lib/monkey/include/monkey/mk_core/mk_list.h:147
#2  0x55d90465d100      in  chunk_state_sync() at lib/chunkio/src/cio_chunk.c:546
#3  0x55d90465d244      in  cio_chunk_up_force() at lib/chunkio/src/cio_chunk.c:600
#4  0x55d903d6f1d5      in  input_chunk_get() at src/flb_input_chunk.c:1061
#5  0x55d903d6fd01      in  input_chunk_append_raw() at src/flb_input_chunk.c:1460
#6  0x55d903d707f7      in  flb_input_chunk_append_raw() at src/flb_input_chunk.c:1810
#7  0x55d903e56399      in  input_log_append() at src/flb_input_log.c:71
#8  0x55d903e564e3      in  flb_input_log_append_records() at src/flb_input_log.c:119
#9  0x55d903f6c4cf      in  process_content() at plugins/in_tail/tail_file.c:604
#10 0x55d903f6ed08      in  flb_tail_file_chunk() at plugins/in_tail/tail_file.c:1415
#11 0x55d903f58ca4      in  in_tail_collect_event() at plugins/in_tail/tail.c:331
#12 0x55d903f5d7cd      in  tail_fs_event() at plugins/in_tail/tail_fs_inotify.c:276
#13 0x55d903d69816      in  flb_input_collector_fd() at src/flb_input.c:1911
#14 0x55d903da762b      in  flb_engine_handle_event() at src/flb_engine.c:543
#15 0x55d903da762b      in  flb_engine_start() at src/flb_engine.c:906
#16 0x55d903d4b26a      in  flb_lib_worker() at src/flb_lib.c:638
#17 0x7f22332cdea6      in  ???() at ???:0
#18 0x7f2232b81a2e      in  ???() at ???:0
#19 0xffffffffffffffff  in  ???() at ???:0
```

https://github.com/fluent/fluent-bit/compare/v2.1.8...v2.2.1