### PR TITLE
chore: 🤖 fix s3 bucket config

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/s3.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/s3.tf
@@ -9,7 +9,6 @@ module "s3_bucket_alertmanager_slack_receivers" {
   count = terraform.workspace == "live" ? 1 : 0
 
   bucket = "cloud-platform-alertmanager-slack-receivers"
-  acl    = "private"
 
   block_public_acls       = true
   block_public_policy     = true

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/s3.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/s3.tf
@@ -33,7 +33,6 @@ resource "aws_s3_object" "alertmanager_slack_receivers" {
 
   bucket = module.s3_bucket_alertmanager_slack_receivers[0].s3_bucket_id
   key    = "alertmanager_slack_receivers.json"
-  acl    = "private"
 
   content = jsonencode(var.alertmanager_slack_receivers)
 


### PR DESCRIPTION
bucket module defaults to `BucketOwnerEnforced` which disables ACLs (recommended AWS practice)