### PR TITLE
SQS for application logs bucket in preparation to start shipping to Cortex XSIAM

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/account/sqs.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/sqs.tf
@@ -186,7 +186,7 @@ resource "aws_s3_bucket_notification" "application_logs_bucket_notification" {
     queue_arn = aws_sqs_queue.cp_application_logs_queue.arn
     events    = ["s3:ObjectCreated:*"] # Events to trigger the notification
   }
-} 
+}
 
 ##### IAM User & Resources to access the sqs queue and read cloudtrail, flowlogs, Route53 Resolver query and application log buckets
 


### PR DESCRIPTION
This PR does the following:

1. Creates SQS queue for updates in the application logs bucket
2. Grants IAM role user permissions to the SQS queue
3. Grants IAM user to GetObject to application logs bucket

Relates to https://github.com/ministryofjustice/cloud-platform/issues/7204