### PR TITLE
feat: script to take and restore snapshots

### DIFF
--- a/scripts/opensearch/snapshots/README.md
+++ b/scripts/opensearch/snapshots/README.md
@@ -1,0 +1,42 @@
+# OpenSearch Snapshot & Restore Script
+
+These two scripts work together to migrate and preserve log data from a live OpenSearch cluster to a separate cluster using snapshots stored in S3.
+
+## Why This Is Needed
+Managing OpenSearch log indices across environments requires careful handling to avoid impacting live workloads. This process is designed with the following considerations in mind:
+
+Restoring large volume of log on the live OpenSearch cluster adds significant load, which may:
+- Increases warm tier instance resource usage.
+- Degrade performance for other users accessing the cluster.
+- Risks cluster instability during peak usage or large restores.
+
+### Safer Approach
+To make the process safe and isolated, all restoration work is performed on a separate OpenSearch cluster, away from production.
+
+This allows us to snapshot and restore large volumes of log data without affecting live service operations.
+
+
+## Script 1: `take_snpashot_cold_incides.sh`
+This script:
+1.	Reads a list of indices from source-index-list.txt (stored in S3).
+2.	Migrates each index from cold to warm tier.
+3.	Takes a snapshot of each index to the S3 snapshot repo.
+4.	Tracks completed snapshots by prefixing the index with `snapshot-taken-`.
+5.	Migrates the index back to cold tier after snapshot.
+
+
+## Script 2: `restore_snpashot.sh`
+This script:
+1.	Downloads the same source-index-list.txt file.
+2.	Filters lines with `snapshot-taken-`.
+3.	Skips indices already restored (snapshot-restored.txt in S3).
+4.	Restores each index from the S3 snapshot repository.
+5.  Set the replica count to `0` to save cost and improve the time.
+5.	Waits for full shard recovery and green index health.
+6.	Migrates restored index to the warm tier.
+
+## Usage
+Taking an OpenSearch snapshot can take more than 30+ minutes per index, depending on shard size and data volume. Therefore, it is recommended to follow this process:
+1.	Run the take-snapshot.sh script to initiate snapshot creation.
+2.	Wait some batch to be completed.
+3.	Once snapshots are expected to be complete, run the restore-snapshot.sh script to begin restoring the indices.

