### PR TITLE
Increase minimum default node group to 60

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
@@ -21,14 +21,14 @@ locals {
   # desired_capcity change is a manual step after initial cluster creation (when no cluster-autoscaler)
   # https://github.com/terraform-aws-modules/terraform-aws-eks/issues/835
   node_groups_count = {
-    live    = "64"
+    live    = "60"
     live-2  = "7"
     manager = "4"
     default = "3"
   }
   # Default node group minimum capacity 
   default_ng_min_count = {
-    live    = "55"
+    live    = "60"
     live-2  = "2"
     manager = "4"
     default = "2"


### PR DESCRIPTION
Increase minimum default node group to 60 on live cluster