### PR TITLE
Fix data call to pick transit subnets

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/transit-gateway-routes/vpc-attachment.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/transit-gateway-routes/vpc-attachment.tf
@@ -22,7 +22,7 @@ data "aws_subnets" "transit" {
   }
   filter {
     name   = "tag:Name"
-    values = ["transit-*"]
+    values = ["*-transit-*"]
   }
 }
 


### PR DESCRIPTION
Apologies; this fixes an error introduced in #4204 

Because the names of the subnets have been changed to prefix the VPC name, the data call needed to be updated too.