### PR TITLE
Revert "reduce external-dns polling for live-2"

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
@@ -81,7 +81,7 @@ module "external_dns" {
 
 
   # For tuning external_dns config for production vs test clusters
-  is_live_cluster = lookup(local.prod_workspace, terraform.workspace, false)
+  is_live_cluster = lookup(local.prod_workspace, terraform.workspace, false) || terraform.workspace == "live-2"
 
   eks_cluster_oidc_issuer_url = data.terraform_remote_state.cluster.outputs.cluster_oidc_issuer_url
 


### PR DESCRIPTION
Reverts ministryofjustice/cloud-platform-infrastructure#2933

This causes the integration tests for live-2 to fail on external-dns and cert-manager tests