### PR TITLE
Create centralised egress VPC

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/egress/firewall.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/egress/firewall.tf
@@ -1,0 +1,108 @@
+locals {
+  raw_rules        = fileexists("./firewall_rules.json") ? jsondecode(file("./firewall_rules.json")) : {}
+  sorted_rule_keys = sort(keys(local.raw_rules))
+  stateful_rules = [for idx, key in local.sorted_rule_keys : {
+    action = local.raw_rules[key].action
+    header = {
+      destination      = local.raw_rules[key].destination_ip
+      destination_port = local.raw_rules[key].destination_port
+      direction        = "ANY"
+      protocol         = local.raw_rules[key].protocol
+      source           = local.raw_rules[key].source_ip
+      source_port      = "ANY"
+    }
+    rule_option = [
+      {
+        keyword  = "sid"
+        settings = [tostring(idx + 1)]
+      }
+    ]
+  }]
+  subnets = { for idx, subnet in module.vpc.private_subnets : "subnet${idx + 1}" =>
+    {
+      subnet_id       = subnet
+      ip_address_type = "IPV4"
+    }
+  }
+  vpc = module.vpc.vpc_id
+}
+
+module "cloud-platform-firewall" {
+  source              = "terraform-aws-modules/network-firewall/aws//modules/firewall"
+  version             = "1.0.2"
+  description         = "Network firewall positioned to secure flows between Cloud Platform and the Internet."
+  firewall_policy_arn = module.cloud-platform-firewall-policy.arn
+  name                = "cloud-platform-egress-firewall"
+  subnet_mapping      = local.subnets
+  vpc_id              = local.vpc
+
+  # Logging configuration
+  create_logging_configuration = true
+  logging_configuration_destination_config = [
+    {
+      log_destination = {
+        logGroup = aws_cloudwatch_log_group.logs.name
+      }
+      log_destination_type = "CloudWatchLogs"
+      log_type             = "ALERT"
+    }
+  ]
+}
+
+module "cloud-platform-firewall-policy" {
+  source      = "terraform-aws-modules/network-firewall/aws//modules/policy"
+  version     = "1.0.2"
+  description = "Firewall policy intended for cloud-platform-egress-firewall"
+  name        = "cloud-platform-egress-firewall-policy"
+
+  stateless_default_actions          = ["aws:forward_to_sfe"]
+  stateless_fragment_default_actions = ["aws:drop"]
+
+  stateful_engine_options = {
+    rule_order = "STRICT_ORDER"
+  }
+
+  stateful_rule_group_reference = [
+    { priority = 1
+    resource_arn = "arn:aws:network-firewall:eu-west-2:aws-managed:stateful-rulegroup/AttackInfrastructureStrictOrder"},
+    { priority = 2
+    resource_arn = "arn:aws:network-firewall:eu-west-2:aws-managed:stateful-rulegroup/MalwareDomainsStrictOrder"},
+    { priority = 3
+    resource_arn = "arn:aws:network-firewall:eu-west-2:aws-managed:stateful-rulegroup/BotNetCommandAndControlDomainsStrictOrder"},
+    { priority = 10
+    resource_arn = module.cloud-platform-firewall-rule-group.arn }
+  ]
+}
+
+module "cloud-platform-firewall-rule-group" {
+  source      = "terraform-aws-modules/network-firewall/aws//modules/rule-group"
+  version     = "1.0.2"
+  capacity    = 5000
+  description = "Stateful rule group configured to control traffic between Cloud Platform and the Internet."
+  name        = "cloud-platform-firewall-stateful-rules"
+  type        = "STATEFUL"
+
+  rule_group = {
+    stateful_rule_options = {
+      rule_order = "STRICT_ORDER"
+    }
+    rules_source = {
+      stateful_rule = local.stateful_rules
+    }
+    rule_variables = {
+      ip_sets = [
+        { key    = "HOME_NET"
+          ip_set = { definition = ["172.20.0.0/16", "10.195.0.0/16"] }
+        },
+        { key    = "EXTERNAL_NET"
+          ip_set = { definition = ["0.0.0.0/0"] }
+        }
+      ]
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_group" "logs" {
+  name_prefix       = "cloud-platform-firewall-logs"
+  retention_in_days = 7
+}

--- a/terraform/aws-accounts/cloud-platform-aws/egress/firewall_rules.json
+++ b/terraform/aws-accounts/cloud-platform-aws/egress/firewall_rules.json
@@ -1,0 +1,9 @@
+{
+  "001_pass_cp_to_any": {
+    "action": "PASS",
+    "source_ip": "$HOME_NET",
+    "destination_ip": "$EXTERNAL_NET",
+    "destination_port": "ANY",
+    "protocol": "IP"
+  }
+}

--- a/terraform/aws-accounts/cloud-platform-aws/egress/providers.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/egress/providers.tf
@@ -1,0 +1,13 @@
+provider "aws" {
+  region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      business-unit = "Platforms"
+      application   = "cloud-platform-aws/inspection"
+      is-production = "true"
+      owner         = "Cloud Platform: platforms@digital.justice.gov.uk"
+      source-code   = "github.com/ministryofjustice/cloud-platform-infrastructure"
+    }
+  }
+}

