### PR TITLE
allowing overwriting SSM parameters that was created outside terraform

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/account/ssm.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/ssm.tf
@@ -18,6 +18,8 @@ resource "aws_ssm_parameter" "account" {
   value       = "PLACEHOLDER"
   description = "infrastructure/account terraform secret: ${each.value}"
 
+  overwrite = true
+
   lifecycle {
     ignore_changes = [value]
   }


### PR DESCRIPTION
Relates to https://github.com/ministryofjustice/cloud-platform/issues/7204