### PR TITLE
Bump sso module version to include Backups Read only for SSO

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/account/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/main.tf
@@ -86,7 +86,7 @@ module "iam" {
 }
 
 module "sso" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-aws-sso?ref=1.5.14"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-aws-sso?ref=1.5.15"
 
   auth0_tenant_domain = "justice-cloud-platform.eu.auth0.com"
 }


### PR DESCRIPTION
This will grant the ability to list the backup vaults, jobs, and protected resources and be able to get more details for the ones within the users namespace through the SSO read only AWS console.

This relates to the S3 buckets AWS Backup restore process issue https://github.com/ministryofjustice/cloud-platform/issues/6039