### PR TITLE
:fire: Remove Steve Marshall from auth users

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
@@ -198,11 +198,6 @@ module "eks" {
       groups   = ["system:masters"]
     },
     {
-      userarn  = "arn:aws:iam::754256621582:user/SteveMarshall"
-      username = "SteveMarshall"
-      groups   = ["system:masters"]
-    },
-    {
       userarn  = "arn:aws:iam::754256621582:user/JackStockley"
       username = "JackStockley"
       groups   = ["system:masters"]


### PR DESCRIPTION
While showing this off to someone, I noticed that Steve's IAM account still exists here.

This pull request includes a change to the `terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf` file to update the list of users in the EKS cluster configuration.

User management updates:

* Removed the user configuration for `SteveMarshall` from the EKS cluster. (`terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf`)