### PR TITLE
perf: ⚡️ configure shard sizes and set n data nodes

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/account/app-opensearch-index-templates.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/app-opensearch-index-templates.tf
@@ -96,7 +96,7 @@ resource "opensearch_index_template" "manager_eventrouter" {
   body     = <<EOF
 {
   "index_patterns": [
-    "live_eventrouter-*"
+    "manager_eventrouter-*"
   ],
     "settings": {
       "index": {

--- a/terraform/aws-accounts/cloud-platform-aws/account/app-opensearch-index-templates.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/app-opensearch-index-templates.tf
@@ -1,5 +1,15 @@
+provider "opensearch" {
+  alias               = "app_logs"
+  url                 = "https://${aws_opensearch_domain.live_app_logs.endpoint}"
+  aws_assume_role_arn = aws_iam_role.os_access_role_app_logs.arn
+  aws_profile         = "moj-cp"
+  sign_aws_requests   = true
+  healthcheck         = false
+  sniff               = false
+}
+
 resource "opensearch_index_template" "live_kubernetes_cluster" {
-  provider = elasticsearch.app_logs
+  provider = opensearch.app_logs
   name     = "live_kubernetes_cluster"
   body     = <<EOF
 {
@@ -17,7 +27,7 @@ EOF
 }
 
 resource "opensearch_index_template" "live_kubernetes_ingress" {
-  provider = elasticsearch.app_logs
+  provider = opensearch.app_logs
   name     = "live_kubernetes_ingress"
   body     = <<EOF
 {
@@ -35,7 +45,7 @@ EOF
 }
 
 resource "opensearch_index_template" "live_eventrouter" {
-  provider = elasticsearch.app_logs
+  provider = opensearch.app_logs
 
   name = "live_eventrouter"
   body = <<EOF
@@ -54,7 +64,7 @@ EOF
 }
 
 resource "opensearch_index_template" "manager_kubernetes_cluster" {
-  provider = elasticsearch.app_logs
+  provider = opensearch.app_logs
 
   name = "manager_kubernetes_cluster"
   body = <<EOF
@@ -73,7 +83,7 @@ EOF
 }
 
 resource "opensearch_index_template" "manager_kubernetes_ingress" {
-  provider = elasticsearch.app_logs
+  provider = opensearch.app_logs
   name     = "manager_kubernetes_ingress"
   body     = <<EOF
 {
@@ -91,7 +101,7 @@ EOF
 }
 
 resource "opensearch_index_template" "manager_eventrouter" {
-  provider = elasticsearch.app_logs
+  provider = opensearch.app_logs
   name     = "manager_eventrouter"
   body     = <<EOF
 {

--- a/terraform/aws-accounts/cloud-platform-aws/account/app-opensearch-index-templates.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/app-opensearch-index-templates.tf
@@ -1,6 +1,7 @@
 resource "opensearch_index_template" "live_kubernetes_cluster" {
-  name = "live_kubernetes_cluster"
-  body = <<EOF
+  provider = elasticsearch.app_logs
+  name     = "live_kubernetes_cluster"
+  body     = <<EOF
 {
   "index_patterns": [
     "live_kuberenetes_cluster-*"
@@ -16,8 +17,9 @@ EOF
 }
 
 resource "opensearch_index_template" "live_kubernetes_ingress" {
-  name = "live_kubernetes_ingress"
-  body = <<EOF
+  provider = elasticsearch.app_logs
+  name     = "live_kubernetes_ingress"
+  body     = <<EOF
 {
   "index_patterns": [
     "live_kuberenetes_ingress-*"
@@ -33,6 +35,8 @@ EOF
 }
 
 resource "opensearch_index_template" "live_eventrouter" {
+  provider = elasticsearch.app_logs
+
   name = "live_eventrouter"
   body = <<EOF
 {
@@ -50,6 +54,8 @@ EOF
 }
 
 resource "opensearch_index_template" "manager_kubernetes_cluster" {
+  provider = elasticsearch.app_logs
+
   name = "manager_kubernetes_cluster"
   body = <<EOF
 {
@@ -67,8 +73,9 @@ EOF
 }
 
 resource "opensearch_index_template" "manager_kubernetes_ingress" {
-  name = "manager_kubernetes_ingress"
-  body = <<EOF
+  provider = elasticsearch.app_logs
+  name     = "manager_kubernetes_ingress"
+  body     = <<EOF
 {
   "index_patterns": [
     "manager_kuberenetes_ingress-*"
@@ -84,8 +91,9 @@ EOF
 }
 
 resource "opensearch_index_template" "manager_eventrouter" {
-  name = "manager_eventrouter"
-  body = <<EOF
+  provider = elasticsearch.app_logs
+  name     = "manager_eventrouter"
+  body     = <<EOF
 {
   "index_patterns": [
     "live_eventrouter-*"

--- a/terraform/aws-accounts/cloud-platform-aws/account/app-opensearch-index-templates.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/app-opensearch-index-templates.tf
@@ -1,13 +1,3 @@
-provider "opensearch" {
-  alias               = "app_logs"
-  url                 = "https://${aws_opensearch_domain.live_app_logs.endpoint}"
-  aws_assume_role_arn = aws_iam_role.os_access_role_app_logs.arn
-  aws_profile         = "moj-cp"
-  sign_aws_requests   = true
-  healthcheck         = false
-  sniff               = false
-}
-
 resource "opensearch_index_template" "live_kubernetes_cluster" {
   provider = opensearch.app_logs
   name     = "live_kubernetes_cluster"

--- a/terraform/aws-accounts/cloud-platform-aws/account/app-opensearch-index-templates.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/app-opensearch-index-templates.tf
@@ -12,7 +12,6 @@ resource "opensearch_index_template" "live_kubernetes_cluster" {
       }
     }
   }
-}
 EOF
 }
 
@@ -29,7 +28,6 @@ resource "opensearch_index_template" "live_kubernetes_ingress" {
         "number_of_replicas": "1"
       }
     }
-  }
 }
 EOF
 }
@@ -47,7 +45,6 @@ resource "opensearch_index_template" "live_eventrouter" {
         "number_of_replicas": "1"
       }
     }
-  }
 }
 EOF
 }
@@ -65,7 +62,6 @@ resource "opensearch_index_template" "manager_kubernetes_cluster" {
         "number_of_replicas": "1"
       }
     }
-  }
 }
 EOF
 }
@@ -83,7 +79,6 @@ resource "opensearch_index_template" "manager_kubernetes_ingress" {
         "number_of_replicas": "1"
       }
     }
-  }
 }
 EOF
 }
@@ -102,6 +97,5 @@ resource "opensearch_index_template" "manager_eventrouter" {
       }
     }
   }
