### PR TITLE
chore: 🤖 bump all ingress controller modules to latest

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
@@ -103,7 +103,7 @@ module "external_secrets_operator" {
 }
 
 module "ingress_controllers_v1" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.8.24"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.9.0"
 
   replica_count            = terraform.workspace == "live" ? "30" : "3"
   controller_name          = "default"
@@ -126,7 +126,7 @@ module "ingress_controllers_v1" {
 }
 
 module "production_only_ingress_controllers_v1" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.8.24"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.9.0"
   count  = terraform.workspace == "live" ? 1 : 0
 
   replica_count            = "6"
@@ -153,7 +153,7 @@ module "production_only_ingress_controllers_v1" {
 
 
 module "modsec_ingress_controllers_v1" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.8.24"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.9.0"
 
   replica_count            = terraform.workspace == "live" ? "12" : "3"
   controller_name          = "modsec"


### PR DESCRIPTION
relates to ministryofjustice/cloud-platform#6387

[release notes](https://github.com/ministryofjustice/cloud-platform-terraform-ingress-controller/releases/tag/1.9.0)