### PR TITLE
Allow traffic to ECP connection test VPC

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/inspection/firewall_rules.json
+++ b/terraform/aws-accounts/cloud-platform-aws/inspection/firewall_rules.json
@@ -6,28 +6,35 @@
     "destination_port": "2484",
     "protocol": "TCP"
   },
-  "002_deny_cp_to_ecp": {
+  "002_allow_cp_to_ecp_443": {
+    "action": "PASS",
+    "source_ip": "$HOME_NET",
+    "destination_ip": "10.205.15.0/24",
+    "destination_port": "443",
+    "protocol": "TCP"
+  },
+  "003_deny_cp_to_ecp": {
     "action": "DROP",
     "source_ip": "$HOME_NET",
     "destination_ip": "10.205.0.0/20",
     "destination_port": "ANY",
     "protocol": "IP"
   },
-  "003_drop_ecp_to_cp": {
+  "004_drop_ecp_to_cp": {
     "action": "DROP",
     "source_ip": "10.205.0.0/20",
     "destination_ip": "$HOME_NET",
     "destination_port": "ANY",
     "protocol": "IP"
   },
-  "004_allow_cp_to_others": {
+  "005_allow_cp_to_others": {
     "action": "PASS",
     "source_ip": "$HOME_NET",
     "destination_ip": "$EXTERNAL_NET",
     "destination_port": "ANY",
     "protocol": "IP"
   },
-  "005_allow_others_to_cp": {
+  "006_allow_others_to_cp": {
     "action": "PASS",
     "source_ip": "$EXTERNAL_NET",
     "destination_ip": "$HOME_NET",

--- a/terraform/aws-accounts/cloud-platform-aws/transit-gateway/transit-gateway.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/transit-gateway/transit-gateway.tf
@@ -24,6 +24,7 @@ locals {
       "192.168.0.0/16" = data.aws_ec2_transit_gateway_peering_attachment.moj-tgw.id,
        */
       "10.205.7.0/24" = aws_ec2_transit_gateway_peering_attachment_accepter.laa-ecp-prod-tgw.id,
+      "10.205.15.0/24" = aws_ec2_transit_gateway_peering_attachment_accepter.laa-ecp-prod-tgw.id,
       "172.20.0.0/16" = module.cloud-platform-transit-gateway.ec2_transit_gateway_vpc_attachment["live_1"].id,
       "10.195.0.0/16" = module.cloud-platform-transit-gateway.ec2_transit_gateway_vpc_attachment["live_2"].id
     },

--- a/terraform/aws-accounts/cloud-platform-aws/transit-gateway/transit-gateway.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/transit-gateway/transit-gateway.tf
@@ -23,10 +23,10 @@ locals {
       "172.12.0.0/12" = data.aws_ec2_transit_gateway_peering_attachment.moj-tgw.id,
       "192.168.0.0/16" = data.aws_ec2_transit_gateway_peering_attachment.moj-tgw.id,
        */
-      "10.205.7.0/24" = aws_ec2_transit_gateway_peering_attachment_accepter.laa-ecp-prod-tgw.id,
+      "10.205.7.0/24"  = aws_ec2_transit_gateway_peering_attachment_accepter.laa-ecp-prod-tgw.id,
       "10.205.15.0/24" = aws_ec2_transit_gateway_peering_attachment_accepter.laa-ecp-prod-tgw.id,
-      "172.20.0.0/16" = module.cloud-platform-transit-gateway.ec2_transit_gateway_vpc_attachment["live_1"].id,
-      "10.195.0.0/16" = module.cloud-platform-transit-gateway.ec2_transit_gateway_vpc_attachment["live_2"].id
+      "172.20.0.0/16"  = module.cloud-platform-transit-gateway.ec2_transit_gateway_vpc_attachment["live_1"].id,
+      "10.195.0.0/16"  = module.cloud-platform-transit-gateway.ec2_transit_gateway_vpc_attachment["live_2"].id
     },
     internal = {
       "10.0.0.0/8"     = module.cloud-platform-transit-gateway.ec2_transit_gateway_vpc_attachment["inspection"].id,

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/transit-gateway-routes/routes.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/transit-gateway-routes/routes.tf
@@ -4,7 +4,8 @@ locals {
 
   cp_tgw_id = data.aws_ec2_transit_gateway.cloud-platform-transit-gateway.id
   ecp_tgw_destination_cidr_blocks = [
-    "10.205.7.0/24"
+    "10.205.7.0/24",
+    "10.205.15.0/24"
   ]
 
   pttp_tgw_id = "tgw-026162f1ba39ce704"


### PR DESCRIPTION
This PR adds the following:
* Adds a firewall rule allowing HTTPS traffic to ECP
* Adds a route sending ECP connection test traffic to the CP TGW
* Adds a route to the CP TGW Inspection route table to send ECP connection test traffic to the ECP TGW

The flow in question would be from an EKS node > to the CP TGW > in and out of the inspection VPC > to the **E**CP TGW