### PR TITLE
Chore: accept tgw attachment for ecp

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/transit-gateway/transit-gateway.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/transit-gateway/transit-gateway.tf
@@ -100,7 +100,7 @@ resource "aws_ec2_transit_gateway_route_table" "this" {
 
 resource "aws_ec2_transit_gateway_route_table_association" "laa-ecp-prod-tgw" {
   transit_gateway_attachment_id  = aws_ec2_transit_gateway_peering_attachment_accepter.laa-ecp-prod-tgw.id
-  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table["external"].id
+  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.this["external"].id
 }
 
 resource "aws_ec2_transit_gateway_route_table_association" "this" {


### PR DESCRIPTION
This PR achieves the following:

Accepts the pending attachment from the LAA ECP Production TGW
Associate the LAA ECP Production TGW peering attachment with the External route table
Add routes to the Inspection route table as follows
To ECP via ECP TGW peering
To CP via relevant CP VPC attachments
The end result will be that traffic - if permitted by the Cloud Platform Network Firewall - will pass from a VPC to the internal TGW route table, then into the inspection VPC where it will pass through the firewall, back to the TGW where it will match against the inspection route table and then out the peering to the LAA ECP.