### PR TITLE
Create dedicated network ACL for public subnets and placeholder for deny rules

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/main.tf
@@ -81,6 +81,8 @@ module "vpc" {
   manage_default_route_table    = false
   manage_default_security_group = false
 
+  public_dedicated_network_acl = true //Creates a dedicated network ACL and attaches to the public subnets
+
   enable_nat_gateway     = true
   enable_vpn_gateway     = false
   enable_dns_hostnames   = true

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/public-nacl-rules.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/public-nacl-rules.tf
@@ -1,0 +1,24 @@
+/// The following are placeholders to create network ACL deny rules for the public subnet to stop traffic to and from the EKS cluster boundary.
+/// Please view the runbook for more information: https://runbooks.cloud-platform.service.justice.gov.uk/block-public-ip-address.html
+
+# resource "aws_network_acl_rule" "deny_inbound_1" {
+#   network_acl_id = module.vpc.public_network_acl_id
+#   rule_number    = 10
+#   egress         = false
+#   protocol       = "-1" # -1 means all protocols
+#   rule_action    = "deny"
+#   cidr_block     = "##.##.##.##/32"
+#   from_port      = 0
+#   to_port        = 0
+# }
+
+# resource "aws_network_acl_rule" "deny_outbound_1" {
+#   network_acl_id = module.vpc.public_network_acl_id
+#   rule_number    = 10
+#   egress         = true
+#   protocol       = "-1" # -1 means all protocols
+#   rule_action    = "deny"
+#   cidr_block     = "##.##.##.##/32"
+#   from_port      = 0
+#   to_port        = 0
+# }


### PR DESCRIPTION
Relates to [Runbook for Individual IP Blocking](https://github.com/ministryofjustice/cloud-platform/issues/6566)

This PR creates a dedicated network ACL with the default rules and associates it with the public subnets. 

PR also includes a placeholder to add deny rules to the public network ACL in the event of when this is required.

