### PR TITLE
fix: 🐛 capture more .env file patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-.env
+*.env
 .terraform
 *.tfstate*
 ssh/*id_rsa


### PR DESCRIPTION
- capture `<name>.env` filename patterns