### PR TITLE
mapping new modsec irsa to app opensearch cluster

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/account/app-opensearch.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/app-opensearch.tf
@@ -249,6 +249,8 @@ resource "elasticsearch_opensearch_roles_mapping" "all_access_app_logs" {
     aws_iam_role.os_access_role_app_logs.arn,
     data.terraform_remote_state.components_manager.outputs.fluent_bit_irsa_arn,
     data.terraform_remote_state.components_live.outputs.fluent_bit_irsa_arn,
+    data.terraform_remote_state.components_live.outputs.fluent_bit_modsec_irsa_arn,
+    data.terraform_remote_state.components_live.outputs.fluent_bit_non_prod_modsec_irsa_arn,
   ], values(data.aws_eks_node_group.current)[*].node_role_arn, values(data.aws_eks_node_group.manager)[*].node_role_arn)
 
   // Permissions to manager-concourse in order to run logging tests


### PR DESCRIPTION
Mapping new modsec irsa roles to app-opensearch cluster role as modsec fluentbit also write logs to this cluster

Relates to https://github.com/ministryofjustice/cloud-platform/issues/7324