### PR TITLE
Bumping Kuberhealthy module to include Daemonset test priority change

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
@@ -257,7 +257,7 @@ module "velero" {
 }
 
 module "kuberhealthy" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-kuberhealthy?ref=1.4.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-kuberhealthy?ref=1.5.0"
 
   cluster_env = terraform.workspace
 


### PR DESCRIPTION
This PR will bump the Kuberhealthy module version to include the change in priority for Daemonset test to 'cluster-critical'.

Module has been tested on a test cluster. 