### PR TITLE
fix: 🐛 modsec syntax

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
@@ -157,7 +157,7 @@ module "non_prod_ingress_controllers_v1" {
 }
 
 module "non_prod_modsec_ingress_controllers_v1" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.11.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.11.4"
 
   count = terraform.workspace == "live" ? 1 : 0
 


### PR DESCRIPTION
https://github.com/ministryofjustice/cloud-platform-terraform-ingress-controller/releases/tag/1.11.4