### PR TITLE
chore: update acme challenge alert throttle time

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/account/app-opensearch-alerts-cp.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/app-opensearch-alerts-cp.tf
@@ -1075,7 +1075,7 @@ locals {
                   "lang" : "mustache"
                 },
                 "throttle" : {
-                  "value" : 1440,
+                  "value" : 30,
                   "unit" : "MINUTES"
                 }
               }


### PR DESCRIPTION
- Update acme challenge alert throttle time from 1440 mins (24 hours) to 30 mins