### PR TITLE
fix: 🐛 instance type not satisfied by enum

### DIFF
--- a/terraform/global-resources/elasticsearch.tf
+++ b/terraform/global-resources/elasticsearch.tf
@@ -168,7 +168,7 @@ resource "aws_elasticsearch_domain" "live_1" {
 
   cluster_config {
     warm_enabled   = false
-    instance_type  = "t3.small.search"
+    instance_type  = "t3.small.elasticsearch"
     instance_count = "1"
     cold_storage_options {
       enabled = true


### PR DESCRIPTION
```
ValidationException: 1 validation error detected: Value 't3.small.search' at 'elasticsearchClusterConfig.instanceType' failed to satisfy constraint: Member must satisfy enum value set
```

https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/infrastructure-global-resources/jobs/terraform-apply/builds/58