### PR TITLE
chore: 🤖 turn on opensearch int tests now os is up again

### DIFF
--- a/test/user_app_logging_test.go
+++ b/test/user_app_logging_test.go
@@ -122,7 +122,6 @@ var _ = Describe("logging", Ordered, func() {
 
 		Describe("check app logs have not been dropped", Ordered, func() {
 			It("should be able to retrieve the log messages from opensearch", func() {
-				Skip("Skipping this test whilst OpenSearch logging is temporarily disabled")
 				values := helpers.SearchData{
 					Query: helpers.BoolData{
 						Bool: helpers.MustFilterData{


### PR DESCRIPTION
- this int test was turned off whilst opensearch indexes were being fixed
- this turns the int test back on