### PR TITLE
chore: Downscale live-2 OpenSearch cluster

### DIFF
--- a/terraform/global-resources/elasticsearch.tf
+++ b/terraform/global-resources/elasticsearch.tf
@@ -305,7 +305,7 @@ resource "aws_elasticsearch_domain" "live-2" {
   elasticsearch_version = "OpenSearch_1.3"
 
   cluster_config {
-    instance_type            = "r6g.large.elasticsearch"
+    instance_type            = "t3.small.search"
     instance_count           = "1"
     dedicated_master_enabled = false
     zone_awareness_enabled   = false

--- a/terraform/global-resources/elasticsearch.tf
+++ b/terraform/global-resources/elasticsearch.tf
@@ -305,23 +305,18 @@ resource "aws_elasticsearch_domain" "live-2" {
   elasticsearch_version = "OpenSearch_1.3"
 
   cluster_config {
-    instance_type            = "r5.large.search"
+    instance_type            = "r6g.xlarge.elasticsearch"
     instance_count           = "2"
     dedicated_master_enabled = true
-    dedicated_master_count   = 3
+    dedicated_master_type    = "m6g.large.elasticsearch"
+    dedicated_master_count   = "3"
     zone_awareness_enabled   = true
     zone_awareness_config {
       availability_zone_count = 2
     }
-
     warm_count   = 2
     warm_enabled = true
-<<<<<<< HEAD
-    warm_type = "ultrawarm1.medium.elasticsearch"
-=======
-    warm_type    = "ultrawarm1.medium.search"
->>>>>>> cc811c1c3f9eabf9cf9811798e803a5a5a94eb48
-
+    warm_type    = "ultrawarm1.medium.elasticsearch"
     cold_storage_options {
       enabled = true
     }

--- a/terraform/global-resources/elasticsearch.tf
+++ b/terraform/global-resources/elasticsearch.tf
@@ -305,27 +305,17 @@ resource "aws_elasticsearch_domain" "live-2" {
   elasticsearch_version = "OpenSearch_1.3"
 
   cluster_config {
-    instance_type            = "r6g.xlarge.elasticsearch"
-    instance_count           = "3"
-    dedicated_master_enabled = true
-    dedicated_master_type    = "m6g.large.elasticsearch"
-    dedicated_master_count   = "3"
-    zone_awareness_enabled   = true
-    zone_awareness_config {
-      availability_zone_count = 3
-    }
-    warm_count   = 3
-    warm_enabled = true
-    warm_type    = "ultrawarm1.medium.elasticsearch"
-    cold_storage_options {
-      enabled = true
-    }
+    instance_type            = "r6g.large.elasticsearch"
+    instance_count           = "1"
+    dedicated_master_enabled = false
+    zone_awareness_enabled   = false
+    warm_enabled            = false
   }
 
   ebs_options {
     ebs_enabled = "true"
     volume_type = "gp3"
-    volume_size = "500"
+    volume_size = "10"
     iops        = "3000"
   }
 

--- a/terraform/global-resources/elasticsearch.tf
+++ b/terraform/global-resources/elasticsearch.tf
@@ -305,18 +305,18 @@ resource "aws_elasticsearch_domain" "live-2" {
   elasticsearch_version = "OpenSearch_1.3"
 
   cluster_config {
-    instance_type            = "t3.small.search"
-    instance_count           = "1"
+    instance_type            = "r5.large.search"
+    instance_count           = "2"
     dedicated_master_enabled = true
-    dedicated_master_count   = 1
+    dedicated_master_count   = 3
     zone_awareness_enabled   = true
     zone_awareness_config {
-      availability_zone_count = 3
+      availability_zone_count = 2
     }
 
     warm_count = 2
     warm_enabled = true
-    warm_type = "ultrawarm1.medium.elasticsearch"
+    warm_type = "ultrawarm1.medium.search"
 
     cold_storage_options {
       enabled = true
@@ -326,7 +326,7 @@ resource "aws_elasticsearch_domain" "live-2" {
   ebs_options {
     ebs_enabled = "true"
     volume_type = "gp3"
-    volume_size = "10"
+    volume_size = "50"
     iops        = "3000"
   }
 

--- a/terraform/global-resources/elasticsearch.tf
+++ b/terraform/global-resources/elasticsearch.tf
@@ -305,10 +305,10 @@ resource "aws_elasticsearch_domain" "live-2" {
   elasticsearch_version = "OpenSearch_1.3"
 
   cluster_config {
-    instance_type            = "r6g.xlarge.elasticsearch"
+    instance_type            = "r5.large.search"
     instance_count           = "2"
     dedicated_master_enabled = true
-    dedicated_master_type    = "m6g.large.elasticsearch"
+    dedicated_master_type    = "r5.large.search"
     dedicated_master_count   = "3"
     zone_awareness_enabled   = true
     zone_awareness_config {

--- a/terraform/global-resources/elasticsearch.tf
+++ b/terraform/global-resources/elasticsearch.tf
@@ -307,9 +307,18 @@ resource "aws_elasticsearch_domain" "live-2" {
   cluster_config {
     instance_type            = "t3.small.search"
     instance_count           = "1"
-    dedicated_master_enabled = false
-    zone_awareness_enabled   = false
-    warm_enabled            = false
+    dedicated_master_enabled = true
+    dedicated_master_count = 1
+    zone_awareness_enabled   = true
+    zone_awareness_config {
+      availability_zone_count = 3
+    }
+    warm_count   = 1
+    warm_enabled = true
+    warm_type    = "ultrawarm1.medium.elasticsearch"
+    cold_storage_options {
+      enabled = true
+    }
   }
 
   ebs_options {

--- a/terraform/global-resources/elasticsearch.tf
+++ b/terraform/global-resources/elasticsearch.tf
@@ -307,7 +307,6 @@ resource "aws_elasticsearch_domain" "live-2" {
   cluster_config {
     instance_type            = "t3.small.search"
     instance_count           = "1"
-<<<<<<< HEAD
     dedicated_master_enabled = true
     dedicated_master_count = 1
     zone_awareness_enabled   = true

--- a/terraform/global-resources/elasticsearch.tf
+++ b/terraform/global-resources/elasticsearch.tf
@@ -313,7 +313,7 @@ resource "aws_elasticsearch_domain" "live-2" {
     zone_awareness_config {
       availability_zone_count = 3
     }
-    warm_count   = 1
+    warm_count   = 2
     warm_enabled = true
     warm_type    = "ultrawarm1.medium.elasticsearch"
     cold_storage_options {

--- a/terraform/global-resources/elasticsearch.tf
+++ b/terraform/global-resources/elasticsearch.tf
@@ -316,7 +316,7 @@ resource "aws_elasticsearch_domain" "live-2" {
 
     warm_count   = 2
     warm_enabled = true
-    warm_type = "ultrawarm1.medium.search"
+    warm_type = "ultrawarm1.medium.elasticsearch"
 
     cold_storage_options {
       enabled = true

--- a/terraform/global-resources/elasticsearch.tf
+++ b/terraform/global-resources/elasticsearch.tf
@@ -308,14 +308,16 @@ resource "aws_elasticsearch_domain" "live-2" {
     instance_type            = "t3.small.search"
     instance_count           = "1"
     dedicated_master_enabled = true
-    dedicated_master_count = 1
+    dedicated_master_count   = 1
     zone_awareness_enabled   = true
     zone_awareness_config {
       availability_zone_count = 3
     }
-    warm_count   = 2
+
+    warm_count = 2
     warm_enabled = true
-    warm_type    = "ultrawarm1.medium.elasticsearch"
+    warm_type = "ultrawarm1.medium.elasticsearch"
+
     cold_storage_options {
       enabled = true
     }


### PR DESCRIPTION
## Purpose
Downscale the live-2 OpenSearch cluster:
- Reduce from 3 to 2 availability zones
- Change to r5.large.search instances from r6g.xlarge.elasticsearch
- Increase data nodes from 3 to 2
- Decrease EBS storage to 50GB per node
- Reduce warm storage instance type to ultrawarm1.medium.elasticsearch

## What's Changed
- Changed instance type from r6g.xlarge.elasticsearch to r5.large.search (memory optimized)
- Decreased instance count from 3 to 2
- Maintained dedicated master nodes (3 nodes)
- Maintained zone awareness (reduced from 3 to 2 AZs)
- Changed warm storage from ultrawarm1.large.elasticsearch to 2 nodes of ultrawarm1.medium.elasticsearch
- Decreased EBS volume size from 500GB to 50GB

## Impact
- Maintained cluster reliability with essential features
- Configuration allows for future upscaling if needed

Related to https://github.com/ministryofjustice/cloud-platform/issues/6932