### PR TITLE
chore: bump trivy module

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
@@ -301,7 +301,7 @@ module "velero" {
 }
 
 module "trivy-operator" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-trivy-operator?ref=0.10.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-trivy-operator?ref=0.11.0"
 
   cluster_domain_name         = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   eks_cluster_oidc_issuer_url = data.terraform_remote_state.cluster.outputs.cluster_oidc_issuer_url


### PR DESCRIPTION
- bump trivy module to increase pod memory limit
https://github.com/ministryofjustice/cloud-platform-terraform-trivy-operator/releases/tag/0.11.0