### PR TITLE
switching components to new kubectl tf provider

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/versions.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/versions.tf
@@ -17,8 +17,8 @@ terraform {
       version = ">= 3.2.1"
     }
     kubectl = {
-      source  = "gavinbunney/kubectl"
-      version = "1.13.2"
+      source  = "alekc/kubectl"
+      version = "2.0.4"
     }
     http = {
       source  = "hashicorp/http"


### PR DESCRIPTION
for calico crds and gp2 manifest objects

relates to ministryofjustice/cloud-platform#5380