### PR TITLE
Bump gatekeeper version to remove canary app

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/gatekeeper.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/gatekeeper.tf
@@ -1,5 +1,5 @@
 module "gatekeeper" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-gatekeeper?ref=1.16.8"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-gatekeeper?ref=1.16.9"
 
   dryrun_map = {
     service_type                       = false,


### PR DESCRIPTION
See release details here:

https://github.com/ministryofjustice/cloud-platform-terraform-gatekeeper/releases/tag/1.16.9