### PR TITLE
Tighten address range for ecp

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/inspection/firewall_rules.json
+++ b/terraform/aws-accounts/cloud-platform-aws/inspection/firewall_rules.json
@@ -1,14 +1,14 @@
 {
-  "001_drop_cp_to_ecp": {
-    "action": "DROP",
+  "001_allow_cp_to_ecp_2484": {
+    "action": "PASS",
     "source_ip": "$HOME_NET",
-    "destination_ip": "10.205.0.0/16",
-    "destination_port": "ANY",
-    "protocol": "IP"
+    "destination_ip": "10.205.0.0/20",
+    "destination_port": "2484",
+    "protocol": "TCP"
   },
   "002_drop_ecp_to_cp": {
     "action": "DROP",
-    "source_ip": "10.205.0.0/16",
+    "source_ip": "10.205.0.0/20",
     "destination_ip": "$HOME_NET",
     "destination_port": "ANY",
     "protocol": "IP"

--- a/terraform/aws-accounts/cloud-platform-aws/inspection/firewall_rules.json
+++ b/terraform/aws-accounts/cloud-platform-aws/inspection/firewall_rules.json
@@ -6,21 +6,28 @@
     "destination_port": "2484",
     "protocol": "TCP"
   },
-  "002_drop_ecp_to_cp": {
+  "002_deny_cp_to_ecp": {
+    "action": "DROP",
+    "source_ip": "$HOME_NET",
+    "destination_ip": "10.205.0.0/20",
+    "destination_port": "ANY",
+    "protocol": "IP"
+  },
+  "003_drop_ecp_to_cp": {
     "action": "DROP",
     "source_ip": "10.205.0.0/20",
     "destination_ip": "$HOME_NET",
     "destination_port": "ANY",
     "protocol": "IP"
   },
-  "003_allow_cp_to_others": {
+  "004_allow_cp_to_others": {
     "action": "PASS",
     "source_ip": "$HOME_NET",
     "destination_ip": "$EXTERNAL_NET",
     "destination_port": "ANY",
     "protocol": "IP"
   },
-  "004_allow_others_to_cp": {
+  "005_allow_others_to_cp": {
     "action": "PASS",
     "source_ip": "$EXTERNAL_NET",
     "destination_ip": "$HOME_NET",

--- a/terraform/aws-accounts/cloud-platform-aws/transit-gateway/transit-gateway.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/transit-gateway/transit-gateway.tf
@@ -23,7 +23,7 @@ locals {
       "172.12.0.0/12" = data.aws_ec2_transit_gateway_peering_attachment.moj-tgw.id,
       "192.168.0.0/16" = data.aws_ec2_transit_gateway_peering_attachment.moj-tgw.id,
        */
-      "10.205.0.0/16" = aws_ec2_transit_gateway_peering_attachment_accepter.laa-ecp-prod-tgw.id,
+      "10.205.0.0/20" = aws_ec2_transit_gateway_peering_attachment_accepter.laa-ecp-prod-tgw.id,
       "172.20.0.0/16" = module.cloud-platform-transit-gateway.ec2_transit_gateway_vpc_attachment["live_1"].id,
       "10.195.0.0/16" = module.cloud-platform-transit-gateway.ec2_transit_gateway_vpc_attachment["live_2"].id
     },


### PR DESCRIPTION
This PR achieves the following:

* Tightens the address range for ECP to `10.205.0.0/20`
* Allow traffic to an ECP TLS listening port on 2484
* Implement a DROP rule after the new rule to prevent accidental leakage on other ports