### PR TITLE
feat: Bump aws-sso module to 1.9.0

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/account/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/main.tf
@@ -122,7 +122,7 @@ module "iam" {
 }
 
 module "sso" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-aws-sso?ref=1.8.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-aws-sso?ref=1.9.0"
 
   auth0_tenant_domain = "justice-cloud-platform.eu.auth0.com"
 }


### PR DESCRIPTION
## Purpose

- [Release notes](https://github.com/ministryofjustice/cloud-platform-terraform-aws-sso/releases/tag/1.9.0)