### PR TITLE
chore: 🤖 bump default ingress controller for helm update

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
@@ -102,7 +102,7 @@ module "external_secrets_operator" {
   ]
 }
 module "ingress_controllers_v1" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.8.10"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.8.11"
 
   replica_count       = lookup(local.live_workspace, terraform.workspace, false) ? "30" : "3"
   controller_name     = "default"


### PR DESCRIPTION
[Release notes](https://github.com/ministryofjustice/cloud-platform-terraform-ingress-controller/releases/tag/1.8.11)

relates to ministryofjustice/cloud-platform#6366

