### PR TITLE
Ingress finops tag

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
@@ -128,7 +128,7 @@ module "ingress_controllers_v1" {
 }
 
 module "non_prod_ingress_controllers_v1" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.10.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.10.6"
   count  = terraform.workspace == "live" ? 1 : 0
 
   replica_count            = "6"
@@ -147,13 +147,15 @@ module "non_prod_ingress_controllers_v1" {
   memory_requests = "5Gi"
   memory_limits   = "20Gi"
 
+  default_tags = local.default_tags
+
   depends_on = [
     module.label_pods_controller
   ]
 }
 
 module "non_prod_modsec_ingress_controllers_v1" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.10.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.10.6"
 
   count = terraform.workspace == "live" ? 1 : 0
 
@@ -174,6 +176,8 @@ module "non_prod_modsec_ingress_controllers_v1" {
   opensearch_modsec_audit_host = lookup(var.elasticsearch_modsec_audit_hosts_maps, terraform.workspace, "placeholder-elasticsearch")
   cluster                      = terraform.workspace
   fluent_bit_version           = "3.0.2-amd64"
+
+  default_tags = local.default_tags
 
   depends_on = [module.ingress_controllers_v1]
 }

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/main.tf
@@ -17,13 +17,7 @@ provider "aws" {
   region = "eu-west-2"
 
   default_tags {
-    tags = {
-      business-unit = "Platforms"
-      application   = "cloud-platform-aws/vpc/eks/core/components"
-      is-production = "true"
-      owner         = "Cloud Platform: platforms@digital.justice.gov.uk"
-      source-code   = "github.com/ministryofjustice/cloud-platform-infrastructure"
-    }
+    tags = local.default_tags
   }
 }
 
@@ -171,5 +165,13 @@ locals {
   }
   live1_cert_dns_name = {
     live = format("- '*.apps.%s'", var.live1_domain)
+  }
+
+  default_tags = {
+    business-unit = "Platforms"
+    application   = "cloud-platform-aws/vpc/eks/core/components"
+    is-production = "true"
+    owner         = "Cloud Platform: platforms@digital.justice.gov.uk"
+    source-code   = "github.com/ministryofjustice/cloud-platform-infrastructure"
   }
 }


### PR DESCRIPTION
Moving default tags out of the provider to local variables so they can be passed into modules.
Bumping non-prod ingress controllers to include default tags.