### PR TITLE
⬆️ bump flowlogs module

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/main.tf
@@ -103,7 +103,7 @@ module "vpc" {
 
 ### 
 module "flowlogs" {
-  source     = "github.com/ministryofjustice/cloud-platform-terraform-flow-logs?ref=1.3.4"
+  source     = "github.com/ministryofjustice/cloud-platform-terraform-flow-logs?ref=1.3.5"
   is_enabled = terraform.workspace == "live-1" ? true : false
   vpc_id     = module.vpc.vpc_id
 }

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/outputs.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/outputs.tf
@@ -64,6 +64,6 @@ output "public_route_tables" {
 }
 
 output "vpc_flowlogs_bucket_arn" {
-  value       = terraform.workspace == "live-1" ? module.flowlogs.s3_bucket_arn : null
+  value       = module.flowlogs.s3_bucket_arn
   description = "VPC Flowlogs bucket arn"
 }


### PR DESCRIPTION
This PR bumps the `flowlogs` module.

The module will terraform output the s3 bucket arn of the VPC flowlogs.  PR of the changes to the module [here](https://github.com/ministryofjustice/cloud-platform-terraform-flow-logs/pull/11) and [here](https://github.com/ministryofjustice/cloud-platform-terraform-flow-logs/pull/12)

The PR relates to [Push Production VPC flow logs to Cortex](https://github.com/ministryofjustice/cloud-platform/issues/5609)