### PR TITLE
perf: ⚡️increase promethues replicas so we have one per az

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
@@ -103,7 +103,7 @@ locals {
     }
   }
 
-  monitoring_ng_24_06_24 = {
+  monitoring_ng_12_12_23 = {
     desired_size = 4
     max_size     = 6
     min_size     = 4
@@ -185,7 +185,7 @@ module "eks" {
 
   eks_managed_node_groups = {
     default_ng_12_12_23    = local.default_ng_12_12_23
-    monitoring_ng_24_06_24 = local.monitoring_ng_24_06_24
+    monitoring_ng_12_12_23 = local.monitoring_ng_12_12_23
   }
 
   iam_role_additional_policies = ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"]

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
@@ -103,10 +103,10 @@ locals {
     }
   }
 
-  monitoring_ng_12_12_23 = {
-    desired_size = 2
-    max_size     = 3
-    min_size     = 2
+  monitoring_ng_24_06_24 = {
+    desired_size = 4
+    max_size     = 6
+    min_size     = 4
     block_device_mappings = {
       xvda = {
         device_name = "/dev/xvda"
@@ -122,7 +122,7 @@ locals {
     }
 
 
-    subnet_ids = data.aws_subnets.private_zone_2b.ids
+    subnet_ids = data.aws_subnets.private.ids
     name       = "${terraform.workspace}-mon-ng"
 
     create_security_group  = false
@@ -185,7 +185,7 @@ module "eks" {
 
   eks_managed_node_groups = {
     default_ng_12_12_23    = local.default_ng_12_12_23
-    monitoring_ng_12_12_23 = local.monitoring_ng_12_12_23
+    monitoring_ng_24_06_24 = local.monitoring_ng_24_06_24
   }
 
   iam_role_additional_policies = ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"]

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
@@ -207,7 +207,7 @@ module "logging" {
 }
 
 module "monitoring" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=3.9.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=3.9.2"
 
   alertmanager_slack_receivers  = local.enable_alerts ? var.alertmanager_slack_receivers : [{ severity = "dummy", webhook = "https://dummy.slack.com", channel = "#dummy-alarms" }]
   pagerduty_config              = local.enable_alerts ? var.pagerduty_config : "dummy"

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
@@ -207,7 +207,7 @@ module "logging" {
 }
 
 module "monitoring" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=3.9.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=3.9.1"
 
   alertmanager_slack_receivers  = local.enable_alerts ? var.alertmanager_slack_receivers : [{ severity = "dummy", webhook = "https://dummy.slack.com", channel = "#dummy-alarms" }]
   pagerduty_config              = local.enable_alerts ? var.pagerduty_config : "dummy"

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
@@ -207,7 +207,7 @@ module "logging" {
 }
 
 module "monitoring" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=3.8.6"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=3.9.0"
 
   alertmanager_slack_receivers  = local.enable_alerts ? var.alertmanager_slack_receivers : [{ severity = "dummy", webhook = "https://dummy.slack.com", channel = "#dummy-alarms" }]
   pagerduty_config              = local.enable_alerts ? var.pagerduty_config : "dummy"

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/main.tf
@@ -75,23 +75,6 @@ data "aws_subnets" "private" {
   }
 }
 
-# This is to get subnet_id, to create a separate node group for monitoring with 2 nodes in "eu-west-2b".
-data "aws_subnets" "private_zone_2b" {
-  filter {
-    name   = "vpc-id"
-    values = [data.aws_vpc.selected.id]
-  }
-
-  filter {
-    name   = "availability-zone"
-    values = ["eu-west-2b"]
-  }
-
-  tags = {
-    SubnetType = "Private"
-  }
-}
-
 data "aws_subnets" "public" {
   filter {
     name   = "vpc-id"


### PR DESCRIPTION
To combat flakey Prometheus and downtime routinely affecting our users, increase the Prometheus replicas to increase resilience. We currently have one Prometheus in a private subnet in `eu-west-2b`. Increase this to 3 one in each AZ (`eu-west-2a/b/c`).

The 3 Prometheis scrape the same targets, meaning we have duplicated each metric twice (3 times in total). To deduplicate this there are 2 steps:

- prometheus deduplicates at the the query level (see the "use deduplication" checkbox in the prom UI)
- thanos compactor runs against the blocks in storage and dedupes the metrics back down to 1. This process runs after the metrics are pushed to s3. So for some time (currently 24hrs) there will be duplicate metrics, this can be reduced by lowering the `--delete-delay=Xh` flag in the Thanos compactor (once the metrics are compacted there's no reason to keep hold of the duplicated original metrics, except the last 2 hours needed for prom UI).

The compactor will be doing a lot more work so keep an eye on resources and bump container resource limits when necessary (watch `#lower-priority-alarms`) and keep an eye on the [compactor performance](https://grafana.manager.cloud-platform.service.justice.gov.uk/d/6581e46e4e5c7ba40a07646395ef7b23/kubernetes-compute-resources-pod?orgId=1&refresh=10s&var-datasource=P5DCFC7561CCDE821&var-cluster=&var-namespace=monitoring&var-pod=thanos-compactor-6bdbfb7b9f-xv7fx&from=now-3h&to=now) and [backlog](https://grafana.live.cloud-platform.service.justice.gov.uk/d/19fa341d-ae9d-4817-8a92-96b5df5ccd0a/thanos-overview?orgId=1). Also consider raising the concurrency setting significantly.

https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/releases/tag/3.9.0

[closes #5743](https://github.com/ministryofjustice/cloud-platform/issues/5743)