### PR TITLE
chore: upgrade cloud-platform-live-2 OpenSearch from 1.3 to 2.3

### DIFF
--- a/terraform/global-resources/elasticsearch.tf
+++ b/terraform/global-resources/elasticsearch.tf
@@ -302,7 +302,7 @@ data "aws_iam_policy_document" "live-2" {
 resource "aws_elasticsearch_domain" "live-2" {
   domain_name           = "cloud-platform-live-2"
   provider              = aws.cloud-platform
-  elasticsearch_version = "OpenSearch_2.3"
+  elasticsearch_version = "OpenSearch_2.17"
 
   cluster_config {
     instance_type            = "r6g.xlarge.elasticsearch"

--- a/terraform/global-resources/elasticsearch.tf
+++ b/terraform/global-resources/elasticsearch.tf
@@ -302,7 +302,7 @@ data "aws_iam_policy_document" "live-2" {
 resource "aws_elasticsearch_domain" "live-2" {
   domain_name           = "cloud-platform-live-2"
   provider              = aws.cloud-platform
-  elasticsearch_version = "OpenSearch_1.3"
+  elasticsearch_version = "OpenSearch_2.3"
 
   cluster_config {
     instance_type            = "r6g.xlarge.elasticsearch"


### PR DESCRIPTION
## Purpose

- Upgrade the OpenSearch version from *opensearch_1.3* to *opensearch_2.17*

## What's Changed

- Upgraded OpenSearch to engine version to 2.17

Related to https://github.com/ministryofjustice/cloud-platform/issues/6932