### PR TITLE
perf: Bump OS EBS Volume

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/account/app-opensearch.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/app-opensearch.tf
@@ -155,7 +155,7 @@ resource "aws_opensearch_domain" "live_app_logs" {
   ebs_options {
     ebs_enabled = "true"
     volume_type = "gp3"
-    volume_size = "8000"
+    volume_size = "12000"
     iops        = "20000" # limit is between 15,000 and 20,000 https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volume-types.html
     throughput  = "593"   # Throughput scales proportionally up. iops x 0.25 (maximum 4,000) https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/general-purpose.html
   }


### PR DESCRIPTION
OS ran out of storage

![image](https://github.com/user-attachments/assets/6163c295-c097-4065-a913-d9b91a574367)
