### PR TITLE
chore: update iam role

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/account/app-opensearch.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/app-opensearch.tf
@@ -62,8 +62,8 @@ resource "aws_iam_policy" "os_access_policy_app_logs" {
         ]
       },
       {
-        Action = ["iam:PassRole"],
-        Effect = "Allow",
+        Action   = ["iam:PassRole"],
+        Effect   = "Allow",
         Resource = aws_iam_role.opensearch_snapshot_role.arn
       }
     ]

--- a/terraform/aws-accounts/cloud-platform-aws/account/app-opensearch.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/app-opensearch.tf
@@ -52,15 +52,20 @@ resource "aws_iam_policy" "os_access_policy_app_logs" {
   name = "opensearch-access-policy-app-logs"
 
   policy = jsonencode({
-    Version = "2012-10-17"
+    Version = "2012-10-17",
     Statement = [
       {
-        Action = ["es:*"]
-        Effect = "Allow"
+        Action = ["es:*"],
+        Effect = "Allow",
         Resource = [
           "arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${local.live_app_logs_domain}/*",
         ]
       },
+      {
+        Action = ["iam:PassRole"],
+        Effect = "Allow",
+        Resource = aws_iam_role.opensearch_snapshot_role.arn
+      }
     ]
   })
 }


### PR DESCRIPTION
- pass the role to opensearch according to aws doc

> In order to register the snapshot repository, you need to be able to pass TheSnapshotRole to OpenSearch Service. You also need access to the es:ESHttpPut action. To grant both of these permissions, attach the following policy to the IAM role whose credentials are being used to sign the request

https://docs.aws.amazon.com/opensearch-service/latest/developerguide/managedomains-snapshots.html#managedomains-snapshot-registerdirectory