### PR TITLE
🎬 Take 2: bumping modsec modules to concurrently ship modsec logs to s3 bucket

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
@@ -157,7 +157,7 @@ module "non_prod_ingress_controllers_v1" {
 }
 
 module "non_prod_modsec_ingress_controllers_v1" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.15.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.15.2"
 
   count = terraform.workspace == "live" ? 1 : 0
 
@@ -192,7 +192,7 @@ module "non_prod_modsec_ingress_controllers_v1" {
 }
 
 module "modsec_ingress_controllers_v1" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.15.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.15.2"
 
   replica_count            = terraform.workspace == "live" ? "12" : "3"
   controller_name          = "modsec"


### PR DESCRIPTION
This PR bumps the logging module. [Changelog here](https://github.com/ministryofjustice/cloud-platform-terraform-ingress-controller/releases/tag/1.15.2)

Summary of changes:

- Attach IRSA annotation to existing modsec service accounts
- Add Output data pipeline to ship modsec logs to the S3 buckets
Relates to https://github.com/ministryofjustice/cloud-platform/issues/7324