### PR TITLE
chore: 🤖 bump external-dns

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
@@ -78,7 +78,7 @@ module "label_pods_controller" {
 
 
 module "external_dns" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-external-dns?ref=1.17.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-external-dns?ref=1.17.2"
 
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   hostzones           = lookup(local.hostzones, terraform.workspace, local.hostzones["default"])


### PR DESCRIPTION
[release](https://github.com/ministryofjustice/cloud-platform-terraform-external-dns/releases/tag/1.17.2)