### PR TITLE
map modsec fluent-bit irsa roles to modsec Opensearch role

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/account/modsec-opensearch.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/modsec-opensearch.tf
@@ -319,6 +319,8 @@ resource "elasticsearch_opensearch_roles_mapping" "all_access" {
   backend_roles = concat([
     "webops",
     aws_iam_role.os_access_role.arn,
+    data.terraform_remote_state.components_live.outputs.fluent_bit_modsec_irsa_arn,
+    data.terraform_remote_state.components_live.outputs.fluent_bit_non_prod_modsec_irsa_arn,
   ], values(data.aws_eks_node_group.current)[*].node_role_arn)
   // Permissions to manager-concourse in order to run modsec logging tests
   users = ["arn:aws:iam::754256621582:user/cloud-platform/manager-concourse", "arn:aws:iam::754256621582:role/aws-reserved/sso.amazonaws.com/eu-west-2/AWSReservedSSO_AdministratorAccess_ae2d551dbf676d8f"]


### PR DESCRIPTION
This PR maps IRSA for modsec fluent-bit to the all_access role in OpenSearch.

This will grant modsec ingress controllers (and thereby the modsec fluent-bit sidecars) access to write to OpenSearch when we switch fluent-bit to IRSA authentication to address the [authentication method precedence](https://docs.fluentbit.io/manual/administration/aws-credentials).

Relates to https://github.com/ministryofjustice/cloud-platform/issues/7324