### PR TITLE
perf: Bump OpenSearch ebs volume to 4TB

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/account/app-opensearch.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/app-opensearch.tf
@@ -155,7 +155,7 @@ resource "aws_opensearch_domain" "live_app_logs" {
   ebs_options {
     ebs_enabled = "true"
     volume_type = "gp3"
-    volume_size = "3072"
+    volume_size = "4000"
     iops        = "16000" # limit is 16,000 https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volume-types.html
     throughput  = "593"   # Throughput scales proportionally up. iops x 0.25 (maximum 4,000) https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/general-purpose.html
   }


### PR DESCRIPTION
Alerts are triggered for OpenSearch not having enough minimum free storage - FreeStorageSpaceTooLow.

Attached shows some of the data node storage is really low.

<img width="1592" alt="image" src="https://github.com/ministryofjustice/cloud-platform-infrastructure/assets/152907271/f3b3db8f-32ee-42f1-9223-5f89f14c132c">
