### PR TITLE
perf: ⚡️ add another monitoring ng

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
@@ -71,7 +71,7 @@ locals {
   }
 
   monitoring_node_size = {
-    live    = ["r6i.12xlarge", "r5.2xlarge"]
+    live    = ["r6i.12xlarge", "r5a.2xlarge"]
     live-2  = ["r6i.2xlarge", "r5a.2xlarge"]
     manager = ["t3a.medium", "t3.medium"]
     default = ["t3a.medium", "t3.medium"]

--- a/test/os_logging_test.go
+++ b/test/os_logging_test.go
@@ -36,7 +36,6 @@ var _ = Describe("logging", Ordered, Serial, func() {
 		emptySlice := make([]interface{}, 0)
 
 		BeforeEach(func() {
-
 			if !(c.ClusterName == "live") && !(c.ClusterName == "manager") {
 				Skip(fmt.Sprintf("Logs don't go to opensearch for cluster: %s", c.ClusterName))
 			}
@@ -92,7 +91,6 @@ var _ = Describe("logging", Ordered, Serial, func() {
 			// Wait for the job to complete
 			err = k8s.WaitUntilJobSucceedE(GinkgoT(), options, "logging-smoketest", 10, 20*time.Second)
 			Expect(err).ToNot(HaveOccurred())
-
 		})
 
 		AfterEach(func() {
@@ -109,15 +107,18 @@ var _ = Describe("logging", Ordered, Serial, func() {
 							{
 								Match: helpers.PhraseData{
 									Log: "hello, world smoketest-logs-" + uniqueId,
-								}},
+								},
+							},
 							{
 								Match: helpers.PhraseData{
 									Stream: "stdout",
-								}},
+								},
+							},
 							{
 								Match: helpers.PhraseData{
 									Namespace: namespace,
-								}},
+								},
+							},
 						},
 					},
 				},


### PR DESCRIPTION
-  we aren't getting the right instances for our monitoring ng in live, update the instance types

n.b this will add a new monitoring node group to each cluster.

⚠️ ~~In Manager do not use the pipeline to remove the old ng as concourse is running on it.~~ (n/a only for default ng on manager)
