### PR TITLE
Bump monitoring to 3.7.3

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
@@ -192,7 +192,7 @@ module "logging" {
 }
 
 module "monitoring" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=3.7.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=3.7.3"
 
   alertmanager_slack_receivers               = local.enable_alerts ? var.alertmanager_slack_receivers : [{ severity = "dummy", webhook = "https://dummy.slack.com", channel = "#dummy-alarms" }]
   pagerduty_config                           = local.enable_alerts ? var.pagerduty_config : "dummy"


### PR DESCRIPTION
https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/releases/tag/3.7.3
