### PR TITLE
Update vpc_cni to v1.19.3-eksbuild.1

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
@@ -347,7 +347,7 @@ module "aws_eks_addons" {
   addon_tags              = local.tags
 
 
-  addon_vpc_cni_version    = "v1.19.0-eksbuild.1"
+  addon_vpc_cni_version    = "v1.19.3-eksbuild.1"
   addon_coredns_version    = "v1.11.4-eksbuild.2"
   addon_kube_proxy_version = "v1.30.9-eksbuild.3"
 }


### PR DESCRIPTION
Update vpc_cni to v1.19.3-eksbuild.1 as a part of the upgrade work to Kube 1.30 - [#6715](https://github.com/ministryofjustice/cloud-platform/issues/6715)