### PR TITLE
Further ECP tightening

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/inspection/firewall_rules.json
+++ b/terraform/aws-accounts/cloud-platform-aws/inspection/firewall_rules.json
@@ -2,7 +2,7 @@
   "001_allow_cp_to_ecp_2484": {
     "action": "PASS",
     "source_ip": "$HOME_NET",
-    "destination_ip": "10.205.0.0/20",
+    "destination_ip": "10.205.7.0/24",
     "destination_port": "2484",
     "protocol": "TCP"
   },

--- a/terraform/aws-accounts/cloud-platform-aws/transit-gateway/transit-gateway.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/transit-gateway/transit-gateway.tf
@@ -23,7 +23,7 @@ locals {
       "172.12.0.0/12" = data.aws_ec2_transit_gateway_peering_attachment.moj-tgw.id,
       "192.168.0.0/16" = data.aws_ec2_transit_gateway_peering_attachment.moj-tgw.id,
        */
-      "10.205.0.0/20" = aws_ec2_transit_gateway_peering_attachment_accepter.laa-ecp-prod-tgw.id,
+      "10.205.7.0/24" = aws_ec2_transit_gateway_peering_attachment_accepter.laa-ecp-prod-tgw.id,
       "172.20.0.0/16" = module.cloud-platform-transit-gateway.ec2_transit_gateway_vpc_attachment["live_1"].id,
       "10.195.0.0/16" = module.cloud-platform-transit-gateway.ec2_transit_gateway_vpc_attachment["live_2"].id
     },


### PR DESCRIPTION
This PR restricts traffic so that, instead of broad access to ECP, only access to the specific VPC in ECP that expects incoming traffic is allowed.