### PR TITLE
chore: 🤖 bump kuberhealthy

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -242,9 +242,15 @@ module "velero" {
 }
 
 module "kuberhealthy" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-kuberhealthy?ref=1.2.10"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-kuberhealthy?ref=1.3.0"
 
-  dependence_prometheus = module.monitoring.prometheus_operator_crds_status
+  cluster_env = terraform.workspace
+
+  depends_on = [
+    module.monitoring.prometheus_operator_crds_status,
+    module.velero,
+    module.gatekeeper
+  ]
 }
 
 module "trivy-operator" {


### PR DESCRIPTION
https://github.com/ministryofjustice/cloud-platform-terraform-kuberhealthy/releases/tag/1.3.0

We need to remove the count method and it's been replaced with a for_each which causes the k8s manifests to be deleted and recreated (not referred to via index any more)