### PR TITLE
AWS Firehose to stream CloudWatch log groups to Cortex - live cluster

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/account/firehose.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/firehose.tf
@@ -1,8 +1,8 @@
 #### AWS Firehose to stream CloudWatch log groups to Cortex XSIAM
 
-# test cluster EKS logs to Cortex XSIAM preproduction environment
-module "firehose_eks_logs_to_xsiam" {
+# live EKS logs to Cortex XSIAM
+module "firehose_eks_live_logs_to_xsiam" {
   source                     = "github.com/ministryofjustice/cloud-platform-terraform-firehose-data-stream?ref=1.0.0"
-  cloudwatch_log_group_names = ["/aws/eks/cp-0206-0839/cluster"]
+  cloudwatch_log_group_names = [data.terraform_remote_state.eks_live.outputs.cloudwatch_log_group_name]
   destination_http_endpoint  = data.aws_ssm_parameter.account["cortex_xsiam_endpoint"].value
 }

--- a/terraform/aws-accounts/cloud-platform-aws/account/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/main.tf
@@ -57,6 +57,18 @@ data "terraform_remote_state" "live-1" {
   }
 }
 
+# get access to live EKS Cluster state
+# Necessary to get CloudWatch Log Group name for Firehose
+data "terraform_remote_state" "eks_live" {
+  backend = "s3"
+  config = {
+    bucket  = "cloud-platform-terraform-state"
+    region  = "eu-west-1"
+    key     = "aws-accounts/cloud-platform-aws/vpc/eks/live/terraform.tfstate"
+    profile = "moj-cp"
+  }
+}
+
 # used for cloudfront/waf
 provider "aws" {
   alias  = "northvirginia"


### PR DESCRIPTION
This PR :

- provisions [AWS FIrehose resources](https://github.com/ministryofjustice/cloud-platform-terraform-firehose-data-stream) to stream logs from the live EKS cluster's CloudWatch log group to Cortex XSIAM.
- deletes the [test Firehose instance](https://github.com/ministryofjustice/cloud-platform-infrastructure/pull/4008)
- introduces `terraform-remote-state` in order to pull the log group name from the EKS module

Relates to https://github.com/ministryofjustice/cloud-platform/issues/7203