### PR TITLE
Increase number of warm nodes

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/account/app-opensearch.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/app-opensearch.tf
@@ -143,7 +143,7 @@ resource "aws_opensearch_domain" "live_app_logs" {
       availability_zone_count = 3
     }
 
-    warm_count   = 15
+    warm_count   = 20
     warm_enabled = true
     warm_type    = "ultrawarm1.medium.search"
 


### PR DESCRIPTION
We are seeing index not being moved from hot storage to warm

```
{
    "cause": "Rejecting migration request for index [manager_kubernetes_ingress-2025.03.07] since we don't have enough [warm] capacity. Please add more warm nodes",
    "message": "Failed to start warm migration [index=manager_kubernetes_ingress-2025.03.07]"
}
```

which in turn could be due to nodes not being movable to cold storage

`GET _plugins/_ism/explain/`

```
 "info": {
      "cause": "Failed to migrate index [live_eventrouter-2024.07.27] to cold storage because another index with the same name already exists in cold storage.",
      "message": "Failed to start cold migration [index=live_eventrouter-2024.07.27]"
    },
```

Those can be sorted separately but in the short term, it would be good to add more resources to the warm storage so that indices can travel down their lifecycle.