-}
 EOF
 }

--- a/terraform/aws-accounts/cloud-platform-aws/account/app-opensearch-index-templates.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/app-opensearch-index-templates.tf
@@ -1,0 +1,107 @@
+resource "opensearch_index_template" "live_kubernetes_cluster" {
+  name = "live_kubernetes_cluster"
+  body = <<EOF
+{
+  "index_patterns": [
+    "live_kuberenetes_cluster-*"
+  ],
+    "settings": {
+      "index": {
+        "number_of_shards": "15",
+        "number_of_replicas": "1"
+      }
+    }
+  }
+}
+EOF
+}
+
+resource "opensearch_index_template" "live_kubernetes_ingress" {
+  name = "live_kubernetes_ingress"
+  body = <<EOF
+{
+  "index_patterns": [
+    "live_kuberenetes_ingress-*"
+  ],
+    "settings": {
+      "index": {
+        "number_of_shards": "1",
+        "number_of_replicas": "1"
+      }
+    }
+  }
+}
+EOF
+}
+
+resource "opensearch_index_template" "live_eventrouter" {
+  name = "live_eventrouter"
+  body = <<EOF
+{
+  "index_patterns": [
+    "live_eventrouter-*"
+  ],
+    "settings": {
+      "index": {
+        "number_of_shards": "1",
+        "number_of_replicas": "1"
+      }
+    }
+  }
+}
+EOF
+}
+
+resource "opensearch_index_template" "manager_kubernetes_cluster" {
+  name = "manager_kubernetes_cluster"
+  body = <<EOF
+{
+  "index_patterns": [
+    "manager_kuberenetes_cluster-*"
+  ],
+    "settings": {
+      "index": {
+        "number_of_shards": "1",
+        "number_of_replicas": "1"
+      }
+    }
+  }
+}
+EOF
+}
+
+resource "opensearch_index_template" "manager_kubernetes_ingress" {
+  name = "manager_kubernetes_ingress"
+  body = <<EOF
+{
+  "index_patterns": [
+    "manager_kuberenetes_ingress-*"
+  ],
+    "settings": {
+      "index": {
+        "number_of_shards": "1",
+        "number_of_replicas": "1"
+      }
+    }
+  }
+}
+EOF
+}
+
+resource "opensearch_index_template" "manager_eventrouter" {
+  name = "manager_eventrouter"
+  body = <<EOF
+{
+  "index_patterns": [
+    "live_eventrouter-*"
+  ],
+    "settings": {
+      "index": {
+        "number_of_shards": "1",
+        "number_of_replicas": "1"
+      }
+    }
+  }
+}
+EOF
+}

--- a/terraform/aws-accounts/cloud-platform-aws/account/app-opensearch.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/app-opensearch.tf
@@ -133,7 +133,7 @@ resource "aws_opensearch_domain" "live_app_logs" {
 
   cluster_config {
     instance_type            = "r6g.4xlarge.search"
-    instance_count           = "12"
+    instance_count           = "15"
     dedicated_master_enabled = true
     dedicated_master_type    = "m6g.large.search"
     dedicated_master_count   = "5"


### PR DESCRIPTION
- shards should be set to ~30gb each
- shards should be a multiple of data nodes

with 5 shards set our live cluster logs:

```
live_kubernetes_cluster-2024.05.24 0     p      STARTED 201889968 85.9gb x.x.x.x 6a9ac9a283d158e32ae8a6d6e3e3679d
```