### PR TITLE
feat: add github-team-filter-input

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
@@ -25,7 +25,7 @@ module "concourse" {
   dockerhub_password                                = var.dockerhub_password
   how_out_of_date_are_we_github_token               = var.how_out_of_date_are_we_github_token
   authorized_keys_github_token                      = var.authorized_keys_github_token
-  github_teams_filter_api_key                       = data.terraform_remote_state.account.outputs.github_teams_filter_api_key
+  teams_filter_api_key                              = data.terraform_remote_state.account.outputs.github_teams_filter_api_key
   limit_active_tasks                                = 2
   environments_live_reports_s3_bucket               = data.terraform_remote_state.account.outputs.concourse_environments_live-reports_bucket
 

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
@@ -1,6 +1,6 @@
 module "concourse" {
   count  = lookup(local.manager_workspace, terraform.workspace, false) ? 1 : 0
-  source = "github.com/ministryofjustice/cloud-platform-terraform-concourse?ref=1.29.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-concourse?ref=1.30.0"
 
   concourse_hostname                                = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   github_auth_client_id                             = var.github_auth_client_id
@@ -25,6 +25,7 @@ module "concourse" {
   dockerhub_password                                = var.dockerhub_password
   how_out_of_date_are_we_github_token               = var.how_out_of_date_are_we_github_token
   authorized_keys_github_token                      = var.authorized_keys_github_token
+  github_teams_filter_api_key                       = data.terraform_remote_state.account.outputs.github_teams_filter_api_key
   limit_active_tasks                                = 2
   environments_live_reports_s3_bucket               = data.terraform_remote_state.account.outputs.concourse_environments_live-reports_bucket
 


### PR DESCRIPTION
This pr is to add the github team filter api key as an input for the concourse module