### PR TITLE
bump modsec controllers - creation of s3 buckets for modsec logs

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
@@ -157,7 +157,7 @@ module "non_prod_ingress_controllers_v1" {
 }
 
 module "non_prod_modsec_ingress_controllers_v1" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.14.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.15.0"
 
   count = terraform.workspace == "live" ? 1 : 0
 
@@ -182,11 +182,17 @@ module "non_prod_modsec_ingress_controllers_v1" {
 
   default_tags = local.default_tags
 
+  # Required variables for tags in S3-Bucket submodule
+  business_unit = local.default_tags["business-unit"]
+  application   = local.default_tags["application"]
+  is_production = local.default_tags["is-production"]
+  team_name     = local.default_tags["owner"]
+
   depends_on = [module.ingress_controllers_v1]
 }
 
 module "modsec_ingress_controllers_v1" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.14.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.15.0"
 
   replica_count            = terraform.workspace == "live" ? "12" : "3"
   controller_name          = "modsec"
@@ -207,6 +213,12 @@ module "modsec_ingress_controllers_v1" {
   fluent_bit_version           = "4.0.2-amd64"
 
   default_tags = local.default_tags
+
+  # Required variables for tags in S3-Bucket submodule
+  business_unit = local.default_tags["business-unit"]
+  application   = local.default_tags["application"]
+  is_production = local.default_tags["is-production"]
+  team_name     = local.default_tags["owner"]
 
   depends_on = [module.ingress_controllers_v1]
 }

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/outputs.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/outputs.tf
@@ -11,5 +11,34 @@ output "s3_bucket_application_logs_arn" {
 output "s3_bucket_application_logs_name" {
   description = "S3 bucket name for application logs"
   value       = module.logging.s3_bucket_application_logs_name
+}
 
+output "fluent_bit_non_prod_modsec_irsa_arn" {
+  description = "IAM Role ARN for Fluent Bit Non-Prod ModSecurity IRSA"
+  value       = length(module.non_prod_modsec_ingress_controllers_v1) > 0 ? module.non_prod_modsec_ingress_controllers_v1[0].fluent_bit_modsec_irsa_arn : null
+}
+
+output "s3_bucket_non_prod_modsec_logs_arn" {
+  description = "S3 bucket name for ModSecurity logs"
+  value       = length(module.non_prod_modsec_ingress_controllers_v1) > 0 ? module.non_prod_modsec_ingress_controllers_v1[0].s3_bucket_modsec_logs_arn : null
+}
+
+output "s3_bucket_non_prod_modsec_logs_name" {
+  description = "S3 bucket name for ModSecurity logs"
+  value       = length(module.non_prod_modsec_ingress_controllers_v1) > 0 ? module.non_prod_modsec_ingress_controllers_v1[0].s3_bucket_modsec_logs_name : null
+}
+
+output "fluent_bit_modsec_irsa_arn" {
+  description = "IAM Role ARN for Fluent Bit Non-Prod ModSecurity IRSA"
+  value       = module.modsec_ingress_controllers_v1.fluent_bit_modsec_irsa_arn
+}
+
+output "s3_bucket_modsec_logs_arn" {
+  description = "S3 bucket name for ModSecurity logs"
+  value       = module.modsec_ingress_controllers_v1.s3_bucket_modsec_logs_arn
+}
+
+output "s3_bucket_modsec_logs_name" {
+  description = "S3 bucket name for ModSecurity logs"
+  value       = module.modsec_ingress_controllers_v1.s3_bucket_modsec_logs_name
 }


### PR DESCRIPTION
This PR bumps the modsec ingress controller. [Changelog here](https://github.com/ministryofjustice/cloud-platform-terraform-ingress-controller/compare/1.14.7...1.15.0)

Summary of changes:
In preparation to ship modsec logs from fluentbit sidecar to a S3 bucket, this PR:
- Create S3 bucket
- Output S3 bucket details to terraform state
- Create IRSA
- Output IRSA details to terraform state

This will not effect the controllers themselves and there will be no restarts.
