### PR TITLE
Adding explicit mapping of time field in template for OpenSearch index

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/account/app-opensearch-index-templates.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/app-opensearch-index-templates.tf
@@ -12,6 +12,13 @@ resource "opensearch_index_template" "live_kubernetes_cluster" {
         "number_of_shards": "15",
         "number_of_replicas": "1"
       }
+    },
+    "mappings": {
+      "properties": {
+        "time" : {
+          "type" :  "date"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
See context in https://github.com/ministryofjustice/cloud-platform/issues/6870#issuecomment-2700633965

A `time` field is found in documents indexed with OpenSearch. Having an explicit mapping for it will allow to query documents based on it, check that it is present in all documents and also compare with '@timestamp'