### PR TITLE
fix: 🐛 data node not warm node bump

### DIFF
--- a/terraform/global-resources/elasticsearch.tf
+++ b/terraform/global-resources/elasticsearch.tf
@@ -168,10 +168,10 @@ resource "aws_elasticsearch_domain" "live_1" {
 
   cluster_config {
     warm_enabled             = true
-    warm_count               = 20
+    warm_count               = 16
     warm_type                = "ultrawarm1.medium.elasticsearch"
     instance_type            = "r6g.4xlarge.elasticsearch"
-    instance_count           = "16"
+    instance_count           = "20"
     dedicated_master_enabled = true
     dedicated_master_type    = "m6g.xlarge.elasticsearch"
     dedicated_master_count   = "5"


### PR DESCRIPTION
- I incorrectly tried to upgrade the warm nodes and that failed, I try again with the instance nodes