### PR TITLE
reverting modsec modules

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/ingress.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/ingress.tf
@@ -51,7 +51,7 @@ module "non_prod_ingress_controllers_v1" {
 }
 
 module "modsec_ingress_controllers_v1" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.15.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.15.3"
 
   replica_count            = terraform.workspace == "live" ? "12" : "3"
   controller_name          = "modsec"
@@ -83,7 +83,7 @@ module "modsec_ingress_controllers_v1" {
 }
 
 module "non_prod_modsec_ingress_controllers_v1" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.15.5"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.15.3"
 
   count = terraform.workspace == "live" ? 1 : 0
 


### PR DESCRIPTION
Revert modules to stop shipping logs to S3

Relates to https://github.com/ministryofjustice/cloud-platform/issues/7324