### PR TITLE
chore: 🤖 remove old node groups

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
@@ -54,109 +54,12 @@ locals {
     default = ["t3a.medium", "t3.medium"]
   }
 
-
   dockerhub_credentials = base64encode("${var.cp_dockerhub_user}:${var.cp_dockerhub_token}")
-
-  default_ng_14_08_24 = {
-    desired_size = lookup(local.node_groups_count, terraform.workspace, local.node_groups_count["default"])
-    max_size     = 85
-    min_size     = lookup(local.default_ng_min_count, terraform.workspace, local.default_ng_min_count["default"])
-
-    block_device_mappings = {
-      xvda = {
-        device_name = "/dev/xvda"
-        ebs = {
-          volume_size           = 200
-          volume_type           = "gp3"
-          iops                  = 0
-          encrypted             = false
-          kms_key_id            = ""
-          delete_on_termination = true
-        }
-      }
-    }
-
-    subnet_ids           = data.aws_subnets.private.ids
-    bootstrap_extra_args = "--use-max-pods false"
-    kubelet_extra_args   = "--max-pods=110"
-    name                 = "${terraform.workspace}-def-ng"
-
-    create_security_group  = false
-    create_launch_template = true
-    pre_bootstrap_user_data = templatefile("${path.module}/templates/user-data-140824.tpl", {
-      dockerhub_credentials = local.dockerhub_credentials
-    })
-    iam_role_additional_policies = ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"]
-
-    instance_types = lookup(local.node_size, terraform.workspace, local.node_size["default"])
-    labels = {
-      Terraform                                  = "true"
-      "cloud-platform.justice.gov.uk/default-ng" = "true"
-      Cluster                                    = terraform.workspace
-      Domain                                     = local.fqdn
-    }
-
-    tags = {
-      default_ng    = "true"
-      application   = "moj-cloud-platform"
-      business-unit = "platforms"
-    }
-  }
 
   tags = {
     Terraform = "true"
     Cluster   = terraform.workspace
     Domain    = local.fqdn
-  }
-
-  monitoring_ng_14_08_24 = {
-    desired_size = 4
-    max_size     = 6
-    min_size     = 4
-    block_device_mappings = {
-      xvda = {
-        device_name = "/dev/xvda"
-        ebs = {
-          volume_size           = 140
-          volume_type           = "gp3"
-          iops                  = 0
-          encrypted             = false
-          kms_key_id            = ""
-          delete_on_termination = true
-        }
-      }
-    }
-
-
-    subnet_ids = data.aws_subnets.private.ids
-    name       = "${terraform.workspace}-mon-ng"
-
-    create_security_group  = false
-    create_launch_template = true
-    pre_bootstrap_user_data = templatefile("${path.module}/templates/user-data-140824.tpl", {
-      dockerhub_credentials = local.dockerhub_credentials
-    })
-
-    iam_role_additional_policies = ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"]
-    instance_types               = lookup(local.monitoring_node_size, terraform.workspace, local.monitoring_node_size["default"])
-    labels = {
-      Terraform                                     = "true"
-      "cloud-platform.justice.gov.uk/monitoring-ng" = "true"
-      Cluster                                       = terraform.workspace
-      Domain                                        = local.fqdn
-    }
-    tags = {
-      monitoring_ng = "true"
-      application   = "moj-cloud-platform"
-      business-unit = "platforms"
-    }
-    taints = [
-      {
-        key    = "monitoring-node"
-        value  = true
-        effect = "NO_SCHEDULE"
-      }
-    ]
   }
 
   default_ng_16_09_24 = {
@@ -280,8 +183,6 @@ module "eks" {
   prefix_separator = ""
 
   eks_managed_node_groups = {
-    default_ng_14_08_24    = local.default_ng_14_08_24
-    monitoring_ng_14_08_24 = local.monitoring_ng_14_08_24
     default_ng_16_09_24    = local.default_ng_16_09_24
     monitoring_ng_16_09_24 = local.monitoring_ng_16_09_24
   }


### PR DESCRIPTION
Now all workloads have moved onto the new node groups in the new subnets successfully, remove the old node groups from code