### PR TITLE
✨VPC Flowlogs to Cortex Xsiam - second take

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/account/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/main.tf
@@ -45,6 +45,18 @@ provider "aws" {
   }
 }
 
+# get access to live-1 VPC state
+# Necessary to get flowlogs bucket id/arn for SQS
+data "terraform_remote_state" "live-1" {
+  backend = "s3"
+  config = {
+    bucket  = "cloud-platform-terraform-state"
+    region  = "eu-west-1"
+    key     = "aws-accounts/cloud-platform-aws/vpc/live-1/terraform.tfstate"
+    profile = "moj-cp"
+  }
+}
+
 # used for cloudfront/waf
 provider "aws" {
   alias  = "northvirginia"

--- a/terraform/aws-accounts/cloud-platform-aws/account/sqs.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/sqs.tf
@@ -1,4 +1,4 @@
-# This covers the SQS and related infrastructure that allows Cortex XSIAM service to access updates to the cloudtrail logging bucket
+#### This covers the SQS and related infrastructure that allows Cortex XSIAM service to access updates to the cloudtrail logging bucket
 
 # SQS Queue to present the logging bucket updates
 resource "aws_sqs_queue" "cp_cloudtrail_log_queue" {
@@ -45,7 +45,54 @@ resource "aws_s3_bucket_notification" "logging_bucket_notification" {
   }
 }
 
-##### Assumable IAM Role & Resources to access the sqs queue and read cloudtrail bucket
+#### This covers the SQS and related infrastructure that allows Cortex XSIAM service to access updates to live-1 VPC Flowlogs logging bucket
+
+# SQS Queue to present the VPC flowlogs bucket updates
+resource "aws_sqs_queue" "cp_vpc_flowlogs_log_queue" {
+  name                       = "cp_vpc_flowlogs_log_queue"
+  sqs_managed_sse_enabled    = true   # Using managed encryption
+  delay_seconds              = 0      # The default is 0 but can be up to 15 minutes
+  max_message_size           = 262144 # 256k which is the max size
+  message_retention_seconds  = 345600 # This is 4 days. The max is 14 days
+  visibility_timeout_seconds = 30     # This is only useful for queues that have multiple subscribers
+}
+
+# This policy grants queue send message from the VPC flowlogs bucket
+resource "aws_sqs_queue_policy" "vpc_flowlogs_queue_policy" {
+  queue_url = aws_sqs_queue.cp_vpc_flowlogs_log_queue.id
+  policy    = data.aws_iam_policy_document.vpc_flowlogs_queue_policy_document.json
+}
+
+data "aws_iam_policy_document" "vpc_flowlogs_queue_policy_document" {
+  statement {
+    sid    = "AllowSendMessage"
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["s3.amazonaws.com"]
+    }
+    actions = ["sqs:SendMessage"]
+    resources = [
+      aws_sqs_queue.cp_vpc_flowlogs_log_queue.arn
+    ]
+    condition {
+      test     = "ArnEquals"
+      variable = "aws:SourceArn"
+      values   = [data.terraform_remote_state.live-1.outputs.vpc_flowlogs_bucket_arn]
+    }
+  }
+}
+
+# S3 bucket event notification for updates from the VPC flowlogs bucket
+resource "aws_s3_bucket_notification" "vpc_flowlogs_bucket_notification" {
+  bucket = data.terraform_remote_state.live-1.outputs.vpc_flowlogs_bucket_id
+  queue {
+    queue_arn = aws_sqs_queue.cp_vpc_flowlogs_log_queue.arn
+    events    = ["s3:ObjectCreated:*"] # Events to trigger the notification
+  }
+}
+
+##### IAM User & Resources to access the sqs queue and read cloudtrail bucket
 
 # Create an IAM policy document to allow access to the SQS Queue and cloudtrail bucket
 data "aws_iam_policy_document" "sqs_queue_read_document" {
@@ -59,13 +106,21 @@ data "aws_iam_policy_document" "sqs_queue_read_document" {
       "sqs:GetQueueUrl",
       "sqs:ListQueues"
     ]
-    resources = [aws_sqs_queue.cp_cloudtrail_log_queue.arn]
+    resources = [
+      aws_sqs_queue.cp_cloudtrail_log_queue.arn,
+      aws_sqs_queue.cp_vpc_flowlogs_log_queue.arn
+    ]
   }
   statement {
-    sid       = "SQSReadLoggingS3"
-    effect    = "Allow"
-    actions   = ["s3:GetObject"]
-    resources = [module.baselines.cloudtraillogs_bucket_arn[0][0], "${module.baselines.cloudtraillogs_bucket_arn[0][0]}/*"]
+    sid     = "SQSReadLoggingS3"
+    effect  = "Allow"
+    actions = ["s3:GetObject"]
+    resources = [
+      module.baselines.cloudtraillogs_bucket_arn[0][0],
+      "${module.baselines.cloudtraillogs_bucket_arn[0][0]}/*",
+      data.terraform_remote_state.live-1.outputs.vpc_flowlogs_bucket_arn,
+      "${data.terraform_remote_state.live-1.outputs.vpc_flowlogs_bucket_arn}/*"
+    ]
   }
 }
 


### PR DESCRIPTION
This PR relates to Push Production VPC flow logs to Cortex [#5609](https://github.com/ministryofjustice/cloud-platform/issues/5609)

This PR does the following:

- Declare `vpc/live-1` remote state data resource
- Creates SQS queue for updates in the CP VPC Flowlogs bucket
- Grants IAM role user permissions to the SQS queue
- Grants IAM user to `GetObject` to CP VPC Flowlogs bucket