### PR TITLE
Bump concourse to 1.20.4

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -1,6 +1,6 @@
 module "concourse" {
   count  = lookup(local.manager_workspace, terraform.workspace, false) ? 1 : 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-concourse?ref=1.20.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-concourse?ref=1.20.4"
 
   concourse_hostname                                = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   github_auth_client_id                             = var.github_auth_client_id


### PR DESCRIPTION
https://github.com/ministryofjustice/cloud-platform-terraform-concourse/releases/tag/1.20.4
