### PR TITLE
perf: ⚡️ increase default manager instance size

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
@@ -43,7 +43,7 @@ locals {
   node_size = {
     live    = ["r6i.2xlarge", "r6i.xlarge", "r5.2xlarge"]
     live-2  = ["r6i.2xlarge", "r6i.xlarge", "r5.2xlarge"]
-    manager = ["m6a.xlarge", "m6a.2xlarge", "m6i.xlarge"]
+    manager = ["m6a.2xlarge", "m6a.4xlarge", "m6i.2xlarge"]
     default = ["m6a.xlarge", "m6a.2xlarge", "m6i.xlarge"]
   }
 

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
@@ -1,6 +1,6 @@
 module "concourse" {
   count  = lookup(local.manager_workspace, terraform.workspace, false) ? 1 : 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-concourse?ref=1.26.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-concourse?ref=1.26.5"
 
   concourse_hostname                                = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   github_auth_client_id                             = var.github_auth_client_id
@@ -25,6 +25,7 @@ module "concourse" {
   dockerhub_password                                = var.dockerhub_password
   how_out_of_date_are_we_github_token               = var.how_out_of_date_are_we_github_token
   authorized_keys_github_token                      = var.authorized_keys_github_token
+  limit_active_tasks                                = 4
 
   hoodaw_host                  = var.hoodaw_host
   hoodaw_api_key               = var.hoodaw_api_key


### PR DESCRIPTION
- bump manager instance size
- pass `limit_active_tasks` var to concourse