### PR TITLE
Update to use latest module which removes cert manager wait

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/cert_manager.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/cert_manager.tf
@@ -1,5 +1,5 @@
 module "cert_manager" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-certmanager?ref=1.10.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-certmanager?ref=1.11.0"
 
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   hostzone            = lookup(local.hostzones, terraform.workspace, local.hostzones["default"])


### PR DESCRIPTION
Removing the 60 second wait from the build for cert manager due to the separation of core and components. [#5886](https://github.com/orgs/ministryofjustice/projects/65/views/3?pane=issue&itemId=71051417)