### PR TITLE
bump monitoring module

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
@@ -207,7 +207,7 @@ module "logging" {
 }
 
 module "monitoring" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=3.19.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=3.19.1"
 
   alertmanager_slack_receivers  = local.enable_alerts ? var.alertmanager_slack_receivers : [{ severity = "dummy", webhook = "https://dummy.slack.com", channel = "#dummy-alarms" }]
   pagerduty_config              = local.enable_alerts ? var.pagerduty_config : "dummy"


### PR DESCRIPTION
This pr bumps the monitoring module as per this merged https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/pull/32 to remove unneeded duplicate prometheus rule