### PR TITLE
Supply static routes to TGW route tables

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/transit-gateway/transit-gateway.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/transit-gateway/transit-gateway.tf
@@ -1,5 +1,35 @@
 locals {
+  flattened_tgw_routes = merge([
+    for table_name, routes in local.tgw_route_table_routes :
+    {
+      for cidr, attachment_id in routes :
+      "${table_name}:${cidr}" => {
+        route_table_name = table_name
+        destination_cidr = cidr
+        attachment_id    = attachment_id
+      }
+    }
+  ]...)
   tgw_route_table_names = toset(["external", "inspection", "internal"])
+  tgw_route_table_routes = {
+    external = {
+      "172.20.0.0/16" = module.cloud-platform-transit-gateway.ec2_transit_gateway_vpc_attachment["inspection"].id,
+      "10.195.0.0/16" = module.cloud-platform-transit-gateway.ec2_transit_gateway_vpc_attachment["inspection"].id,
+    },
+    /* This will require established peering with LAA ECP and MOJ TGW for full routing assignments
+    inspection = {
+      "10.0.0.0/8" = data.aws_ec2_transit_gateway_peering_attachment.moj-tgw.id,
+      "172.12.0.0/12" = data.aws_ec2_transit_gateway_peering_attachment.moj-tgw.id,
+      "192.168.0.0/16" = data.aws_ec2_transit_gateway_peering_attachment.moj-tgw.id,
+      "10.205.4.0/22" = data.aws_ec2_transit_gateway_peering_attachment.laa-ecp-tgw.id
+    },
+    */
+    internal = {
+      "10.0.0.0/8"     = module.cloud-platform-transit-gateway.ec2_transit_gateway_vpc_attachment["inspection"].id,
+      "172.16.0.0/12"  = module.cloud-platform-transit-gateway.ec2_transit_gateway_vpc_attachment["inspection"].id,
+      "192.168.0.0/16" = module.cloud-platform-transit-gateway.ec2_transit_gateway_vpc_attachment["inspection"].id,
+    }
+  }
   vpc_attachments = {
     inspection = {
       appliance_mode_support                          = true
@@ -52,4 +82,18 @@ resource "aws_ec2_transit_gateway_route_table_propagation" "this" {
   for_each                       = local.vpc_attachments
   transit_gateway_attachment_id  = module.cloud-platform-transit-gateway.ec2_transit_gateway_vpc_attachment[each.key].id
   transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.this[each.value.route_table].id
+}
+
+/* Ensure all attached VPCs propagate their routes into the inspection route table */
+resource "aws_ec2_transit_gateway_route_table_propagation" "inspection" {
+  for_each                       = local.vpc_attachments
+  transit_gateway_attachment_id  = module.cloud-platform-transit-gateway.ec2_transit_gateway_vpc_attachment[each.key].id
+  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.this["inspection"].id
+}
+
+resource "aws_ec2_transit_gateway_route" "this" {
+  for_each                       = local.flattened_tgw_routes
+  destination_cidr_block         = each.value.destination_cidr
+  transit_gateway_attachment_id  = each.value.attachment_id
+  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.this[each.value.route_table_name].id
 }


### PR DESCRIPTION
This PR uses a local value to flatten out a map of route table names to routes and attachment IDs.

This ensures that:
* Attachments associated with the `external` route table send traffic via the inspection VPC
* Attachments associated with the `inspection` route table understand all paths traffic can take
* Attachments associated with the `internal` route table send traffic via the inspection VPC