### PR TITLE
perf: Bump Elaticsearch IOPS

### DIFF
--- a/terraform/global-resources/elasticsearch.tf
+++ b/terraform/global-resources/elasticsearch.tf
@@ -187,7 +187,7 @@ resource "aws_elasticsearch_domain" "live_1" {
     ebs_enabled = "true"
     volume_type = "gp3"
     volume_size = "5000"
-    iops        = 13000 # limit is 16,000 https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volume-types.html
+    iops        = 17000 # Must be between 15,000 to 20,000 https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volume-types.html
     throughput  = 500   # limit is 1,000
   }
 


### PR DESCRIPTION
Got below error in [terraform apply](https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/infrastructure-global-resources/jobs/terraform-apply/builds/32#L6674b47e:788) for bumping ebs volume from 4TB to 5TB, so we need to bump the IOPS

`Error: updating Elasticsearch Domain
(arn:aws:es:eu-west-2:754256621582:domain/cloud-platform-live) config: LimitExceededException: IOPS must be between 15000 and 20000` 