### PR TITLE
Fixing ecr document typo from DescribeRepository to DescribeRepositories

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/account/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/main.tf
@@ -87,7 +87,7 @@ module "iam" {
 
 # Github SSO
 module "sso" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-aws-sso?ref=1.5.9"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-aws-sso?ref=1.5.10"
 
   auth0_tenant_domain = "justice-cloud-platform.eu.auth0.com"
 }


### PR DESCRIPTION
Fixing typo for issue [#6036](https://github.com/ministryofjustice/cloud-platform/issues/6036)