### PR TITLE
Create cloud platform transit gateway

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/transit-gateway/backend.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/transit-gateway/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket  = "cloud-platform-terraform-state"
+    key     = "transit-gateway/terraform.tfstate"
+    region  = "eu-west-1"
+    profile = "moj-cp"
+  }
+}

--- a/terraform/aws-accounts/cloud-platform-aws/transit-gateway/providers.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/transit-gateway/providers.tf
@@ -1,0 +1,13 @@
+provider "aws" {
+  region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      business-unit = "Platforms"
+      application   = "cloud-platform-aws/transit-gateway"
+      is-production = "true"
+      owner         = "Cloud Platform: platforms@digital.justice.gov.uk"
+      source-code   = "github.com/ministryofjustice/cloud-platform-infrastructure"
+    }
+  }
+}

--- a/terraform/aws-accounts/cloud-platform-aws/transit-gateway/transit-gateway.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/transit-gateway/transit-gateway.tf
@@ -1,0 +1,22 @@
+locals {
+  tgw_route_table_names = toset(["external", "inspection", "internal"])
+}
+
+module "cloud-platform-transit-gateway" {
+  source  = "terraform-aws-modules/transit-gateway/aws"
+  version = "2.13.0"
+
+  name        = "cloud-platform-transit-gateway"
+  description = "Transit Gateway connecting the MOJ Cloud Platform with internal AWS and on-premise environments."
+
+  create_tgw_routes                      = false
+  enable_default_route_table_association = false
+  enable_default_route_table_propagation = false
+  share_tgw                              = false
+  vpc_attachments                        = {}
+}
+
+resource "aws_ec2_transit_gateway_route_table" "this" {
+  for_each           = local.tgw_route_table_names
+  transit_gateway_id = module.cloud-platform-transit-gateway.ec2_transit_gateway_id
+}

--- a/terraform/aws-accounts/cloud-platform-aws/transit-gateway/versions.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/transit-gateway/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.83.0"
+    }
+  }
+  required_version = ">= 1.2.5"
+}


### PR DESCRIPTION
Creates a Transit Gateway with three route tables and no attachments.

This will later be peered with the another MOJ transit gateway and the inspection VPC.