### PR TITLE
chore: 🤖 rename prod-only -> default-non-prod

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
@@ -142,8 +142,7 @@ module "non_prod_ingress_controllers_v1" {
   is_live_cluster          = lookup(local.prod_workspace, terraform.workspace, false)
   live1_cert_dns_name      = lookup(local.live1_cert_dns_name, terraform.workspace, "")
 
-  # Enable this when we remove the module "ingress_controllers"
-  enable_external_dns_annotation = true
+  enable_external_dns_annotation = false // this creates the wildcards in external dns
 
   memory_requests = "5Gi"
   memory_limits   = "20Gi"

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
@@ -127,12 +127,12 @@ module "ingress_controllers_v1" {
   ]
 }
 
-module "production_only_ingress_controllers_v1" {
+module "non_prod_ingress_controllers_v1" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.10.4"
   count  = terraform.workspace == "live" ? 1 : 0
 
   replica_count            = "3"
-  controller_name          = "production-only"
+  controller_name          = "default-non-prod"
   enable_cross_zone_lb     = false
   enable_anti_affinity     = terraform.workspace == "live" ? true : false
   upstream_keepalive_time  = "120s"
@@ -143,7 +143,7 @@ module "production_only_ingress_controllers_v1" {
   live1_cert_dns_name      = lookup(local.live1_cert_dns_name, terraform.workspace, "")
 
   # Enable this when we remove the module "ingress_controllers"
-  enable_external_dns_annotation = false
+  enable_external_dns_annotation = true
 
   memory_requests = "5Gi"
   memory_limits   = "20Gi"

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
@@ -216,8 +216,7 @@ module "kuberos" {
   depends_on = [
     module.ingress_controllers_v1,
     module.modsec_ingress_controllers_v1,
-    module.production_only_ingress_controllers_v1
-
+    module.non_prod_ingress_controllers_v1
   ]
 }
 


### PR DESCRIPTION
We no longer need the `production-only` ingress controller.

But we do need a `default-non-prod` to mimic the setup we have with modsec.

There are some minor config optimisations that are different to the current `default` ingress, this is intentional as it would be nice to roll those optimisations out to prod, once they are rolled and validated against non-prod workloads.

- there are no workloads affected by this change