### PR TITLE
Bump sso module version to include ecr read only

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/account/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/main.tf
@@ -87,7 +87,7 @@ module "iam" {
 
 # Github SSO
 module "sso" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-aws-sso?ref=1.5.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-aws-sso?ref=1.5.8"
 
   auth0_tenant_domain = "justice-cloud-platform.eu.auth0.com"
 }


### PR DESCRIPTION
Bumping sso module to release [1.5.8](https://github.com/ministryofjustice/cloud-platform-terraform-aws-sso/releases/tag/1.5.8) for ECR Console read-only access
[#6036](https://github.com/ministryofjustice/cloud-platform/issues/6036)