### PR TITLE
fix: 🐛 node count

### DIFF
--- a/terraform/global-resources/elasticsearch.tf
+++ b/terraform/global-resources/elasticsearch.tf
@@ -178,6 +178,11 @@ resource "aws_elasticsearch_domain" "live_1" {
     cold_storage_options {
       enabled = true
     }
+
+    zone_awareness_enabled = true
+    zone_awareness_config {
+      availability_zone_count = 3
+    }
   }
 
   ebs_options {

--- a/terraform/global-resources/elasticsearch.tf
+++ b/terraform/global-resources/elasticsearch.tf
@@ -171,10 +171,10 @@ resource "aws_elasticsearch_domain" "live_1" {
     warm_count               = 16
     warm_type                = "ultrawarm1.medium.elasticsearch"
     instance_type            = "r6g.4xlarge.elasticsearch"
-    instance_count           = "4"
+    instance_count           = "16"
     dedicated_master_enabled = true
     dedicated_master_type    = "m6g.xlarge.elasticsearch"
-    dedicated_master_count   = "3"
+    dedicated_master_count   = "5"
     cold_storage_options {
       enabled = true
     }


### PR DESCRIPTION
- keep node count the same until the indexes are resized