### PR TITLE
Fix node version bump to match actual version

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/account/modsec-opensearch.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/modsec-opensearch.tf
@@ -258,7 +258,7 @@ resource "auth0_action" "add-github-teams-to-opensearch-saml" {
 
   dependencies {
     name    = "node-fetch"
-    version = "2"
+    version = "2.7.0"
   }
 
   secrets {


### PR DESCRIPTION
The node version is bumped to 2.7.0 for the auth0 action. Fix the code to match the actual version
