### PR TITLE
perf: bump IOPS

### DIFF
--- a/terraform/global-resources/elasticsearch.tf
+++ b/terraform/global-resources/elasticsearch.tf
@@ -187,7 +187,7 @@ resource "aws_elasticsearch_domain" "live_1" {
     ebs_enabled = "true"
     volume_type = "gp3"
     volume_size = "8000"
-    iops        = 17000 # Must be between 15,000 to 20,000 https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volume-types.html
+    iops        = 20000 # Must be between 15,000 to 20,000 https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volume-types.html
     throughput  = 500   # limit is 1,000
   }
 


### PR DESCRIPTION
Resolve `Error: updating Elasticsearch Domain (arn:aws:es:eu-west-2:754256621582:domain/cloud-platform-live) config: LimitExceededException: IOPS must be set to 20000`

concourse link [here](https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/infrastructure-global-resources/jobs/terraform-apply/builds/34#L6674f368:788)