### PR TITLE
Removing test firehose

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/account/firehose.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/firehose.tf
@@ -6,8 +6,3 @@ module "firehose_eks_live_logs_to_xsiam" {
   cloudwatch_log_group_names = [data.terraform_remote_state.eks_live.outputs.cloudwatch_log_group_name]
   destination_http_endpoint  = data.aws_ssm_parameter.account["cortex_xsiam_endpoint"].value
 }
-
-module "test_firehose_eks_app_logs_to_xsiam" {
-  source                    = "github.com/ministryofjustice/cloud-platform-terraform-firehose-data-stream?ref=no-loggroup"
-  destination_http_endpoint = data.aws_ssm_parameter.account["cortex_xsiam_endpoint_preprod"].value
-}

--- a/terraform/aws-accounts/cloud-platform-aws/account/ssm.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/ssm.tf
@@ -4,8 +4,7 @@
 
 locals {
   ssm_parameters = [
-    "cortex_xsiam_endpoint",
-    "cortex_xsiam_endpoint_preprod"
+    "cortex_xsiam_endpoint"
   ]
 }
 


### PR DESCRIPTION
This removes the firehose resources that was originally set up to ship app logs to Cortex. We have dropped this solution and opted for S3 instead.

Relates to https://github.com/ministryofjustice/cloud-platform/issues/7204