### PR TITLE
added permission alerting/monitor/execute to allow user to run query …

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/account/app-opensearch.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/app-opensearch.tf
@@ -350,6 +350,7 @@ resource "elasticsearch_opensearch_role" "all_org_members_app_logs" {
     "cluster:admin/opendistro/alerting/alerts/ack",
     "cluster:admin/opendistro/alerting/monitors/get",
     "cluster:admin/opendistro/alerting/monitors/search",
+    "cluster:admin/opendistro/alerting/monitors/execute",
     "cluster:admin/opensearch/notifications/configs/get",
     "cluster:admin/opendistro/reports/definition/create",
     "cluster:admin/opendistro/reports/definition/update",


### PR DESCRIPTION
Added additional cluster permissions cluster:admin/opendistro/alerting/monitor/execute to allow user to run OpenSearch query DSL without getting permissions error="[security_exception] no permissions for [cluster:admin/opendistro/alerting/monitor/execute] and User [name=..."

