### PR TITLE
Adding AdminRole as a cluster master to allow engineering access.

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
@@ -328,6 +328,11 @@ module "eks" {
       userarn  = "arn:aws:iam::754256621582:user/EmmaTerry"
       username = "EmmaTerry"
       groups   = ["system:masters"]
+    },
+    {
+      userarn  = "arn:aws:iam::754256621582:role/aws-reserved/sso.amazonaws.com/eu-west-2/AWSReservedSSO_AdministratorAccess_bf5aaeece9ced5cc"
+      username = "administratoraccess"
+      groups   = ["system:masters"]
     }
   ]
 


### PR DESCRIPTION
This adds the SSO admin role in the cloud platform account master-level access to the cluster.

https://github.com/ministryofjustice/cloud-platform/issues/6791
https://github.com/ministryofjustice/central-digital-architecture-backlog/issues/7

Context: https://docs.google.com/document/d/1x0MzeNKY_EtcmT0UjOMXXWqhNhH-6T-gsLmj6h_8REM/edit?tab=t.0

This will resolve access issues to the cluster which have been blocking SSO adoption