### PR TITLE
Amend Transit Gateway attachment behaviour

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/transit-gateway/transit-gateway.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/transit-gateway/transit-gateway.tf
@@ -2,7 +2,7 @@ locals {
   tgw_route_table_names = toset(["external", "inspection", "internal"])
   vpc_attachments = {
     inspection = {
-      appliance_mode_support = true
+      appliance_mode_support                 = true
       enable_default_route_table_association = false
       enable_default_route_table_propagation = false
       route_table                            = "inspection"
@@ -19,9 +19,11 @@ module "cloud-platform-transit-gateway" {
   name        = "cloud-platform-transit-gateway"
   description = "Transit Gateway connecting the MOJ Cloud Platform with internal AWS and on-premise environments."
 
-  create_tgw_routes = false
-  share_tgw         = false
-  vpc_attachments   = local.vpc_attachments
+  create_tgw_routes                      = false
+  enable_default_route_table_association = false
+  enable_default_route_table_propagation = false
+  share_tgw                              = false
+  vpc_attachments                        = local.vpc_attachments
 }
 
 /* aws_ec2_transit_gateway_route_table doesn't appear to consume default_tags supplied by the provider.

--- a/terraform/aws-accounts/cloud-platform-aws/transit-gateway/transit-gateway.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/transit-gateway/transit-gateway.tf
@@ -3,9 +3,11 @@ locals {
   vpc_attachments = {
     inspection = {
       appliance_mode_support = true
-      vpc_id                 = data.aws_vpc.inspection_vpc.id
-      route_table            = "inspection"
-      subnet_ids             = toset([for subnet in data.aws_subnet.inspection_vpc_intra : subnet.id])
+      enable_default_route_table_association = false
+      enable_default_route_table_propagation = false
+      route_table                            = "inspection"
+      subnet_ids                             = toset([for subnet in data.aws_subnet.inspection_vpc_intra : subnet.id])
+      vpc_id                                 = data.aws_vpc.inspection_vpc.id
     }
   }
 }
@@ -17,11 +19,9 @@ module "cloud-platform-transit-gateway" {
   name        = "cloud-platform-transit-gateway"
   description = "Transit Gateway connecting the MOJ Cloud Platform with internal AWS and on-premise environments."
 
-  create_tgw_routes                      = false
-  enable_default_route_table_association = false
-  enable_default_route_table_propagation = false
-  share_tgw                              = false
-  vpc_attachments                        = local.vpc_attachments
+  create_tgw_routes = false
+  share_tgw         = false
+  vpc_attachments   = local.vpc_attachments
 }
 
 /* aws_ec2_transit_gateway_route_table doesn't appear to consume default_tags supplied by the provider.


### PR DESCRIPTION
When we specify the behaviour for default route table attachment/propagation directly in the `transit-gateway` module it is obeyed when a VPC is attached. However, when terraform is run after the attachment this behaviour is overridden by the defaults.

This PR specifies the behaviour in `local.vpc_attachments` to ensure it is obeyed.