### PR TITLE
chore: 🤖 bump velero s3 bucket module to latest release

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/account/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/main.tf
@@ -156,7 +156,7 @@ module "s3_bucket_thanos" {
 
 module "s3_bucket_velero" {
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "2.14.0" # 2.15 pins to terraform-aws-provider <= 4, so this module needs to be upgraded to 3.6.0, which has some resource changes (which may require manual intervention for terraform state imports)
+  version = "4.3.0"
 
   bucket = "cloud-platform-velero-backups"
   acl    = "private"


### PR DESCRIPTION
no-ops, required terraform imports have been carried out