### PR TITLE
feat: 🎸 add ext-dns hosted zone for test cluster access

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/main.tf
@@ -138,7 +138,8 @@ locals {
   hostzones = {
     default = [
       "arn:aws:route53:::hostedzone/${data.aws_route53_zone.selected.zone_id}",
-      "arn:aws:route53:::hostedzone/${data.aws_route53_zone.integrationtest.zone_id}"
+      "arn:aws:route53:::hostedzone/${data.aws_route53_zone.integrationtest.zone_id}",
+      "arn:aws:route53:::hostedzone/${data.aws_route53_zone.external_dns_test.zone_id}"
     ]
     manager = [
       "arn:aws:route53:::hostedzone/${data.aws_route53_zone.selected.zone_id}",


### PR DESCRIPTION
So that test cluster external-dns IAM policy has permission to control the ext-dns testing hosted zone

relates to ministryofjustice/cloud-platform#6752