### PR TITLE
chore: 🤖 tuning thanos manager cluster node disk config

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
@@ -189,14 +189,14 @@ locals {
         ebs = {
           volume_size           = 200
           volume_type           = "gp3"
-          iops                  = 0
+          iops                  = 4000
+          throughput            = 150
           encrypted             = false
           kms_key_id            = ""
           delete_on_termination = true
         }
       }
     }
-
 
     subnet_ids = data.aws_subnets.thanos_nodegroup_az.ids
     name       = "${terraform.workspace}-thanos-ng"


### PR DESCRIPTION
## Purpose

First attempt to resolve low priority alert which we see very frequently:

[FIRING:1] :warning: NodeDiskIOSaturation

### Method

increasing `iops` from default `3000` > `4000`, `throughput` from default `125` > `150`. 

thanos node is a heavy singleton instance in `manager` cluster. Has a unique workload requirement. 

This change is a very small adjustment in nodegroup disk specs, let it settle in and adjust if/when required.