### PR TITLE
bumping logging module to concurrently ship logs to s3 bucket

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
@@ -230,7 +230,7 @@ module "kuberos" {
 }
 
 module "logging" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-logging?ref=1.24.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-logging?ref=1.25.0"
 
   opensearch_app_host = lookup(var.opensearch_app_host_map, terraform.workspace, "placeholder-opensearch")
   elasticsearch_host  = lookup(var.elasticsearch_hosts_maps, terraform.workspace, "placeholder-elasticsearch")
@@ -238,6 +238,13 @@ module "logging" {
   depends_on = [
     module.label_pods_controller
   ]
+
+  # Required variables for tags in S3-Bucket submodule
+  business_unit = local.default_tags["business-unit"]
+  application   = local.default_tags["application"]
+  is_production = local.default_tags["is-production"]
+  team_name     = local.default_tags["owner"]
+
 }
 
 module "monitoring" {


### PR DESCRIPTION
This PR bumps the logging module. [Changelog here](https://github.com/ministryofjustice/cloud-platform-terraform-logging/compare/1.24.2...1.25.0)

Summary of changes:
- Create S3 bucket
- Create IRSA and attach to existing `fluent-bit` service account
- Add Output data pipeline from `fluent-bit` to ship application logs to the S3 bucket
- Output S3 bucket details to terraform state

Will monitor performance of logging during the course of the day.

Relates to https://github.com/ministryofjustice/cloud-platform/issues/7204