### PR TITLE
perf: ⚡️ ingress indices are large (and growing)

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/account/app-opensearch-index-templates.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/app-opensearch-index-templates.tf
@@ -36,7 +36,7 @@ resource "opensearch_index_template" "live_kubernetes_ingress" {
   "template": {
     "settings": {
       "index": {
-        "number_of_shards": "1",
+        "number_of_shards": "4",
         "number_of_replicas": "1"
       }
     }


### PR DESCRIPTION
- we have a bunch of warm indices stuck that can't move because they are too large, we need to reindex these but first we should make sure future indices are correctly shared.

```
  {
    "index": "live_kubernetes_cluster-2024.07.12",
    "state": true,
    "cause": "Rejecting migration request for index [live_kubernetes_cluster-2024.07.12] because the shard size [100 GiB] exceeds the warm migration shard size limit of [100 GiB]. To avoid migration failures, reindex your data to reduce shard sizes, then migrate it to UltraWarm storage.",
    "message": "Failed to start warm migration [index=live_kubernetes_cluster-2024.07.12]"
  },
```