### PR TITLE
output s3 bucket name from logging module

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/outputs.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/outputs.tf
@@ -11,5 +11,5 @@ output "s3_bucket_application_logs_arn" {
 output "s3_bucket_application_logs_name" {
   description = "S3 bucket name for application logs"
   value       = module.logging.s3_bucket_application_logs_name
-  
+
 }


### PR DESCRIPTION
Outputting S3 bucket name. This will be used for the SQS queue at account level

Relates to https://github.com/ministryofjustice/cloud-platform/issues/7204