### PR TITLE
fix: 🐛 buffer limits for defaut ingress

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
@@ -230,7 +230,7 @@ module "kuberos" {
 }
 
 module "logging" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-logging?ref=1.26.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-logging?ref=1.26.1"
 
   opensearch_app_host = lookup(var.opensearch_app_host_map, terraform.workspace, "placeholder-opensearch")
   elasticsearch_host  = lookup(var.elasticsearch_hosts_maps, terraform.workspace, "placeholder-elasticsearch")


### PR DESCRIPTION
https://github.com/ministryofjustice/cloud-platform-terraform-logging/releases/tag/1.26.1