### PR TITLE
feat: Add index template for es

### DIFF
--- a/terraform/global-resources/elasticsearch.tf
+++ b/terraform/global-resources/elasticsearch.tf
@@ -395,3 +395,20 @@ resource "elasticsearch_index_template" "template_index_kubernetes" {
 
   provider = elasticsearch.live-2
 }
+
+resource "elasticsearch_index_template" "live_kubernetes_cluster" {
+  name = "live_kubernetes_cluster"
+  body = <<EOF
+{
+  "index_patterns": [
+    "live_kubernetes_cluster-*"
+  ],
+  "template": {
+    "settings": {
+      "number_of_shards": "16",
+      "number_of_replicas": "1"
+    }
+  }
+}
+  EOF
+}


### PR DESCRIPTION
## 👀 Purpose

- This adds a new index tempalte for live_kubernetes_cluster index. This should break down the file sizes so that they can be moved to warm. We've seen errors where the index is too large to move.

## ♻️ What's changed

- Add index template

## 📝 Notes

-Adds an index template for live_kubernetes_cluster_* index