### PR TITLE
Move `live-1` and `live-2` TGW endpoints to dedicated subnets

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/transit-gateway-routes/vpc-attachment.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/transit-gateway-routes/vpc-attachment.tf
@@ -1,7 +1,35 @@
+locals {
+  vpcs_to_attach = toset(["live-1", "live-2"])
+}
+
+data "aws_ec2_transit_gateway" "pttp-tgw" {
+  id = "tgw-026162f1ba39ce704"
+}
+
+data "aws_vpc" "selected" {
+  for_each = local.vpcs_to_attach
+  filter {
+    name   = "tag:Name"
+    values = [each.key]
+  }
+}
+
+data "aws_subnets" "transit" {
+  for_each = local.vpcs_to_attach
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.selected[each.key].id]
+  }
+  filter {
+    name   = "tag:Name"
+    values = ["transit-*"]
+  }
+}
+
 resource "aws_ec2_transit_gateway_vpc_attachment" "cp-live-pttp" {
-  transit_gateway_id = "tgw-026162f1ba39ce704" # eu-west-2 TGW
-  subnet_ids         = ["subnet-07fa62f055b2bcfce", "subnet-042d27892b9d249dc", "subnet-008096de384cdb660"]
-  vpc_id             = "vpc-0726ec279947067f8"
+  transit_gateway_id = data.aws_ec2_transit_gateway.pttp-tgw.id # eu-west-2 TGW
+  subnet_ids         = toset(data.aws_subnets.transit["live-1"].ids)
+  vpc_id             = data.aws_vpc.selected["live-1"].id
 
   tags = {
     Name  = "cp-live-pttp"
@@ -10,9 +38,9 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "cp-live-pttp" {
 }
 
 resource "aws_ec2_transit_gateway_vpc_attachment" "cp-live-2-pttp" {
-  transit_gateway_id = "tgw-026162f1ba39ce704" # eu-west-2 TGW
-  subnet_ids         = ["subnet-013ebce75092e9f1a", "subnet-04f8b186d9e918447", "subnet-0a8637bc986c186a8"]
-  vpc_id             = "vpc-05f6163cd8616d19c"
+  transit_gateway_id = data.aws_ec2_transit_gateway.pttp-tgw.id # eu-west-2 TGW
+  subnet_ids         = toset(data.aws_subnets.transit["live-2"].ids)
+  vpc_id             = data.aws_vpc.selected["live-2"].id
 
   tags = {
     Name  = "cp-live-2-pttp"


### PR DESCRIPTION
This PR does the following:
* Uses data calls to populate values in the VPC attachment resources
* Modifies the subnets used to hold endpoints to dedicated `transit` subnets

No routing is changed as a consequence of this PR.