### PR TITLE
chore: 🤖 bump monitoring and update subnet-exporter image

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
@@ -240,7 +240,7 @@ module "logging" {
 }
 
 module "monitoring" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=3.22.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=3.23.0"
 
   alertmanager_slack_receivers  = local.enable_alerts ? var.alertmanager_slack_receivers : [{ severity = "dummy", webhook = "https://dummy.slack.com", channel = "#dummy-alarms" }]
   pagerduty_config              = local.enable_alerts ? data.aws_ssm_parameter.components["pagerduty_config"].value : "dummy"
@@ -264,7 +264,7 @@ module "monitoring" {
   enable_cloudwatch_exporter    = lookup(local.live_workspace, terraform.workspace, false)
   enable_rds_exporter           = terraform.workspace == "live"
   enable_subnet_exporter        = terraform.workspace == "live"
-  aws_subnet_exporter_image_tag = "d79d5d75cbdcd442b9a04e17269ece994b3b551d"
+  aws_subnet_exporter_image_tag = "c8dd738558837b9eef99858c3eaeeb70957b90b0"
 
   eks_cluster_oidc_issuer_url = data.terraform_remote_state.cluster.outputs.cluster_oidc_issuer_url
 


### PR DESCRIPTION
[release](https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/releases/tag/3.23.0)

relates to ministryofjustice/cloud-platform#6550

