### PR TITLE
feat: Update decheduler for 1.28 kube release

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
@@ -56,7 +56,7 @@ module "cluster_autoscaler" {
 
 module "descheduler" {
   count  = lookup(local.manager_workspace, terraform.workspace, false) ? 0 : 1
-  source = "github.com/ministryofjustice/cloud-platform-terraform-descheduler?ref=0.7.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-descheduler?ref=0.8.0"
 
   depends_on = [
     module.monitoring,


### PR DESCRIPTION
https://github.com/ministryofjustice/cloud-platform-terraform-descheduler/releases/tag/0.8.0