### PR TITLE
chore: 🤖 some more tuning for thanos compactor nodegroup

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
@@ -187,10 +187,10 @@ locals {
       xvda = {
         device_name = "/dev/xvda"
         ebs = {
-          volume_size           = 200
+          volume_size           = 400
           volume_type           = "gp3"
-          iops                  = 4000
-          throughput            = 150
+          iops                  = 6000
+          throughput            = 300
           encrypted             = false
           kms_key_id            = ""
           delete_on_termination = true


### PR DESCRIPTION
doubling volume size and increasing iops values.

In response to continued `NodeDiskSaturation` and compactor backlog performance issues