### PR TITLE
reverting Gatekeepr upgrade

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/gatekeeper.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/gatekeeper.tf
@@ -1,5 +1,5 @@
 module "gatekeeper" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-gatekeeper?ref=1.16.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-gatekeeper?ref=1.15.0"
 
   dryrun_map = {
     service_type                       = false,


### PR DESCRIPTION
Reverting Gatekeeper upgrade as the latest version causes an issue when destroying a cluster:
```
Error: k8sexternaldnsidentifier failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in 'null'


Error: k8ssnippetallowlist failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in 'null'


Error: deny-privilege-escalation failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in ''


Error: warn-kubectl-create-sa failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in 'null'


Error: k8svalidhostname failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in 'null'


Error: run-as-non-root failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in ''


Error: k8smodsecsnippetnginxclass failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in 'null'


Error: k8sexternaldnsweight failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in 'null'


Error: default-supplemental-groups failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in ''


Error: deny-privilege-escalation-init failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in ''


Error: user-ns-require-psa-label failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in 'null'


Error: allow-duplicate-hostname failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in 'null'


Error: k8sblockingresses failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in 'null'


Error: k8swarnserviceaccountsecretdelete failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in 'null'


Error: run-as-non-root-init failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in ''


Error: run-as-non-root-eph failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in ''


Error: k8smodsecnginxclass failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in 'null'


Error: default-seccomp-profile failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in ''


Error: drop-all-cap-eph failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in ''


Error: deny-privilege-escalation-eph failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in ''


Error: verify-1.29 failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in 'null'


Error: k8sservicetypeloadbalancer failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in 'null'


Error: drop-all-cap-init failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in ''


Error: k8shostnamelength failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in 'null'


Error: lockprivcapabilities failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in 'null'


Error: k8singressclash failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in 'null'


Error: default-fs-group failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in ''


Error: verify-1.27 failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in 'null'


Error: verify-1.26 failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in 'null'


Error: drop-all-cap failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in ''

FATA[0108] failed to destroy terraform: failed to destroy component in yy-1804-0000: exit status 1

Error: k8sexternaldnsidentifier failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in 'null'


Error: k8ssnippetallowlist failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in 'null'


Error: deny-privilege-escalation failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in ''


Error: warn-kubectl-create-sa failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in 'null'


Error: k8svalidhostname failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in 'null'


Error: run-as-non-root failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in ''


Error: k8smodsecsnippetnginxclass failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in 'null'


Error: k8sexternaldnsweight failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in 'null'


Error: default-supplemental-groups failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in ''


Error: deny-privilege-escalation-init failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in ''


Error: user-ns-require-psa-label failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in 'null'


Error: allow-duplicate-hostname failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in 'null'


Error: k8sblockingresses failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in 'null'


Error: k8swarnserviceaccountsecretdelete failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in 'null'


Error: run-as-non-root-init failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in ''


Error: run-as-non-root-eph failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in ''


Error: k8smodsecnginxclass failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in 'null'


Error: default-seccomp-profile failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in ''


Error: drop-all-cap-eph failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in ''


Error: deny-privilege-escalation-eph failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in ''


Error: verify-1.29 failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in 'null'


Error: k8sservicetypeloadbalancer failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in 'null'


Error: drop-all-cap-init failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in ''


Error: k8shostnamelength failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in 'null'


Error: lockprivcapabilities failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in 'null'


Error: k8singressclash failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in 'null'


Error: default-fs-group failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in ''


Error: verify-1.27 failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in 'null'


Error: verify-1.26 failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in 'null'


Error: drop-all-cap failed to delete kubernetes resource: admission webhook "validation.gatekeeper.sh" denied the request: Object 'Kind' is missing in ''
```
 There is an [open issue](https://github.com/open-policy-agent/gatekeeper/issues/3918) for this bug which should be fixed in the next Gatekeeper release. We'll revisit when there's a release for this fix.