--- a/terraform/aws-accounts/cloud-platform-aws/egress/versions.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/egress/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.83.0"
+    }
+  }
+  required_version = ">= 1.2.5"
+}

--- a/terraform/aws-accounts/cloud-platform-aws/egress/vpc.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/egress/vpc.tf
@@ -1,0 +1,141 @@
+data "aws_availability_zones" "available" {
+  state = "available"
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+/* Because the route table details aren't fully exposed this allows us to map route tables to subnets and from there
+we can get the correct availability zone */
+data "aws_route_table" "intra" {
+  for_each = { for i in range(local.num_azs) : i => i }
+  filter {
+    name   = "tag:Name"
+    values = ["${module.vpc.name}-${local.intra_subnet_suffix}-${local.azs[each.key]}"]
+  }
+  vpc_id = module.vpc.vpc_id
+}
+data "aws_route_table" "public" {
+  for_each = { for i in range(local.num_azs) : i => i }
+  filter {
+    name   = "tag:Name"
+    values = ["${module.vpc.name}-${local.public_subnet_suffix}-${local.azs[each.key]}"]
+  }
+  vpc_id = module.vpc.vpc_id
+}
+
+data "aws_ec2_transit_gateway" "cloud-platform-transit-gateway" {
+  filter {
+    name   = "tag:Name"
+    values = ["cloud-platform-transit-gateway"]
+  }
+}
+
+locals {
+  vpc_cidr = "10.0.0.0/16"
+  azs      = slice(data.aws_availability_zones.available.names, 0, local.num_azs)
+  num_azs  = 3
+
+  subnet_cidrs    = cidrsubnets("10.0.0.0/16", 12, 12, 12, 12, 12, 12, 12, 12, 12)
+  public_subnets  = slice(local.subnet_cidrs, 6, 9)
+  private_subnets = slice(local.subnet_cidrs, 0, 3)
+  intra_subnets   = slice(local.subnet_cidrs, 3, 6)
+
+  intra_subnet_suffix   = "transit"
+  private_subnet_suffix = "firewall"
+  public_subnet_suffix  = "public"
+
+  private_route_table_ids = toset(module.vpc.private_route_table_ids)
+  public_route_table_ids = toset(module.vpc.public_route_table_ids)
+
+  /* Create a map of Availability Zones with corresponding VPC Endpoint IDs */
+  az_to_endpoint_id = {
+    for sync in module.cloud-platform-firewall.status[0].sync_states :
+    sync.availability_zone => sync.attachment[0].endpoint_id
+  }
+
+  az_to_intra_route_table_id = {
+    for idx, az in local.azs :
+    az => data.aws_route_table.intra[tostring(idx)].id
+  }
+
+  az_to_public_route_table_id = {
+    for idx, az in local.azs :
+    az => data.aws_route_table.public[tostring(idx)].id
+  }
+
+  az_to_intra_route_table_and_endpoint = {
+    for az in local.azs : az => {
+      route_table_id  = local.az_to_intra_route_table_id[az]
+      vpc_endpoint_id = local.az_to_endpoint_id[az]
+    }
+  }
+
+  az_to_public_route_table_and_endpoint = {
+    for az in local.azs : az => {
+      route_table_id  = local.az_to_public_route_table_id[az]
+      vpc_endpoint_id = local.az_to_endpoint_id[az]
+    }
+  }
+}
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "5.21.0"
+
+  name = "egress-vpc"
+
+  azs  = local.azs
+  cidr = local.vpc_cidr
+
+  create_flow_log_cloudwatch_log_group = true
+  create_flow_log_cloudwatch_iam_role  = true
+  create_igw                           = true
+  create_multiple_intra_route_tables   = true
+  create_multiple_public_route_tables  = true
+
+  enable_flow_log        = true
+  enable_nat_gateway     = true
+  one_nat_gateway_per_az = true
+
+  intra_subnets       = local.intra_subnets
+  intra_subnet_names  = [for key in local.azs : "transit-${key}"]
+  intra_subnet_suffix = local.intra_subnet_suffix
+
+  private_subnets       = local.private_subnets
+  private_subnet_names  = [for key in local.azs : "firewall-${key}"]
+  private_subnet_suffix = local.private_subnet_suffix
+
+  public_subnets       = local.public_subnets
+  public_subnet_names  = [for key in local.azs : "public-${key}"]
+  public_subnet_suffix = local.public_subnet_suffix
+}
+
+resource "aws_route" "transit-to-firewall" {
+  for_each               = local.az_to_intra_route_table_and_endpoint
+  destination_cidr_block = "0.0.0.0/0"
+  route_table_id         = each.value["route_table_id"]
+  vpc_endpoint_id        = each.value["vpc_endpoint_id"]
+}
+
+resource "aws_route" "firewall-to-transit" {
+  for_each               = local.private_route_table_ids
+  destination_cidr_block = "0.0.0.0/0"
+  route_table_id         = each.key
+  transit_gateway_id     = data.aws_ec2_transit_gateway.cloud-platform-transit-gateway.id
+}
+
+resource "aws_route" "public-to-firewall-172-20-0-0-16" {
+  for_each               = local.az_to_public_route_table_and_endpoint
+  destination_cidr_block = "172.20.0.0/16"
+  route_table_id         = each.value["route_table_id"]
+  vpc_endpoint_id        = each.value["vpc_endpoint_id"]
+}
+
+resource "aws_route" "public-to-firewall-10-195-0-0-16" {
+  for_each               = local.az_to_public_route_table_and_endpoint
+  destination_cidr_block = "10.195.0.0/16"
+  route_table_id         = each.value["route_table_id"]
+  vpc_endpoint_id        = each.value["vpc_endpoint_id"]
+}


### PR DESCRIPTION
This PR achieves the following:

* Creates a new VPC - `egress-vpc`
  * This is a simple three-tier VPC with transit, firewall, and public subnets
  * Transit subnets will have TGW endpoints, and routes to the AZ-local firewall endpoint
  * Firewall subnets will have firewall endpoints, and routes relevant to the TGW or AZ-local NAT Gateway
  * Public subnets will have NAT gateways, and routes relevant to the AZ-local firewall endpoint
* Creates a new AWS Network Firewall - `cloud-platform-egress-firewall`
  * This firewall serves as an inline-inspection appliance, checking outbound traffic against AWS Managed Rule Groups in _strict_ order, then allowing all outbound traffic.

A follow-on PR will ensure the VPC is attached to the CP Transit Gateway with appropriate routes.