### PR TITLE
param opensearch req delay

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/account/modsec-opensearch.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/modsec-opensearch.tf
@@ -316,7 +316,7 @@ resource "elasticsearch_opensearch_roles_mapping" "all_access" {
     aws_iam_role.os_access_role.arn,
   ], values(data.aws_eks_node_group.current)[*].node_role_arn)
   // Permissions to manager-concourse in order to run modsec logging tests
-  users = ["arn:aws:iam::754256621582:user/cloud-platform/manager-concourse"]
+  users = ["arn:aws:iam::754256621582:user/cloud-platform/manager-concourse", "arn:aws:iam::754256621582:role/aws-reserved/sso.amazonaws.com/eu-west-2/AWSReservedSSO_AdministratorAccess_ae2d551dbf676d8f"]
   depends_on = [
     aws_opensearch_domain_saml_options.live_modsec_audit,
   ]

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
@@ -105,7 +105,7 @@ module "external_secrets_operator" {
 }
 
 module "ingress_controllers_v1" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.12.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.12.2"
 
   replica_count            = terraform.workspace == "live" ? "30" : "3"
   controller_name          = "default"
@@ -130,7 +130,7 @@ module "ingress_controllers_v1" {
 }
 
 module "non_prod_ingress_controllers_v1" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.12.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.12.2"
   count  = terraform.workspace == "live" ? 1 : 0
 
   replica_count            = "6"
@@ -157,7 +157,7 @@ module "non_prod_ingress_controllers_v1" {
 }
 
 module "non_prod_modsec_ingress_controllers_v1" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.12.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.12.2"
 
   count = terraform.workspace == "live" ? 1 : 0
 
@@ -186,7 +186,7 @@ module "non_prod_modsec_ingress_controllers_v1" {
 }
 
 module "modsec_ingress_controllers_v1" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.12.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.12.2"
 
   replica_count            = terraform.workspace == "live" ? "12" : "3"
   controller_name          = "modsec"

--- a/test/helpers/search.go
+++ b/test/helpers/search.go
@@ -62,7 +62,7 @@ func GetSearchResults(delay int, values SearchData, search string, awsSigner *si
 
 	Expect(signErr).ToNot(HaveOccurred())
 
-	time.Sleep(delay * time.Second) // prevent dial tcp: lookup smoketest-logs-usepwe.integrationtest.service.justice.gov.uk: no such host errors and wait for logs
+	time.Sleep(time.Duration(delay) * time.Second) // prevent dial tcp: lookup smoketest-logs-usepwe.integrationtest.service.justice.gov.uk: no such host errors and wait for logs
 
 	resp, httpErr := client.Do(req)
 
@@ -80,6 +80,5 @@ func GetSearchResults(delay int, values SearchData, search string, awsSigner *si
 
 	Expect(unmarshalErr).ToNot(HaveOccurred())
 
-	// Check the logs for the expected message
 	Expect(hits.Hits.Total.Value).To(Equal(100))
 }

--- a/test/helpers/search.go
+++ b/test/helpers/search.go
@@ -35,7 +35,7 @@ type SearchData struct {
 	Query BoolData `json:"query"`
 }
 
-func GetSearchResults(values SearchData, search string, awsSigner *signer.Signer, client *http.Client) {
+func GetSearchResults(delay int, values SearchData, search string, awsSigner *signer.Signer, client *http.Client) {
 	type ValueKey struct {
 		Value int `json:"value"`
 	}
@@ -62,7 +62,7 @@ func GetSearchResults(values SearchData, search string, awsSigner *signer.Signer
 
 	Expect(signErr).ToNot(HaveOccurred())
 
-	time.Sleep(80 * time.Second) // prevent dial tcp: lookup smoketest-logs-usepwe.integrationtest.service.justice.gov.uk: no such host errors and wait for logs
+	time.Sleep(delay * time.Second) // prevent dial tcp: lookup smoketest-logs-usepwe.integrationtest.service.justice.gov.uk: no such host errors and wait for logs
 
 	resp, httpErr := client.Do(req)
 

--- a/test/modsec_logging_test.go
+++ b/test/modsec_logging_test.go
@@ -134,7 +134,7 @@ var _ = Describe("logging", Ordered, Serial, func() {
 					},
 				}
 
-				helpers.GetSearchResults(values, search, awsSigner, client)
+				helpers.GetSearchResults(120, values, search, awsSigner, client)
 			})
 
 			It("should be able to retrieve the audit log messages from modsec opensearch", func() {
@@ -154,7 +154,7 @@ var _ = Describe("logging", Ordered, Serial, func() {
 					},
 				}
 
-				helpers.GetSearchResults(auditValues, search, awsSigner, client)
+				helpers.GetSearchResults(120, auditValues, search, awsSigner, client)
 			})
 		})
 	})

--- a/test/modsec_logging_test.go
+++ b/test/modsec_logging_test.go
@@ -134,7 +134,7 @@ var _ = Describe("logging", Ordered, Serial, func() {
 					},
 				}
 
-				helpers.GetSearchResults(120, values, search, awsSigner, client)
+				helpers.GetSearchResults(30, values, search, awsSigner, client)
 			})
 
 			It("should be able to retrieve the audit log messages from modsec opensearch", func() {
@@ -154,7 +154,7 @@ var _ = Describe("logging", Ordered, Serial, func() {
 					},
 				}
 
-				helpers.GetSearchResults(120, auditValues, search, awsSigner, client)
+				helpers.GetSearchResults(30, auditValues, search, awsSigner, client)
 			})
 		})
 	})

--- a/test/os_logging_test.go
+++ b/test/os_logging_test.go
@@ -124,7 +124,7 @@ var _ = Describe("logging", Ordered, Serial, func() {
 				},
 			}
 
-			helpers.GetSearchResults(values, search, awsSigner, client)
+			helpers.GetSearchResults(50, values, search, awsSigner, client)
 		})
 	})
 })

--- a/test/user_app_logging_test.go
+++ b/test/user_app_logging_test.go
@@ -139,7 +139,7 @@ var _ = Describe("logging", Ordered, func() {
 					},
 				}
 
-				helpers.GetSearchResults(values, search, awsSigner, client)
+				helpers.GetSearchResults(180, values, search, awsSigner, client)
 			})
 		})
 	})


### PR DESCRIPTION
- bump ingresses to pick up logging fix
- add aws sso arn to modsec (so we can run the int tests from local)
- parameterise opensearch delay request

https://github.com/ministryofjustice/cloud-platform-terraform-ingress-controller/releases/tag/1.12.2