### PR TITLE
adding ssm parameters for account layer in prep for Cortex XSIAM

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/account/ssm.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/ssm.tf
@@ -24,9 +24,9 @@ resource "aws_ssm_parameter" "account" {
 
 # Data blocks for SSM parameter lookup in all workspaces
 data "aws_ssm_parameter" "account" {
-    for_each = toset(local.ssm_parameters)
+  for_each = toset(local.ssm_parameters)
 
-    name = "/cloud-platform/infrastructure/account/${each.value}"
+  name = "/cloud-platform/infrastructure/account/${each.value}"
 
-    depends_on = [aws_ssm_parameter.account]
+  depends_on = [aws_ssm_parameter.account]
 }


### PR DESCRIPTION
Relates to https://github.com/ministryofjustice/cloud-platform/issues/7203

This is adding ssm parameters functionality to the account layer, and follows the same pattern already implemented at the [components layer](https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/main/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/ssm.tf).

This is in preparation to store sensitive Cortex XSIAM endpoint variable which will be required for the new [cloud-platform-terraform-firehose-data-stream](https://github.com/ministryofjustice/cloud-platform-terraform-firehose-data-stream) terraform module to stream Cloudwatch logs to Cortex XSIAM.