### PR TITLE
chore: 🤖 bump monitoring module

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
@@ -240,7 +240,7 @@ module "logging" {
 }
 
 module "monitoring" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=3.21.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=3.22.0"
 
   alertmanager_slack_receivers  = local.enable_alerts ? var.alertmanager_slack_receivers : [{ severity = "dummy", webhook = "https://dummy.slack.com", channel = "#dummy-alarms" }]
   pagerduty_config              = local.enable_alerts ? data.aws_ssm_parameter.components["pagerduty_config"].value : "dummy"


### PR DESCRIPTION
network policy additions for calling thanos internally

[release](https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/releases/tag/3.22.0)