### PR TITLE
perf: ⚡️ bump replicas to alleviate timeouts

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -100,7 +100,7 @@ module "external_secrets_operator" {
 module "ingress_controllers_v1" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.7.5"
 
-  replica_count       = lookup(local.live_workspace, terraform.workspace, false) ? "12" : "3"
+  replica_count       = lookup(local.live_workspace, terraform.workspace, false) ? "30" : "3"
   controller_name     = "default"
   enable_latest_tls   = true
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
@@ -136,23 +136,6 @@ module "modsec_ingress_controllers_v1" {
 
   depends_on = [module.ingress_controllers_v1]
 }
-
-module "ingress_controllers_v1_test" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.7.4"
-
-  replica_count       = "3"
-  controller_name     = "testing"
-  enable_latest_tls   = true
-  cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
-  is_live_cluster     = lookup(local.prod_workspace, terraform.workspace, false)
-  live1_cert_dns_name = lookup(local.live1_cert_dns_name, terraform.workspace, "")
-
-  # Enable this when we remove the module "ingress_controllers"
-  enable_external_dns_annotation = true
-
-  depends_on = [module.cert_manager.helm_cert_manager_status]
-}
-
 
 module "kuberos" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-kuberos?ref=0.5.5"

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -98,7 +98,7 @@ module "external_secrets_operator" {
   ]
 }
 module "ingress_controllers_v1" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.7.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.7.6"
 
   replica_count       = lookup(local.live_workspace, terraform.workspace, false) ? "30" : "3"
   controller_name     = "default"
@@ -117,7 +117,7 @@ module "ingress_controllers_v1" {
 }
 
 module "modsec_ingress_controllers_v1" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.7.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.7.6"
 
   replica_count       = lookup(local.live_workspace, terraform.workspace, false) ? "12" : "3"
   controller_name     = "modsec"


### PR DESCRIPTION
Following further testing, we've seen an notable decrease in timeouts when we increase the number of ingress replicas. See the testing results below:

Summary:
> Success rate: 99.37% -> 99.92%
>   [54] timeout -> [6]
>   [5] Connection reset by peer (os error 104) -> [2]
>   [4] connection error -> [0]

3 ingress replicas:

```
Summary:
  Success rate: 99.37%
  Total:        48.6973 secs
  Slowest:      11.5267 secs
  Fastest:      0.0063 secs
  Average:      4.7402 secs
  Requests/sec: 205.3502
  Total data:   19.41 KiB
  Size/request: 2
  Size/sec:     408 B
Response time histogram:
   0.006 [1]    |
   1.158 [1594] |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
   2.310 [1044] |■■■■■■■■■■■■■■■■■■■
   3.462 [1172] |■■■■■■■■■■■■■■■■■■■■■
   4.614 [1008] |■■■■■■■■■■■■■■■■■■
   5.767 [1023] |■■■■■■■■■■■■■■■■■■
   6.919 [1001] |■■■■■■■■■■■■■■■■■■
   8.071 [1748] |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
   9.223 [1053] |■■■■■■■■■■■■■■■■■■■
  10.375 [228]  |■■■■
  11.527 [65]   |■
Response time distribution:
  10.00% in 1.0123 secs
  25.00% in 2.0485 secs
  50.00% in 5.0114 secs
  75.00% in 7.0247 secs
  90.00% in 9.0115 secs
  95.00% in 9.0255 secs
  99.00% in 10.3378 secs
  99.90% in 11.2973 secs
  99.99% in 11.5267 secs
Details (average, fastest, slowest):
  DNS+dialup:   0.2415 secs, 0.0044 secs, 2.5178 secs
  DNS-lookup:   0.0000 secs, 0.0000 secs, 0.0073 secs
Status code distribution:
  [200] 9937 responses
Error distribution:
  [54] timeout
  [5] Connection reset by peer (os error 104)
  [4] connection error
```

30 replicas
```
Summary:
  Success rate: 99.92%
  Total:        45.7034 secs
  Slowest:      11.4282 secs
  Fastest:      0.0059 secs
  Average:      4.7180 secs
  Requests/sec: 218.8023

  Total data:   19.52 KiB
  Size/request: 2
  Size/sec:     437 B

Response time histogram:
   0.006 [1]    |
   1.148 [1635] |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
   2.290 [1138] |■■■■■■■■■■■■■■■■■■■■
   3.433 [1083] |■■■■■■■■■■■■■■■■■■■
   4.575 [981]  |■■■■■■■■■■■■■■■■■■
   5.717 [1008] |■■■■■■■■■■■■■■■■■■
   6.859 [1056] |■■■■■■■■■■■■■■■■■■■
   8.002 [956]  |■■■■■■■■■■■■■■■■■
   9.144 [1738] |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  10.286 [290]  |■■■■■
  11.428 [106]  |■

Response time distribution:
  10.00% in 1.0101 secs
  25.00% in 2.0144 secs
  50.00% in 5.0097 secs
  75.00% in 7.0141 secs
  90.00% in 9.0099 secs
  95.00% in 9.0158 secs
  99.00% in 10.2919 secs
  99.90% in 11.0331 secs
  99.99% in 11.4282 secs


Details (average, fastest, slowest):
  DNS+dialup:   0.2280 secs, 0.0043 secs, 2.4326 secs
  DNS-lookup:   0.0000 secs, 0.0000 secs, 0.0001 secs

Status code distribution:
  [200] 9992 responses

Error distribution:
  [6] timeout
  [2] Connection reset by peer (os error 104)
```

Going forward:

We will monitor the rate of 499s over the next week and communicate with the user. If this does not impact the user's timeouts then we will move them onto a production-only ingress and observe the results there.
