### PR TITLE
fix: 🐛 placeholder-opensearch for manager cluster

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/variables.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/variables.tf
@@ -39,7 +39,8 @@ variable "opensearch_app_host_map" {
   }
 
   type = object({
-    live = string
+    manager = string
+    live    = string
   })
 }
 


### PR DESCRIPTION
The placeholder address error could be causing the other logs to fail to be flushed