### PR TITLE
feat: create opensearch s3 snapshot repository

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/account/app-opensearch.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/app-opensearch.tf
@@ -471,3 +471,14 @@ module "live_app_logs_opensearch_monitoring" {
   tags                               = local.app_logs_tags
 }
 
+module "opensearch_snapshot_repository" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-opensearch-snapshot-repository?ref=0.0.8"
+
+  providers = {
+    opensearch = opensearch.app_logs
+  }
+
+  opensearch_primary_domain = local.live_app_logs_domain
+  opensearch_domain_names   = [local.live_app_logs_domain, "test-restore"] # List of domain names allowed to assume the role
+
+}


### PR DESCRIPTION
- create opensearch s3 snapshot repository with [new opensearch s3 snapshot repository module](https://github.com/ministryofjustice/cloud-platform-terraform-opensearch-snapshot-repository) 
- relates to https://github.com/ministryofjustice/cloud-platform/issues/7333