### PR TITLE
chore: 🤖 bump monitoring for rds metrics update

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
@@ -199,7 +199,7 @@ module "logging" {
 }
 
 module "monitoring" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=3.15.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=3.15.1"
 
   alertmanager_slack_receivers  = local.enable_alerts ? var.alertmanager_slack_receivers : [{ severity = "dummy", webhook = "https://dummy.slack.com", channel = "#dummy-alarms" }]
   pagerduty_config              = local.enable_alerts ? var.pagerduty_config : "dummy"


### PR DESCRIPTION
relates to ministryofjustice/cloud-platform#6463

[release notes](https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/releases/tag/3.15.1)