### PR TITLE
fix: 🐛 external-dns test

### DIFF
--- a/test/external_dns_test.go
+++ b/test/external_dns_test.go
@@ -18,7 +18,7 @@ import (
 
 // External DNS tests the external-dns function in a cluster can create
 // and destroy route53 entries. It uses the test domain to register.
-var _ = Describe("external-dns", Serial, func() {
+var _ = FDescribe("external-dns", Serial, func() {
 	var (
 		namespaceName, domain string
 		options               *k8s.KubectlOptions
@@ -59,7 +59,7 @@ var _ = Describe("external-dns", Serial, func() {
 	})
 
 	Context("when creating and then deleting an ingress resource", func() {
-		It("should delete the A record", func() {
+		It("should create and then delete the A record", func() {
 			GinkgoWriter.Printf("\nWaiting for A record to be created\n")
 			Eventually(func() bool {
 				exists, err := helpers.RecordSets(domain, hostedZoneId)
@@ -80,14 +80,4 @@ var _ = Describe("external-dns", Serial, func() {
 		})
 	})
 
-	Context("when ingress resource is created", func() {
-		It("should create the A record", func() {
-			GinkgoWriter.Printf("\nWaiting for A record to be created")
-			Eventually(func() bool {
-				exists, err := helpers.RecordSets(domain, hostedZoneId)
-				Expect(err).NotTo(HaveOccurred())
-				return exists
-			}, "10m", "10s").Should(BeTrue())
-		})
-	})
 })

--- a/test/external_dns_test.go
+++ b/test/external_dns_test.go
@@ -18,7 +18,7 @@ import (
 
 // External DNS tests the external-dns function in a cluster can create
 // and destroy route53 entries. It uses the test domain to register.
-var _ = FDescribe("external-dns", Serial, func() {
+var _ = Describe("external-dns", Serial, func() {
 	var (
 		namespaceName, domain string
 		options               *k8s.KubectlOptions

--- a/test/fixtures/external-dns-ingress.yaml.tmpl
+++ b/test/fixtures/external-dns-ingress.yaml.tmpl
@@ -19,3 +19,36 @@ spec:
             name: ingress-external-svc
             port:
               number: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-external-svc
+spec:
+  ports:
+  - port: 80
+    targetPort: 80
+  selector:
+    app: ingress-external-svc
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ingress-external-svc
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ingress-external-svc
+  template:
+    metadata:
+      labels:
+        app: ingress-external-svc
+    spec:
+      containers:
+      - name: nginx
+        image: nginxinc/nginx-unprivileged:1.26-bookworm
+        ports:
+        - containerPort: 80
+---


### PR DESCRIPTION
using complete deployment template for external-dns test to avoid erroring ingress resource missing referenced svc object, update test logic