### PR TITLE
Bump trivy-operator to 0.8.2

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -247,7 +247,7 @@ module "kuberhealthy" {
 }
 
 module "trivy-operator" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-trivy-operator?ref=0.8.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-trivy-operator?ref=0.8.2"
 
   depends_on = [
     module.monitoring.prometheus_operator_crds_status


### PR DESCRIPTION
https://github.com/ministryofjustice/cloud-platform-terraform-trivy-operator/releases/tag/0.8.2

Closes: https://github.com/ministryofjustice/cloud-platform/issues/5188
