### PR TITLE
Update autoscale module to latest that removes overprovision daemonset pods

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
@@ -41,7 +41,7 @@ module "concourse" {
 }
 
 module "cluster_autoscaler" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-cluster-autoscaler?ref=1.10.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-cluster-autoscaler?ref=1.11.0"
 
   enable_overprovision        = lookup(local.prod_workspace, terraform.workspace, false)
   cluster_domain_name         = data.terraform_remote_state.cluster.outputs.cluster_domain_name


### PR DESCRIPTION
The overprovision daemonset pods are no longer required as kuberhealthy daemonset tests are now passing with higher cluster priority.

This change removes the creation of all Overprovision Daemonset pods.

This change has been tested on a test cluster, before change:
<img width="687" alt="Screenshot 2024-08-21 at 17 11 08" src="https://github.com/user-attachments/assets/212b0271-8995-430e-8d87-94abead76e69">

After change applied:
<img width="645" alt="Screenshot 2024-08-21 at 17 16 39" src="https://github.com/user-attachments/assets/7206c114-64ba-4084-b068-bdad4506af1f">
