### PR TITLE
chore: 🤖 bump logging for temp disabling of OS outputs

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
@@ -189,7 +189,7 @@ module "kuberos" {
 }
 
 module "logging" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-logging?ref=1.17.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-logging?ref=1.17.3"
 
   opensearch_app_host = lookup(var.opensearch_app_host_map, terraform.workspace, "placeholder-opensearch")
   elasticsearch_host  = lookup(var.elasticsearch_hosts_maps, terraform.workspace, "placeholder-elasticsearch")


### PR DESCRIPTION
release notes:
https://github.com/ministryofjustice/cloud-platform-terraform-logging/releases/tag/1.17.3