### PR TITLE
chore: 🤖 tune cloudwatch elasticsearch jvmpressure alert

### DIFF
--- a/terraform/global-resources/elasticsearch.tf
+++ b/terraform/global-resources/elasticsearch.tf
@@ -282,6 +282,9 @@ module "live_elasticsearch_monitoring" {
   sns_topic         = data.terraform_remote_state.account.outputs.slack_sns_topic
 
   alarm_cluster_status_is_yellow_periods = 10
+  jvm_memory_pressure_threshold = 90
+  alarm_jvm_memory_pressure_too_high_period = 600
+
 }
 
 # This is the OpenSearch cluster for live-2

--- a/terraform/global-resources/elasticsearch.tf
+++ b/terraform/global-resources/elasticsearch.tf
@@ -281,8 +281,8 @@ module "live_elasticsearch_monitoring" {
   create_sns_topic  = false
   sns_topic         = data.terraform_remote_state.account.outputs.slack_sns_topic
 
-  alarm_cluster_status_is_yellow_periods = 10
-  jvm_memory_pressure_threshold = 90
+  alarm_cluster_status_is_yellow_periods    = 10
+  jvm_memory_pressure_threshold             = 90
   alarm_jvm_memory_pressure_too_high_period = 600
 
 }


### PR DESCRIPTION
this PR increases the jvm memory pressure alert threshold from default value of 80% to 90%, whilst reducing the threshold pressure period from default of 15 to 10 mins. This is based on viewing jvm pressure spike patterns and to focus lower priority alert attention on the pressure remaining high for abnormal lengths of time