### PR TITLE
bump iam module to latest with Jas removed

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/account/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/main.tf
@@ -115,7 +115,7 @@ data "aws_region" "current" {}
 
 # IAM configuration for cloud-platform. Users, groups, OIDC providers etc
 module "iam" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-awsaccounts-iam?ref=0.3.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-awsaccounts-iam?ref=0.3.2"
 
   aws_account_name         = "cloud-platform-aws"
   circleci_organisation_id = jsondecode(data.aws_secretsmanager_secret_version.circleci.secret_string)["organisation_id"]


### PR DESCRIPTION
[Changelog](http://github.com/ministryofjustice/cloud-platform-terraform-awsaccounts-iam/releases/tag/0.3.2)

Relates to https://github.com/ministryofjustice/cloud-platform/issues/7432