### PR TITLE
chore: Update ModSec OpenSearch CloudWatch Alert

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/account/modsec-opensearch.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/modsec-opensearch.tf
@@ -420,5 +420,12 @@ module "live_mod_sec_opensearch_monitoring" {
   domain_name         = local.live_modsec_audit_domain
   sns_topic           = module.baselines.slack_sns_topic
   min_available_nodes = aws_opensearch_domain.live_modsec_audit.cluster_config[0].instance_count
-  tags                = local.mod_sec_tags
+  monitor_free_storage_space_total_too_low = true
+
+  # Using this calculation of (size-in-gb * 25% * 1024) because 25% is the best-practice for low disk, per AWS's recommendations. This value is in MiB so need to * 1024
+  free_storage_space_threshold = aws_opensearch_domain.live_modsec_audit.ebs_options[0].volume_size * 0.25 * 1024
+
+  # Using this calculation of (size-in-gb * total instance count * 25% * 1024) because 25% is the best-practice for low disk, per AWS's recommendations. This value is in MiB so need to * 1024
+  free_storage_space_total_threshold = aws_opensearch_domain.live_modsec_audit.ebs_options[0].volume_size * live_modsec_audit.live_app_logs.cluster_config[0].instance_count * 0.25 * 1024
+  tags                               = local.app_logs_tags
 }

--- a/terraform/aws-accounts/cloud-platform-aws/account/modsec-opensearch.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/modsec-opensearch.tf
@@ -415,11 +415,11 @@ resource "elasticsearch_opensearch_roles_mapping" "all_org_members" {
 }
 
 module "live_mod_sec_opensearch_monitoring" {
-  source              = "github.com/ministryofjustice/cloud-platform-terraform-opensearch-cloudwatch-alarm?ref=0.0.2"
-  alarm_name_prefix   = "CP-live-mod-sec-"
-  domain_name         = local.live_modsec_audit_domain
-  sns_topic           = module.baselines.slack_sns_topic
-  min_available_nodes = aws_opensearch_domain.live_modsec_audit.cluster_config[0].instance_count
+  source                                   = "github.com/ministryofjustice/cloud-platform-terraform-opensearch-cloudwatch-alarm?ref=0.0.2"
+  alarm_name_prefix                        = "CP-live-mod-sec-"
+  domain_name                              = local.live_modsec_audit_domain
+  sns_topic                                = module.baselines.slack_sns_topic
+  min_available_nodes                      = aws_opensearch_domain.live_modsec_audit.cluster_config[0].instance_count
   monitor_free_storage_space_total_too_low = true
 
   # Using this calculation of (size-in-gb * 25% * 1024) because 25% is the best-practice for low disk, per AWS's recommendations. This value is in MiB so need to * 1024

--- a/terraform/aws-accounts/cloud-platform-aws/account/modsec-opensearch.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/modsec-opensearch.tf
@@ -427,5 +427,5 @@ module "live_mod_sec_opensearch_monitoring" {
 
   # Using this calculation of (size-in-gb * total instance count * 25% * 1024) because 25% is the best-practice for low disk, per AWS's recommendations. This value is in MiB so need to * 1024
   free_storage_space_total_threshold = aws_opensearch_domain.live_modsec_audit.ebs_options[0].volume_size * aws_opensearch_domain.live_modsec_audit.cluster_config[0].instance_count * 0.25 * 1024
-  tags                               = local.app_logs_tags
+  tags                               = local.mod_sec_tags
 }

--- a/terraform/aws-accounts/cloud-platform-aws/account/modsec-opensearch.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/modsec-opensearch.tf
@@ -426,6 +426,6 @@ module "live_mod_sec_opensearch_monitoring" {
   free_storage_space_threshold = aws_opensearch_domain.live_modsec_audit.ebs_options[0].volume_size * 0.25 * 1024
 
   # Using this calculation of (size-in-gb * total instance count * 25% * 1024) because 25% is the best-practice for low disk, per AWS's recommendations. This value is in MiB so need to * 1024
-  free_storage_space_total_threshold = aws_opensearch_domain.live_modsec_audit.ebs_options[0].volume_size * live_modsec_audit.live_app_logs.cluster_config[0].instance_count * 0.25 * 1024
+  free_storage_space_total_threshold = aws_opensearch_domain.live_modsec_audit.ebs_options[0].volume_size * aws_opensearch_domain.live_modsec_audit.cluster_config[0].instance_count * 0.25 * 1024
   tags                               = local.app_logs_tags
 }


### PR DESCRIPTION
## Summary
- Update alert to monitor ModSec OpenSearch total node storage size.

## Details
- Alert Threshold:

  - Based on the [OpenSearch CloudWatch alarm guide](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/cloudwatch-alarms.html), the alarm triggers at 25% of the storage space for each node.
  - Calculated threshold:
    - Formula: (size-in-gb * instance count * 25% * 1024)
    - The value is in MiB, so it needs to be multiplied by 1024.
 - Updated to use attribute references instead of hardcoding the storage threshold.

- Relates to [cloud-platform/issues/5928](https://github.com/ministryofjustice/cloud-platform/issues/5928)