### PR TITLE
feat: 🎸 AWS Firehose to stream CloudWatch log groups to Cortex - EKS test cluster logs

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/account/firehose.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/firehose.tf
@@ -1,0 +1,8 @@
+#### AWS Firehose to stream CloudWatch log groups to Cortex XSIAM
+
+# test cluster EKS logs to Cortex XSIAM preproduction environment
+module "firehose_eks_logs_to_xsiam" {
+  source                     = "github.com/ministryofjustice/cloud-platform-terraform-firehose-data-stream?ref=1.0.0"
+  cloudwatch_log_group_names = ["/aws/eks/cp-0206-0839/cluster"]
+  destination_http_endpoint  = data.aws_ssm_parameter.account["cortex_xsiam_endpoint"].value
+}


### PR DESCRIPTION
This PR provisions [AWS FIrehose resources](https://github.com/ministryofjustice/cloud-platform-terraform-firehose-data-stream) to stream logs from a CloudWatch log group to Cortex XSIAM for a test cluster.

Relates to https://github.com/ministryofjustice/cloud-platform/issues/7203

