### PR TITLE
Update to latest release of autoscaler module as post 1.30 upgrade action

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
@@ -42,7 +42,7 @@ module "concourse" {
 }
 
 module "cluster_autoscaler" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-cluster-autoscaler?ref=1.11.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-cluster-autoscaler?ref=1.12.0"
 
   enable_overprovision        = lookup(local.prod_workspace, terraform.workspace, false)
   cluster_domain_name         = data.terraform_remote_state.cluster.outputs.cluster_domain_name


### PR DESCRIPTION
Update to latest release of autoscaler module as post 1.30 upgrade action.
Relates to ticket [#6720](https://github.com/ministryofjustice/cloud-platform/issues/6720)

This change has been tested on test cluster and checked autoscaler functionality.