### PR TITLE
Add route53 zone and record for ECP

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/route53.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/route53.tf
@@ -1,0 +1,30 @@
+locals {
+  route53_zones = toset(["aws.prd.legalservices.gov.uk"])
+  route53_records = {
+    "aws.prd.legalservices.gov.uk" = [
+      { name  = "cwa-prod-db", type = "A",
+        alias = { name = "cwa-production-database-nlb-12d44851fda0f196.elb.eu-west-2.amazonaws.com", zone_id = "ZD4D7Y8KGAS4G" }
+      }
+    ]
+  }
+}
+
+resource "aws_route53_zone" "this" {
+  for_each = local.route53_zones
+  name     = each.key
+  dynamic "vpc" {
+    for_each = { for k in keys(module.vpc) : k => module.vpc[k].vpc_id }
+    content {
+      vpc_id = vpc.value
+    }
+  }
+}
+
+module "route53-records" {
+  depends_on = [aws_route53_zone.this]
+  source     = "terraform-aws-modules/route53/aws//modules/records"
+  version    = "5.0.0"
+  for_each   = local.route53_zones
+  records    = local.route53_records[each.key]
+  zone_id    = aws_route53_zone.this[each.key].zone_id
+}


### PR DESCRIPTION
Database access in ECP is gated behind a network load balancer.

This PR creates a private Route53 Hosted Zone, populates it with a record, and associates it with two VCPs.

NB. This zone and record can be removed as soon as the ECP is retired. 