### PR TITLE
bumping modsec ingress-controllers to ship flb logs to os

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/components.tf
@@ -157,7 +157,7 @@ module "non_prod_ingress_controllers_v1" {
 }
 
 module "non_prod_modsec_ingress_controllers_v1" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.15.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.15.3"
 
   count = terraform.workspace == "live" ? 1 : 0
 
@@ -192,7 +192,7 @@ module "non_prod_modsec_ingress_controllers_v1" {
 }
 
 module "modsec_ingress_controllers_v1" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.15.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.15.3"
 
   replica_count            = terraform.workspace == "live" ? "12" : "3"
   controller_name          = "modsec"


### PR DESCRIPTION
This PR bumps the modsec ingress-controller modules. [Changelog here](https://github.com/ministryofjustice/cloud-platform-terraform-ingress-controller/releases/tag/1.15.3)

Summary of changes:

1. Remove S3 outputs
2. Ship fluent-bit system logs to OpenSearch
3. Switch fluent-bit log level to debug for verbose logging

Relates to https://github.com/ministryofjustice/cloud-platform/issues/7324