### PR TITLE
chore: 🤖 bump autoscaler for k8s 1.28

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
@@ -38,7 +38,7 @@ module "concourse" {
 }
 
 module "cluster_autoscaler" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-cluster-autoscaler?ref=1.9.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-cluster-autoscaler?ref=1.10.0"
 
   enable_overprovision        = lookup(local.prod_workspace, terraform.workspace, false)
   cluster_domain_name         = data.terraform_remote_state.cluster.outputs.cluster_domain_name


### PR DESCRIPTION
Release:
https://github.com/ministryofjustice/cloud-platform-terraform-cluster-autoscaler/releases/tag/1.10.0

relates to ministryofjustice/cloud-platform#5582