### PR TITLE
perf: ⚡️ increase data node size to raise jvm heap size (match current elastic search)

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/account/app-opensearch.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/app-opensearch.tf
@@ -132,7 +132,7 @@ resource "aws_opensearch_domain" "live_app_logs" {
   }
 
   cluster_config {
-    instance_type            = "r6g.xlarge.search"
+    instance_type            = "r6g.4xlarge.search"
     instance_count           = "12"
     dedicated_master_enabled = true
     dedicated_master_type    = "m6g.large.search"


### PR DESCRIPTION
By default, OpenSearch Service uses 50% of an instance's RAM for JVM heaps up to 32 GiB in size. The JVM memory pressure specifies the percentage of the Java heap in a cluster node.
https://repost.aws/knowledge-center/opensearch-high-jvm-memory-pressure

https://aws.amazon.com/opensearch-service/pricing/

current elastic search: https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/f34a90e82313ac473e023d1d90a57673bdb304e1/terraform/global-resources/elasticsearch.tf#L169