### PR TITLE
switch gatekeeper module to alekc kubectl provider

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components/components.tf
@@ -211,7 +211,7 @@ module "monitoring" {
 }
 
 module "gatekeeper" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-gatekeeper?ref=1.10.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-gatekeeper?ref=1.11.0"
 
   dryrun_map = {
     service_type                       = false,


### PR DESCRIPTION
Relates to ministryofjustice/cloud-platform#5380