### PR TITLE
chore: Turn on alert for OpenSearch total node storage

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/account/app-opensearch.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/app-opensearch.tf
@@ -383,11 +383,17 @@ resource "auth0_rule_config" "opensearch_app_logs_client_id" {
 }
 
 module "live_app_logs_opensearch_monitoring" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-opensearch-cloudwatch-alarm?ref=0.0.2"
-  alarm_name_prefix   = "CP-live-app-logs-"
-  domain_name         = local.live_app_logs_domain
-  sns_topic           = module.baselines.slack_sns_topic
-  min_available_nodes = aws_opensearch_domain.live_app_logs.cluster_config[0].instance_count
-  tags                = local.app_logs_tags
-}
+  source                                   = "github.com/ministryofjustice/cloud-platform-terraform-opensearch-cloudwatch-alarm?ref=0.0.2"
+  alarm_name_prefix                        = "CP-live-app-logs-"
+  domain_name                              = local.live_app_logs_domain
+  sns_topic                                = module.baselines.slack_sns_topic
+  min_available_nodes                      = aws_opensearch_domain.live_app_logs.cluster_config[0].instance_count
+  monitor_free_storage_space_total_too_low = true
 
+  # Using this calculation of (size-in-gb * 25% * 1024) because 25% is the best-practice for low disk, per AWS's recommendations. This value is in MiB so need to * 1024
+  free_storage_space_threshold             = aws_opensearch_domain.live_app_logs.ebs_options[0].volume_size  * 0.25 * 1024
+  
+  # Using this calculation of (size-in-gb * total instance count * 25% * 1024) because 25% is the best-practice for low disk, per AWS's recommendations. This value is in MiB so need to * 1024
+  free_storage_space_total_threshold       = aws_opensearch_domain.live_app_logs.ebs_options[0].volume_size * aws_opensearch_domain.live_app_logs.cluster_config[0].instance_count * 0.25 * 1024
+  tags                                     = local.app_logs_tags
+}

--- a/terraform/aws-accounts/cloud-platform-aws/account/app-opensearch.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/app-opensearch.tf
@@ -391,9 +391,9 @@ module "live_app_logs_opensearch_monitoring" {
   monitor_free_storage_space_total_too_low = true
 
   # Using this calculation of (size-in-gb * 25% * 1024) because 25% is the best-practice for low disk, per AWS's recommendations. This value is in MiB so need to * 1024
-  free_storage_space_threshold             = aws_opensearch_domain.live_app_logs.ebs_options[0].volume_size  * 0.25 * 1024
-  
+  free_storage_space_threshold = aws_opensearch_domain.live_app_logs.ebs_options[0].volume_size * 0.25 * 1024
+
   # Using this calculation of (size-in-gb * total instance count * 25% * 1024) because 25% is the best-practice for low disk, per AWS's recommendations. This value is in MiB so need to * 1024
-  free_storage_space_total_threshold       = aws_opensearch_domain.live_app_logs.ebs_options[0].volume_size * aws_opensearch_domain.live_app_logs.cluster_config[0].instance_count * 0.25 * 1024
-  tags                                     = local.app_logs_tags
+  free_storage_space_total_threshold = aws_opensearch_domain.live_app_logs.ebs_options[0].volume_size * aws_opensearch_domain.live_app_logs.cluster_config[0].instance_count * 0.25 * 1024
+  tags                               = local.app_logs_tags
 }


### PR DESCRIPTION
## Summary
- Added an alert to monitor OpenSearch storage size across all nodes.

## Details
- Alert Threshold:

  - Based on the [OpenSearch CloudWatch alarm guide](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/cloudwatch-alarms.html), the alarm triggers at 25% of the storage space for each node.
  - Calculated threshold:
    - Formula: (size-in-gb * instance count * 25% * 1024)
    - The value is in MiB, so it needs to be multiplied by 1024.
- Code Improvement:
  - Updated to use attribute references instead of hardcoding the storage threshold.

- Relates to [cloud-platform/issues/5928](https://github.com/ministryofjustice/cloud-platform/issues/5928)