### PR TITLE
chore: 🤖 bump monitoring for elasticache metrics

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
@@ -198,7 +198,7 @@ module "logging" {
 }
 
 module "monitoring" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=3.13.8"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=3.14.0"
 
   alertmanager_slack_receivers  = local.enable_alerts ? var.alertmanager_slack_receivers : [{ severity = "dummy", webhook = "https://dummy.slack.com", channel = "#dummy-alarms" }]
   pagerduty_config              = local.enable_alerts ? var.pagerduty_config : "dummy"


### PR DESCRIPTION
[Release notes](https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/releases/tag/3.14.0)

relates to ministryofjustice/cloud-platform#6277