### PR TITLE
ci: 🎡 pin malformed yaml action

### DIFF
--- a/.github/workflows/malformed-yaml.yml
+++ b/.github/workflows/malformed-yaml.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.1
-      - uses: ministryofjustice/github-actions/malformed-yaml@main
+      - uses: ministryofjustice/github-actions/malformed-yaml@v15.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I have opened an issue with ops-eng while they fix the dependency I've pinned the version to the last working release.
https://github.com/ministryofjustice/github-actions/issues/230