### PR TITLE
chore: 🤖 delete ssm slack webhook block

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/main.tf
@@ -173,10 +173,3 @@ locals {
     live = format("- '*.apps.%s'", var.live1_domain)
   }
 }
-
-resource "aws_ssm_parameter" "alertmanager_slack_receivers_import" {
-  name        = "/cloud-platform/alertmanager_slack_receivers_import"
-  type        = "SecureString"
-  value       = jsonencode(var.alertmanager_slack_receivers)
-  description = "Temp block to import Slack receivers for Alertmanager"
-}


### PR DESCRIPTION
```
Error: creating SSM Parameter (/cloud-platform/alertmanager_slack_receivers_import): ValidationException: 1 validation error detected: Value at 'value' failed to satisfy constraint: Member must have length less than or equal to 32768
```

We'll need to look at something like splitting the data somehow to get this working.