### PR TITLE
debug modsec logging: removing S3 outputs for audit logs

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/ingress.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/ingress.tf
@@ -51,7 +51,7 @@ module "non_prod_ingress_controllers_v1" {
 }
 
 module "modsec_ingress_controllers_v1" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.15.9"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.15.10"
 
   replica_count            = terraform.workspace == "live" ? "12" : "3"
   controller_name          = "modsec"
@@ -83,7 +83,7 @@ module "modsec_ingress_controllers_v1" {
 }
 
 module "non_prod_modsec_ingress_controllers_v1" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.15.9"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.15.10"
 
   count = terraform.workspace == "live" ? 1 : 0
 


### PR DESCRIPTION
[Changelog here](https://github.com/ministryofjustice/cloud-platform-terraform-ingress-controller/releases/tag/1.15.10)

Homing in on modsec stdout logs going to S3 as the culprit causing the storage buf overlimit

Removing modsec audit logs going to S3 to ascertain that this output is not a factor in storage buf overlimit

Relates to https://github.com/ministryofjustice/cloud-platform/issues/7324