### PR TITLE
chore: 🤖 rollback external-dns to functional release

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
@@ -78,7 +78,7 @@ module "label_pods_controller" {
 
 
 module "external_dns" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-external-dns?ref=1.16.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-external-dns?ref=1.17.0"
 
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   hostzones           = lookup(local.hostzones, terraform.workspace, local.hostzones["default"])


### PR DESCRIPTION
[Release](https://github.com/ministryofjustice/cloud-platform-terraform-external-dns/releases/tag/1.17.0)