### PR TITLE
fix: revert trivy bump to avoid high priority alarm flood

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
@@ -275,7 +275,7 @@ module "kuberhealthy" {
 }
 
 module "trivy-operator" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-trivy-operator?ref=0.10.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-trivy-operator?ref=0.9.0"
 
   cluster_domain_name         = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   eks_cluster_oidc_issuer_url = data.terraform_remote_state.cluster.outputs.cluster_oidc_issuer_url


### PR DESCRIPTION
- revert trivy bump temporarily to avoid high priority alarm flood