### PR TITLE
🔥 Removing addition NAT Gateways

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/main.tf
@@ -81,9 +81,9 @@ module "vpc" {
   manage_default_route_table    = false
   manage_default_security_group = false
 
-  enable_nat_gateway   = true
-  enable_vpn_gateway   = false
-  enable_dns_hostnames = true
+  enable_nat_gateway     = true
+  enable_vpn_gateway     = false
+  enable_dns_hostnames   = true
   one_nat_gateway_per_az = true
 
   public_subnet_tags = merge({


### PR DESCRIPTION
This PR removes the additional NAT Gateways that were provisioned when [we added the new `EKS-Private` subnets](https://github.com/ministryofjustice/cloud-platform-infrastructure/pull/3356) to the VPC.

Setting `one_nat_gateway_per_az = true` will associate the `EKS-Private` subnets to the current `Private` route tables, thereby routing traffic to the original NAT gateways.

Relates to [EKS in-place subnet modification #6030](https://github.com/ministryofjustice/cloud-platform/issues/6030)