### PR TITLE
bump the monitoring image

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/monitoring.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/monitoring.tf
@@ -1,5 +1,5 @@
 module "monitoring" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=3.28.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=3.28.1"
 
   alertmanager_slack_receivers  = local.enable_alerts ? var.alertmanager_slack_receivers : [{ severity = "dummy", webhook = "https://dummy.slack.com", channel = "#dummy-alarms" }]
   pagerduty_config              = local.enable_alerts ? data.aws_ssm_parameter.components["pagerduty_config"].value : "dummy"


### PR DESCRIPTION
This pr is to bump the monitoring image due to updating the thanos image to legacy as per this[ release](https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/releases/tag/3.28.1)
This pr is part of the ongoing work in issue https://github.com/orgs/ministryofjustice/projects/65/views/3?pane=issue&itemId=120717229&issue=ministryofjustice%7Ccloud-platform%7C7379