### PR TITLE
chore: 🤖 bump trivy module

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
@@ -320,14 +320,14 @@ module "velero" {
 }
 
 module "trivy-operator" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-trivy-operator?ref=0.12.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-trivy-operator?ref=0.13.0"
 
   cluster_domain_name         = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   eks_cluster_oidc_issuer_url = data.terraform_remote_state.cluster.outputs.cluster_oidc_issuer_url
 
   # job concurrency limit and scanner report ttl need balancing to
   # ensure report completeness across the cluster
-  job_concurrency_limit = 2
+  job_concurrency_limit = 4
   scanner_report_ttl    = "48h"
 
   scan_job_timeout    = "10m"


### PR DESCRIPTION
- improve mem management for operator pod
- double scan concurrency

[release](https://github.com/ministryofjustice/cloud-platform-terraform-trivy-operator/releases/tag/0.13.0)