### PR TITLE
:wrench: adding path to iam user

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/account/sqs.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/sqs.tf
@@ -79,6 +79,7 @@ resource "aws_iam_policy" "sqs_queue_read_policy" {
 # Creates an IAM user that will access the sqs queue and read Cloudtrail bucket
 resource "aws_iam_user" "cortex_xsiam_user" {
   name = "cortex_xsiam_user"
+  path = "/cloud-platform/soc/"
 }
 
 resource "aws_iam_user_policy_attachment" "sqs_queue_read_policy_attachment" {


### PR DESCRIPTION
Fixes [this](https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/infrastructure-account/jobs/terraform-apply/builds/58)

Adding iam user under a `path` as the pipeline user `manager-concourse` only has permissions to create IAM user under these.