### PR TITLE
fix: wait sometime to prevent jq error

### DIFF
--- a/scripts/opensearch/snapshots/restore_snapshots/restore_snapshot.sh
+++ b/scripts/opensearch/snapshots/restore_snapshots/restore_snapshot.sh
@@ -122,6 +122,7 @@ while IFS= read -r line; do
         }
       }'
 
+    sleep 100
     wait_for_restore "$raw_index_name"
 
     echo "Checking if index $raw_index_name is green..."


### PR DESCRIPTION
- add the waiting time to snapshot restore script
- prevent jq errors when the snapshot shard are not ready