### PR TITLE
chore: 🤖 bump monitoring for metrics server upgrade

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/monitoring.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/monitoring.tf
@@ -1,5 +1,5 @@
 module "monitoring" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=3.26.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=3.27.0"
 
   alertmanager_slack_receivers  = local.enable_alerts ? var.alertmanager_slack_receivers : [{ severity = "dummy", webhook = "https://dummy.slack.com", channel = "#dummy-alarms" }]
   pagerduty_config              = local.enable_alerts ? data.aws_ssm_parameter.components["pagerduty_config"].value : "dummy"


### PR DESCRIPTION
[release](https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/releases/tag/3.27.0)