### PR TITLE
fix: 🐛 for cold you need warm

### DIFF
--- a/terraform/global-resources/elasticsearch.tf
+++ b/terraform/global-resources/elasticsearch.tf
@@ -168,7 +168,7 @@ resource "aws_elasticsearch_domain" "live_1" {
 
   cluster_config {
     warm_enabled = true
-    warm_count   = 1
+    warm_count   = 2
     warm_type    = "ultrawarm1.medium.elasticsearch"
 
     instance_type  = "r6g.4xlarge.elasticsearch"

--- a/terraform/global-resources/elasticsearch.tf
+++ b/terraform/global-resources/elasticsearch.tf
@@ -167,9 +167,13 @@ resource "aws_elasticsearch_domain" "live_1" {
   elasticsearch_version = "7.10"
 
   cluster_config {
-    warm_enabled             = false
-    instance_type            = "r6g.4xlarge.elasticsearch"
-    instance_count           = "4"
+    warm_enabled = true
+    warm_count   = 1
+    warm_type    = "ultrawarm1.medium.elasticsearch"
+
+    instance_type  = "r6g.4xlarge.elasticsearch"
+    instance_count = "1"
+
     dedicated_master_enabled = true
     dedicated_master_type    = "m6g.xlarge.elasticsearch"
     dedicated_master_count   = "3"


### PR DESCRIPTION
```
BaseException: To use cold storage, you must have UltraWarm enabled.
```

https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/infrastructure-global-resources/jobs/terraform-apply/builds/64