### PR TITLE
Output Cloudwatch Log Group name for EKS Cluster

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/outputs.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/outputs.tf
@@ -74,3 +74,8 @@ output "cluster_endpoint" {
   value       = module.eks.cluster_endpoint
   description = "The endpoint for your EKS Kubernetes API."
 }
+
+output "cloudwatch_log_group_name" {
+  value       = module.eks.cloudwatch_log_group_name
+  description = "The name of the CloudWatch log group for the EKS cluster."
+}


### PR DESCRIPTION
This will output the the Log Group name. The output will be used as an input for the Firehose module to send logs to Cortex XSIAM.

Relates to https://github.com/ministryofjustice/cloud-platform/issues/7203