### PR TITLE
Bumping prod ingress controllers to module 1.10.6

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
@@ -105,7 +105,7 @@ module "external_secrets_operator" {
 }
 
 module "ingress_controllers_v1" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.10.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.10.6"
 
   replica_count            = terraform.workspace == "live" ? "30" : "3"
   controller_name          = "default"
@@ -121,6 +121,8 @@ module "ingress_controllers_v1" {
 
   memory_requests = lookup(local.live_workspace, terraform.workspace, false) ? "5Gi" : "512Mi"
   memory_limits   = lookup(local.live_workspace, terraform.workspace, false) ? "20Gi" : "2Gi"
+
+  default_tags = local.default_tags
 
   depends_on = [
     module.label_pods_controller
@@ -183,7 +185,7 @@ module "non_prod_modsec_ingress_controllers_v1" {
 }
 
 module "modsec_ingress_controllers_v1" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.10.4"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.10.6"
 
 
   replica_count            = terraform.workspace == "live" ? "12" : "3"
@@ -202,6 +204,8 @@ module "modsec_ingress_controllers_v1" {
   opensearch_modsec_audit_host = lookup(var.elasticsearch_modsec_audit_hosts_maps, terraform.workspace, "placeholder-elasticsearch")
   cluster                      = terraform.workspace
   fluent_bit_version           = "3.0.2-amd64"
+
+  default_tags = local.default_tags
 
   depends_on = [module.ingress_controllers_v1]
 }


### PR DESCRIPTION
Including changes for finops tagging (1.10.6) and logging format changes (1.10.5)
Been tested on live using the non-prod ingress controllers. 