### PR TITLE
Bump monitoring module to include low ip prefix alert 

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
@@ -241,7 +241,7 @@ module "logging" {
 }
 
 module "monitoring" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=3.23.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=3.24.0"
 
   alertmanager_slack_receivers  = local.enable_alerts ? var.alertmanager_slack_receivers : [{ severity = "dummy", webhook = "https://dummy.slack.com", channel = "#dummy-alarms" }]
   pagerduty_config              = local.enable_alerts ? data.aws_ssm_parameter.components["pagerduty_config"].value : "dummy"


### PR DESCRIPTION
Bump monitoring module to the latest version. This creates an alert that indicates when we are running low on remaining IP Prefixes for the cluster, triggering at 10% remaining.

Relevant issue: [#6571](https://github.com/ministryofjustice/cloud-platform/issues/6571)