### PR TITLE
feat: bump calico module to 0.1.9

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/calico.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/calico.tf
@@ -42,7 +42,7 @@ resource "kubectl_manifest" "calico_crds" {
 
 
 module "tigera_calico" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-tigera-calico?ref=0.1.8"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-tigera-calico?ref=0.1.9"
 
   depends_on = [
     kubectl_manifest.calico_crds


### PR DESCRIPTION
## 👀 Purpose

- See https://github.com/ministryofjustice/cloud-platform-terraform-tigera-calico/releases/tag/0.1.9
- See https://github.com/orgs/ministryofjustice/projects/65/views/3?pane=issue&itemId=81539621