### PR TITLE
chore: 🤖 bump modsec production controller

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
@@ -186,7 +186,7 @@ module "non_prod_modsec_ingress_controllers_v1" {
 }
 
 module "modsec_ingress_controllers_v1" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.13.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.14.0"
 
   replica_count            = terraform.workspace == "live" ? "12" : "3"
   controller_name          = "modsec"


### PR DESCRIPTION
This PR rolls back ingress controller version from 1.12.1 to 1.12.0 in order to re-enable admission webhook point validation of ingress configurations.

[release notes](https://github.com/ministryofjustice/cloud-platform-terraform-ingress-controller/releases/tag/1.14.0)