### PR TITLE
perf: Bump Elasticsearch ebs volume to 4TB

### DIFF
--- a/terraform/global-resources/elasticsearch.tf
+++ b/terraform/global-resources/elasticsearch.tf
@@ -186,7 +186,7 @@ resource "aws_elasticsearch_domain" "live_1" {
   ebs_options {
     ebs_enabled = "true"
     volume_type = "gp3"
-    volume_size = "3072"
+    volume_size = "4000"
     iops        = 13000 # limit is 16,000 https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volume-types.html
     throughput  = 500   # limit is 1,000
   }


### PR DESCRIPTION
Alerts are triggered for ElasticSearch not having enough minimum free storage - `FreeStorageSpaceTooLow`.

Attached shows some of the data node storage is really low.

<img width="1574" alt="es" src="https://github.com/ministryofjustice/cloud-platform-infrastructure/assets/152907271/732944f2-f1a1-4237-a6ef-ed12f1f56ec3">
