### PR TITLE
Bump OpenSearch CloudWatch Alarm version

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/account/app-opensearch.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/app-opensearch.tf
@@ -381,10 +381,10 @@ resource "auth0_rule_config" "opensearch_app_logs_client_id" {
 }
 
 module "live_app_logs_opensearch_monitoring" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-opensearch-cloudwatch-alarm?ref=0.0.1"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-opensearch-cloudwatch-alarm?ref=0.0.2"
   alarm_name_prefix   = "CP-live-app-logs-"
   domain_name         = local.live_app_logs_domain
   sns_topic           = module.baselines.slack_sns_topic
-  min_available_nodes = "12"
+  min_available_nodes = aws_opensearch_domain.live_app_logs.cluster_config[0].instance_count
   tags                = local.app_logs_tags
 }

--- a/terraform/aws-accounts/cloud-platform-aws/account/modsec-opensearch.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/modsec-opensearch.tf
@@ -415,10 +415,10 @@ resource "elasticsearch_opensearch_roles_mapping" "all_org_members" {
 }
 
 module "live_mod_sec_opensearch_monitoring" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-opensearch-cloudwatch-alarm?ref=0.0.1"
+  source              = "github.com/ministryofjustice/cloud-platform-terraform-opensearch-cloudwatch-alarm?ref=0.0.2"
   alarm_name_prefix   = "CP-live-mod-sec-"
   domain_name         = local.live_modsec_audit_domain
   sns_topic           = module.baselines.slack_sns_topic
-  min_available_nodes = "3"
+  min_available_nodes = aws_opensearch_domain.live_modsec_audit.cluster_config[0].instance_count
   tags                = local.mod_sec_tags
 }


### PR DESCRIPTION
- Bump OpenSearch CloudWatch Alarm version
- Get the module min_available_nodes value from attribute reference instead of hardcoding it