### PR TITLE
bump modsec to debug concurrent log shipping to both S3 and OS

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/ingress.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/ingress.tf
@@ -51,7 +51,7 @@ module "non_prod_ingress_controllers_v1" {
 }
 
 module "modsec_ingress_controllers_v1" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.15.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.15.4"
 
   replica_count            = terraform.workspace == "live" ? "12" : "3"
   controller_name          = "modsec"
@@ -83,7 +83,7 @@ module "modsec_ingress_controllers_v1" {
 }
 
 module "non_prod_modsec_ingress_controllers_v1" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.15.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.15.4"
 
   count = terraform.workspace == "live" ? 1 : 0
 


### PR DESCRIPTION
The purpose is to capture fluent-bit system logs of modsec logs going to OpenSearch tapering off and eventually failing. Will then revert when I've captured enough logs.

Relates to https://github.com/ministryofjustice/cloud-platform/issues/7324