### PR TITLE
debug: bump modsec with increased max chunks for fluentbit

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/ingress.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/ingress.tf
@@ -51,7 +51,7 @@ module "non_prod_ingress_controllers_v1" {
 }
 
 module "modsec_ingress_controllers_v1" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.15.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.15.7"
 
   replica_count            = terraform.workspace == "live" ? "12" : "3"
   controller_name          = "modsec"
@@ -83,7 +83,7 @@ module "modsec_ingress_controllers_v1" {
 }
 
 module "non_prod_modsec_ingress_controllers_v1" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.15.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.15.7"
 
   count = terraform.workspace == "live" ? 1 : 0
 


### PR DESCRIPTION
[Changelog here](https://github.com/ministryofjustice/cloud-platform-terraform-ingress-controller/releases/tag/1.15.7)

Summary of change:

Increasing `Storage.max_chunks_up` from 128 to 256 as we're seeing the following when outputting to S3:
```
nginx-ingress-modsec-controller-58797fd96b-9xvjp flb-modsec-logs [2025/07/30 19:22:28] [ info] [input] modsec_nginx_ingress_audit resume (storage buf overlimit 127/128)
```

Increasing as per [fluent-bit doc](https://docs.fluentbit.io/manual/administration/buffering-and-storage#filesystem-buffering)

Relates to https://github.com/ministryofjustice/cloud-platform/issues/7324