### PR TITLE
chore: 🤖 bump descheduler to latest compatible release

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
@@ -59,7 +59,7 @@ module "cluster_autoscaler" {
 
 module "descheduler" {
   count  = lookup(local.manager_workspace, terraform.workspace, false) ? 0 : 1
-  source = "github.com/ministryofjustice/cloud-platform-terraform-descheduler?ref=0.9.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-descheduler?ref=0.9.1"
 
   depends_on = [
     module.monitoring,


### PR DESCRIPTION
[release notes](https://github.com/ministryofjustice/cloud-platform-terraform-descheduler/releases/tag/0.9.1)

relates to ministryofjustice/cloud-platform#6509