### PR TITLE
⬆️ bump monitoring module

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
@@ -198,7 +198,7 @@ module "logging" {
 }
 
 module "monitoring" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=3.13.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=3.13.8"
 
   alertmanager_slack_receivers  = local.enable_alerts ? var.alertmanager_slack_receivers : [{ severity = "dummy", webhook = "https://dummy.slack.com", channel = "#dummy-alarms" }]
   pagerduty_config              = local.enable_alerts ? var.pagerduty_config : "dummy"


### PR DESCRIPTION
This PR bumps the monitoring module. Module [changelog here](https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/releases/tag/3.13.8)

Relates to [Monitoring Module: Fix Prometheus Alerts Deployment](https://github.com/ministryofjustice/cloud-platform/issues/5057)