### PR TITLE
:arrow_up: bumping awsaccounts-baselines module

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/account/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/main.tf
@@ -82,7 +82,7 @@ module "sso" {
 
 # Baselines: cloudtrail, cloudwatch, lambda. Everything that our accounts should have
 module "baselines" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-awsaccounts-baselines?ref=0.2.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-awsaccounts-baselines?ref=0.2.2"
 
   enable_logging           = true
   enable_slack_integration = true


### PR DESCRIPTION
This bumps the baselines module. The module will now terraform [output the s3 bucket arn of where the cloudtrail logs](https://github.com/ministryofjustice/cloud-platform-terraform-awsaccounts-baselines/pull/27) are going to.

Related to [pushing Cloudtrail logs to cortex issue](https://github.com/ministryofjustice/cloud-platform/issues/5608)