### PR TITLE
chore: 🤖 bump monitoring module for prom upgrade k8s1.28

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
@@ -203,7 +203,7 @@ module "logging" {
 }
 
 module "monitoring" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=3.11.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=3.12.0"
 
   alertmanager_slack_receivers  = local.enable_alerts ? var.alertmanager_slack_receivers : [{ severity = "dummy", webhook = "https://dummy.slack.com", channel = "#dummy-alarms" }]
   pagerduty_config              = local.enable_alerts ? var.pagerduty_config : "dummy"


### PR DESCRIPTION
release: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/releases/tag/3.12.0

relates to ministryofjustice/cloudplatform#5581