### PR TITLE
:zap: Concourse bump - introducing placement strategy - 2

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
@@ -1,6 +1,6 @@
 module "concourse" {
   count  = lookup(local.manager_workspace, terraform.workspace, false) ? 1 : 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-concourse?ref=1.25.9"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-concourse?ref=1.25.10"
 
   concourse_hostname                                = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   github_auth_client_id                             = var.github_auth_client_id


### PR DESCRIPTION
Concourse module bump to ensure better concourse jobs distribution across workers

Module changes [here](https://github.com/ministryofjustice/cloud-platform-terraform-concourse/pull/396)

Related to [Concourse worker job distribution fix](https://github.com/ministryofjustice/cloud-platform/issues/5839) issue