### PR TITLE
map fluent-bit irsa to OpenSearch role

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/account/app-opensearch.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/app-opensearch.tf
@@ -241,6 +241,8 @@ resource "elasticsearch_opensearch_roles_mapping" "all_access_app_logs" {
     "webops",
     "organisation-security-auditor",
     aws_iam_role.os_access_role_app_logs.arn,
+    data.terraform_remote_state.components_manager.outputs.fluent_bit_irsa_arn,
+    data.terraform_remote_state.components_live.outputs.fluent_bit_irsa_arn,
   ], values(data.aws_eks_node_group.current)[*].node_role_arn, values(data.aws_eks_node_group.manager)[*].node_role_arn)
 
   // Permissions to manager-concourse in order to run logging tests

--- a/terraform/aws-accounts/cloud-platform-aws/account/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/main.tf
@@ -69,6 +69,30 @@ data "terraform_remote_state" "eks_live" {
   }
 }
 
+# get access to components state in manager workspace
+# Necessary to fluent-bit irsa role
+data "terraform_remote_state" "components_manager" {
+  backend = "s3"
+  config = {
+    bucket  = "cloud-platform-terraform-state"
+    region  = "eu-west-1"
+    key     = "aws-accounts/cloud-platform-aws/vpc/eks/core/components/manager/terraform.tfstate"
+    profile = "moj-cp"
+  }
+}
+
+# get access to components state in live workspace
+# Necessary to fluent-bit irsa role
+data "terraform_remote_state" "components_live" {
+  backend = "s3"
+  config = {
+    bucket  = "cloud-platform-terraform-state"
+    region  = "eu-west-1"
+    key     = "aws-accounts/cloud-platform-aws/vpc/eks/core/components/live/terraform.tfstate"
+    profile = "moj-cp"
+  }
+}
+
 # used for cloudfront/waf
 provider "aws" {
   alias  = "northvirginia"


### PR DESCRIPTION
This PR maps IRSA for fluent-bit to the all_access role in OpenSearch. 

This will grant fluent-bit access to write to OpenSearch when we switch fluent-bit to IRSA authentication to address the [authentication method precedence](https://docs.fluentbit.io/manual/administration/aws-credentials). Full context [here](https://github.com/ministryofjustice/cloud-platform/issues/7204#issuecomment-3022835561)

Relates to https://github.com/ministryofjustice/cloud-platform/issues/7204