### PR TITLE
reduce window of time for observed throttling messages

### DIFF
--- a/terraform/global-resources/kibana-alerts.tf
+++ b/terraform/global-resources/kibana-alerts.tf
@@ -460,7 +460,7 @@ resource "elasticsearch_opensearch_monitor" "external_dns_throttling" {
                     "range": {
                       "@timestamp": {
                          "boost": 1,
-                         "from": "{{period_end}}||-10m",
+                         "from": "{{period_end}}||-1m",
                          "to": "{{period_end}}",
                          "include_lower": true,
                          "include_upper": true,


### PR DESCRIPTION
external-dns uses [aws sdk retryer](https://aws.github.io/aws-sdk-go-v2/docs/configuring-sdk/retries-timeouts/#standard-retryer) set to max 3 attempts with sensible backoff defaults. We are probably being too sensitive with our throttling alert triggers. 

Relates to ministryofjustice/cloud-platform#5326

