### PR TITLE
chore: 🤖 bump SSO module and output api key for components

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/account/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/main.tf
@@ -86,7 +86,7 @@ module "iam" {
 }
 
 module "sso" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-aws-sso?ref=1.6.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-aws-sso?ref=1.7.0"
 
   auth0_tenant_domain = "justice-cloud-platform.eu.auth0.com"
 }

--- a/terraform/aws-accounts/cloud-platform-aws/account/outputs.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/outputs.tf
@@ -12,3 +12,8 @@ output "click_here_to_login" {
   value       = module.sso.saml_login_page
   description = "SSO login page for Cloud Platform"
 }
+
+output "github_teams_filter_api_key" {
+  value       = module.sso.github_teams_filter_api_key
+  description = "API key for the GitHub teams filter API"
+}


### PR DESCRIPTION
This PR:

• updates the [SSO module](https://github.com/ministryofjustice/cloud-platform-terraform-aws-sso/releases/tag/1.7.0) for SAML auth0 action update to call filter teams API for mitigating team string length issue for AWS Read-only console access

- output the SSM param api key for `data` retrieval in `components`

relates to ministryofjustice/cloud-platform#6368