### PR TITLE
fix: bump throughput

### DIFF
--- a/terraform/global-resources/elasticsearch.tf
+++ b/terraform/global-resources/elasticsearch.tf
@@ -188,7 +188,7 @@ resource "aws_elasticsearch_domain" "live_1" {
     volume_type = "gp3"
     volume_size = "8000"
     iops        = 20000 # Must be between 15,000 to 20,000 https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volume-types.html
-    throughput  = 500   # limit is 1,000
+    throughput  = 593   # limit is 1,000
   }
 
   advanced_options = {


### PR DESCRIPTION
fix `Error: updating Elasticsearch Domain (arn:aws:es:eu-west-2:754256621582:domain/cloud-platform-live) config: LimitExceededException: Throughput must be set to 593`

concourse link [here](https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/infrastructure-global-resources/jobs/terraform-apply/builds/35#L6674f44c:789)