### PR TITLE
chore: 🤖 bump logging, use current_time_index for index date

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
@@ -222,7 +222,7 @@ module "kuberos" {
 }
 
 module "logging" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-logging?ref=1.18.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-logging?ref=1.19.0"
 
   opensearch_app_host = lookup(var.opensearch_app_host_map, terraform.workspace, "placeholder-opensearch")
   elasticsearch_host  = lookup(var.elasticsearch_hosts_maps, terraform.workspace, "placeholder-elasticsearch")


### PR DESCRIPTION
https://github.com/ministryofjustice/cloud-platform-terraform-logging/releases/tag/1.19.0