### PR TITLE
Route to ECP via CP transit gateway

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/transit-gateway-routes/data.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/transit-gateway-routes/data.tf
@@ -1,0 +1,6 @@
+data "aws_ec2_transit_gateway" "cloud-platform-transit-gateway" {
+  filter {
+    name   = "tag:Name"
+    values = ["cloud-platform-transit-gateway"]
+  }
+}

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/transit-gateway-routes/routes.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/transit-gateway-routes/routes.tf
@@ -2,7 +2,7 @@
 locals {
   route_tables = data.terraform_remote_state.cluster-network.outputs.private_route_tables
 
-  ecp_tgw_id = "tgw-0ffb674cc543a84ae"
+  cp_tgw_id = data.aws_ec2_transit_gateway.cloud-platform-transit-gateway.id
   ecp_tgw_destination_cidr_blocks = [
     "10.205.7.0/24"
   ]
@@ -42,6 +42,6 @@ module "tgw_route_to_ecp" {
 
   destination_cidr_block = each.key
 
-  transit_gateway_id = local.ecp_tgw_id
+  transit_gateway_id = local.cp_tgw_id
   route_tables       = local.route_tables
 }


### PR DESCRIPTION
Fixes my mistakes from a previous PR.

This PR uses a data call to retrieve the ID of the CP transit gateway, and then routes to ECP via that TGW. This ensures that traffic is routed correctly and moves through the CP inspection VPC on the way out.