### PR TITLE
fix: 🐛 update non-prod modsec controller module call

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
@@ -158,6 +158,7 @@ module "non_prod_modsec_ingress_controllers_v1" {
 
   count = terraform.workspace == "live" ? 1 : 0
 
+  is_non_prod_modsec       = true
   replica_count            = "3"
   controller_name          = "modsec-non-prod"
   cluster_domain_name      = data.terraform_remote_state.cluster.outputs.cluster_domain_name


### PR DESCRIPTION
missing input for suffixing configmap naming to avoid clash with existing prod modsec resources

[release notes](https://github.com/ministryofjustice/cloud-platform-terraform-ingress-controller/releases/tag/1.10.2)