--- a/scripts/opensearch/snapshots/restore_snapshots/restore_snapshot.sh
+++ b/scripts/opensearch/snapshots/restore_snapshots/restore_snapshot.sh
@@ -1,0 +1,179 @@
+#!/bin/bash
+
+set -eu
+
+IS_PIPELINE=$1
+
+if [[ "$IS_PIPELINE" = true ]]; then
+  export USE_SESSION_TOKEN=false
+else
+  export USE_SESSION_TOKEN=true
+fi
+
+RESTORE_OS_ENDPOINT="https://search-test-restore-5utyz7htozji7omw54emmciqum.eu-west-2.es.amazonaws.com"
+SNAPSHOT_REPO="cp-live-app-logs-snapshot-s3-repository"
+S3_SOURCE_INDEX_FILE="s3://cloud-platform-concourse-environments-live-reports/opensearch-snapshots/source-index-list.txt"
+S3_RESTORED_INDEX_FILE="s3://cloud-platform-concourse-environments-live-reports/opensearch-snapshots/snapshot-restored.txt"
+
+MAX_BATCH=10
+TMP_FILE="$(mktemp)"
+RESTORED_INDICES_FILE="$(mktemp)"
+EXISTING_RESTORED_FILE="$(mktemp)"
+
+echo "Downloading index list from $S3_SOURCE_INDEX_FILE"
+aws s3 cp "$S3_SOURCE_INDEX_FILE" "$TMP_FILE"
+TOTAL_INDICES_TO_RESTORE=$(wc -l < "$TMP_FILE")
+aws s3 cp "$S3_RESTORED_INDEX_FILE" "$EXISTING_RESTORED_FILE"
+
+count=0
+
+wait_for_restore() {
+  local index_name="$1"
+  echo "Waiting for restore to complete for index: $index_name"
+
+  while true; do
+    local all_done=false
+    local recovery_output
+    recovery_output=$(curl -s -XGET -L \
+      --user "$AWS_ACCESS_KEY_ID:$AWS_SECRET_ACCESS_KEY" \
+      ${USE_SESSION_TOKEN:+ -H "x-amz-security-token: $AWS_SESSION_TOKEN"} \
+      --aws-sigv4 "aws:amz:eu-west-2:es" \
+      "$RESTORE_OS_ENDPOINT/${index_name}/_recovery")
+
+    local shard_count
+    shard_count=$(echo "$recovery_output" | jq ".\"${index_name}\".shards | length")
+    echo "Checking $shard_count shards for index: $index_name"
+
+    local snapshot_shard_indexes=()
+    local ready_snapshot_shards=0
+
+    for ((i = 0; i < shard_count; i++)); do
+      local type stage percent
+
+      type=$(echo "$recovery_output" | jq -r ".\"${index_name}\".shards[$i].type")
+      stage=$(echo "$recovery_output" | jq -r ".\"${index_name}\".shards[$i].stage")
+      percent=$(echo "$recovery_output" | jq -r ".\"${index_name}\".shards[$i].index.size.percent")
+
+      echo "Shard $i — type=$type, stage=$stage, percent=$percent"
+
+      if [[ "$type" == "SNAPSHOT" ]]; then
+        snapshot_shard_indexes+=("$i")
+        if [[ "$stage" == "DONE" && "$percent" == "100.0%" ]]; then
+          ((ready_snapshot_shards++))
+        fi
+      fi
+    done
+
+    local total_snapshot_shards=${#snapshot_shard_indexes[@]}
+    if [[ "$ready_snapshot_shards" -eq "$total_snapshot_shards" ]]; then
+      all_done=true
+    fi
+
+    if [[ "$all_done" == true ]]; then
+      echo "Restore completed for index: $index_name"
+      return 0
+    else
+      echo "Waiting for restore to complete..."
+      sleep 60
+    fi
+  done
+}
+
+while IFS= read -r line; do
+  [[ -z "$line" || "$line" =~ ^# ]] && continue
+
+  if [[ "$line" == snapshot-taken-* ]]; then
+    raw_index_name="${line#snapshot-taken-}"
+    echo "Processing index: $raw_index_name"
+
+    STATUS_CODE=$(curl -s -o /dev/null -w "%{http_code}" -I -L \
+      --user "$AWS_ACCESS_KEY_ID:$AWS_SECRET_ACCESS_KEY" \
+      ${USE_SESSION_TOKEN:+ -H "x-amz-security-token: $AWS_SESSION_TOKEN"} \
+      --aws-sigv4 "aws:amz:eu-west-2:es" \
+      "$RESTORE_OS_ENDPOINT/${raw_index_name}")
+
+    if [[ "$STATUS_CODE" == "200" ]]; then
+      echo "Index $raw_index_name already exists in this OpenSearch cluster. Skipping."
+      continue
+    fi
+
+    echo "Index $raw_index_name does not exist in this OpenSearch cluster. Restoring..."
+
+    # Restore snapshot
+    curl -s -XPOST -L \
+      --user "$AWS_ACCESS_KEY_ID:$AWS_SECRET_ACCESS_KEY" \
+      ${USE_SESSION_TOKEN:+ -H "x-amz-security-token: $AWS_SESSION_TOKEN"} \
+      -H "Content-Type: application/json" \
+      --aws-sigv4 "aws:amz:eu-west-2:es" \
+      "$RESTORE_OS_ENDPOINT/_snapshot/$SNAPSHOT_REPO/$raw_index_name/_restore" \
+      -d "{
+        \"indices\": \"$raw_index_name\",
+        \"include_global_state\": false,
+        \"partial\": false,
+        \"ignore_unavailable\": false,
+        \"include_aliases\": false
+      }"
+
+    echo
+    echo "Setting replicas to 0 for $raw_index_name..."
+    curl -s -XPUT -L \
+      --user "$AWS_ACCESS_KEY_ID:$AWS_SECRET_ACCESS_KEY" \
+      ${USE_SESSION_TOKEN:+ -H "x-amz-security-token: $AWS_SESSION_TOKEN"} \
+      -H "Content-Type: application/json" \
+      --aws-sigv4 "aws:amz:eu-west-2:es" \
+      "$RESTORE_OS_ENDPOINT/$raw_index_name/_settings" \
+      -d '{
+        "index": {
+          "number_of_replicas": 0
+        }
+      }'
+
+    wait_for_restore "$raw_index_name"
+
+    echo "Checking if index $raw_index_name is green..."
+
+    while true; do
+    index_health=$(curl -s -XGET -L \
+        --user "$AWS_ACCESS_KEY_ID:$AWS_SECRET_ACCESS_KEY" \
+        ${USE_SESSION_TOKEN:+ -H "x-amz-security-token: $AWS_SESSION_TOKEN"}  \
+        --aws-sigv4 "aws:amz:eu-west-2:es" \
+        "$RESTORE_OS_ENDPOINT/_cat/indices/$raw_index_name?h=health")
+
+    if [[ "$index_health" == "green" ]]; then
+        echo "Index $raw_index_name is green. Proceeding to migrate to warm tier."
+        break
+    else
+        echo "Index $raw_index_name health is $index_health. Sleeping 60s and retrying..."
+        sleep 10
+    fi
+    done
+
+    echo "Migrating $raw_index_name to warm tier..."
+    curl -s -XPOST -L \
+      --user "$AWS_ACCESS_KEY_ID:$AWS_SECRET_ACCESS_KEY" \
+      ${USE_SESSION_TOKEN:+ -H "x-amz-security-token: $AWS_SESSION_TOKEN"} \
+      --aws-sigv4 "aws:amz:eu-west-2:es" \
+      "$RESTORE_OS_ENDPOINT/_ultrawarm/migration/$raw_index_name/_warm"
+
+    echo
+    echo "$raw_index_name" >> "$RESTORED_INDICES_FILE"
+
+    ((count++))
+    if [[ "$count" -ge "$MAX_BATCH" ]]; then
+      echo "Reached max batch size of $MAX_BATCH. Stopping."
+      break
+    fi
+  else
+    echo "Skipping non-taken snapshot line: $line"
+  fi
+done < "$TMP_FILE"
+
+# Append newly restored indices to existing list and upload to S3
+cat "$RESTORED_INDICES_FILE" >> "$EXISTING_RESTORED_FILE"
+aws s3 cp "$EXISTING_RESTORED_FILE" "$S3_RESTORED_INDEX_FILE"
+
+echo "Batch complete. $count index snapshots restored."
+
+TOTAL_RESTORED_INDICES=$(wc -l < "$EXISTING_RESTORED_FILE")
+
+echo "Total restored snapshot: $TOTAL_RESTORED_INDICES / $TOTAL_INDICES_TO_RESTORE"

--- a/scripts/opensearch/snapshots/take_snapshots/take_snapshot_cold_indices.sh
+++ b/scripts/opensearch/snapshots/take_snapshots/take_snapshot_cold_indices.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+
+set -eu
+
+IS_PIPELINE=$1
+
+if [[ "$IS_PIPELINE" = true ]]; then
+  export USE_SESSION_TOKEN=false
+else
+  export USE_SESSION_TOKEN=true
+fi
+
+LIVE_OS_ENDPOINT="https://app-logs.cloud-platform.service.justice.gov.uk"
+SNAPSHOT_REPO="cp-live-app-logs-snapshot-s3-repository"
+S3_SOURCE_INDEX_FILE="s3://cloud-platform-concourse-environments-live-reports/opensearch-snapshots/source-index-list.txt"
+
+LOCAL_INDEX_FILE="index_list.txt"
+TMP_FILE="$(mktemp)"
+MAX_BATCH=10
+COUNT=0
+
+echo "Downloading index list from $S3_SOURCE_INDEX_FILE"
+aws s3 cp "$S3_SOURCE_INDEX_FILE" "$LOCAL_INDEX_FILE"
+
+# Function to check snapshot status
+wait_for_snapshot() {
+  local snapshot_name="$1"
+
+  while true; do
+    STATUS=$(curl -s -XGET -L \
+      --user "$AWS_ACCESS_KEY_ID:$AWS_SECRET_ACCESS_KEY" \
+      ${USE_SESSION_TOKEN:+ -H "x-amz-security-token: $AWS_SESSION_TOKEN"} \
+      --aws-sigv4 "aws:amz:eu-west-2:es" \
+      "${LIVE_OS_ENDPOINT}/_snapshot/${SNAPSHOT_REPO}/${snapshot_name}/_status" \
+      | jq -r '.snapshots[0].state')
+
+    if [[ "$STATUS" == "SUCCESS" ]]; then
+      echo "Snapshot '${snapshot_name}' completed successfully."
+      return 0
+    elif [[ "$STATUS" == "FAILED" || "$STATUS" == "PARTIAL" ]]; then
+      echo "Snapshot '${snapshot_name}' failed with status: $STATUS"
+      return 1
+    else
+      echo "Snapshot '${snapshot_name}' is in progress... (status: $STATUS)"
+      sleep 60
+    fi
+  done
+}
+
+echo "Reading index list from $LOCAL_INDEX_FILE"
+
+while IFS= read -r index || [[ -n "$index" ]]; do
+  index="${index//$'\r'/}"  # Strip Windows line endings
+
+  if [[ -z "$index" || "$index" =~ ^# || "$index" =~ ^snapshot-taken- ]]; then
+    echo "$index" >> "$TMP_FILE"
+    continue
+  fi
+
+  if (( COUNT >= MAX_BATCH )); then
+    echo "$index" >> "$TMP_FILE"
+    continue
+  fi
+
+  echo "Migrating cold index $index to warm..."
+
+  curl -s -XPOST -L \
+    --user "$AWS_ACCESS_KEY_ID:$AWS_SECRET_ACCESS_KEY" \
+    ${USE_SESSION_TOKEN:+ -H "x-amz-security-token: $AWS_SESSION_TOKEN"} \
+    -H "Content-Type: application/json" \
+    --aws-sigv4 "aws:amz:eu-west-2:es" \
+    "${LIVE_OS_ENDPOINT}/_cold/migration/_warm" \
+    -d "{
+      \"indices\": \"${index}\"
+    }"
+
+  sleep 10
+  echo
+  echo "Taking snapshot of index: $index..."
+
+  curl -s -XPUT -L \
+    --user "$AWS_ACCESS_KEY_ID:$AWS_SECRET_ACCESS_KEY" \
+    ${USE_SESSION_TOKEN:+ -H "x-amz-security-token: $AWS_SESSION_TOKEN"} \
+    -H "Content-Type: application/json" \
+    --aws-sigv4 "aws:amz:eu-west-2:es" \
+    "${LIVE_OS_ENDPOINT}/_snapshot/${SNAPSHOT_REPO}/${index}" \
+    -d "{
+      \"indices\": \"${index}\",
+      \"include_global_state\": false,
+      \"partial\": false
+    }"
+
+  echo
+  if wait_for_snapshot "$index"; then
+    echo "snapshot-taken-$index" >> "$TMP_FILE"
+  else
+    echo "$index" >> "$TMP_FILE"
+  fi
+
+  COUNT=$((COUNT + 1))
+
+  echo "Migrating warm index $index to cold..."
+
+  curl -s -XPOST -L \
+    --user "$AWS_ACCESS_KEY_ID:$AWS_SECRET_ACCESS_KEY" \
+    ${USE_SESSION_TOKEN:+ -H "x-amz-security-token: $AWS_SESSION_TOKEN"} \
+    -H "Content-Type: application/json" \
+    --aws-sigv4 "aws:amz:eu-west-2:es" \
+    "${LIVE_OS_ENDPOINT}/_ultrawarm/migration/${index}/_cold" \
+    -d '{
+      "timestamp_field": "@timestamp"
+    }'
+
+  sleep 10
+  echo
+  echo "Job completed for index $index"
+done < "$LOCAL_INDEX_FILE"
+
+echo "Uploading updated index list to $S3_SOURCE_INDEX_FILE"
+mv "$TMP_FILE" "$LOCAL_INDEX_FILE"
+aws s3 cp "$LOCAL_INDEX_FILE" "$S3_SOURCE_INDEX_FILE"
+
+echo "Batch complete. $COUNT index snapshots taken."
+
+TOTAL_INDEXES=$(wc -l < "$LOCAL_INDEX_FILE")
+TOTAL_SNAPSHOT_TAKEN=$(grep -c '^snapshot-taken-' "$LOCAL_INDEX_FILE")
+
+echo "Snapshot progress: $TOTAL_SNAPSHOT_TAKEN / $TOTAL_INDEXES indices completed."


### PR DESCRIPTION
Script 1: `take_snpashot_cold_incides.sh`
- Reads a list of indices from source-index-list.txt (stored in S3).
- Migrates each index from cold to warm tier.
- Takes a snapshot of each index to the S3 snapshot repo.
- Tracks completed snapshots by prefixing the index with snapshot-taken-.
- Migrates the index back to cold tier after snapshot.


Script 2: `restore_snpashot.sh`
- Downloads the same source-index-list.txt file.
- Filters lines with snapshot-taken-.
- Skips indices already restored (snapshot-restored.txt in S3).
- Restores each index from the S3 snapshot repository.
- Set the replica count to 0 to save cost and improve the time.
- Waits for full shard recovery and green index health.
- Migrates restored index to the warm tier.

relates to https://github.com/ministryofjustice/cloud-platform/issues/7335
