### PR TITLE
⬆️ bump monitoring module 3.13.0

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
@@ -203,7 +203,7 @@ module "logging" {
 }
 
 module "monitoring" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=3.12.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=3.13.0"
 
   alertmanager_slack_receivers  = local.enable_alerts ? var.alertmanager_slack_receivers : [{ severity = "dummy", webhook = "https://dummy.slack.com", channel = "#dummy-alarms" }]
   pagerduty_config              = local.enable_alerts ? var.pagerduty_config : "dummy"


### PR DESCRIPTION
Bumping `monitoring` module to upgrade `metrics-server`. PR for new module [here](https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/pull/261)

Relates to issue [Container image upgrade](https://github.com/ministryofjustice/cloud-platform/issues/5694)