### PR TITLE
perf: Bump gatekeeper audit pod memory

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/gatekeeper.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/gatekeeper.tf
@@ -32,6 +32,6 @@ module "gatekeeper" {
   out_of_hours_alert   = lookup(local.prod_2_workspace, terraform.workspace, false) ? "true" : "false"
   controller_mem_limit = terraform.workspace == "live" ? "4Gi" : "1Gi"
   controller_mem_req   = terraform.workspace == "live" ? "1Gi" : "512Mi"
-  audit_mem_limit      = terraform.workspace == "live" ? "4Gi" : "1Gi"
-  audit_mem_req        = terraform.workspace == "live" ? "1Gi" : "512Mi"
+  audit_mem_limit      = terraform.workspace == "live" ? "16Gi" : "1Gi"
+  audit_mem_req        = terraform.workspace == "live" ? "4Gi" : "512Mi"
 }


### PR DESCRIPTION
- there are high resource tracking in gatekeeper audit pod log
- gatekeeper audit pod was `OOMKilled` and `CrashLooping` frequently

![image](https://github.com/user-attachments/assets/87533fb2-c9ae-4b50-8cd0-143a5fdf484f)

- relates to https://github.com/ministryofjustice/cloud-platform/issues/6817 
