### PR TITLE
chore: 🤖 bump autoscaler for vpa recommmender

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/cluster_autoscaler.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/cluster_autoscaler.tf
@@ -1,10 +1,11 @@
 module "cluster_autoscaler" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-cluster-autoscaler?ref=1.13.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-cluster-autoscaler?ref=1.14.0"
 
   enable_overprovision        = lookup(local.prod_workspace, terraform.workspace, false)
   cluster_domain_name         = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   eks_cluster_id              = data.terraform_remote_state.cluster.outputs.cluster_id
   eks_cluster_oidc_issuer_url = data.terraform_remote_state.cluster.outputs.cluster_oidc_issuer_url
+  enable_vpa_recommender      = terraform.workspace == "manager"
 
   # These values are for tuning live cluster overprovisioner memory and CPU requests
   live_memory_request = "1800Mi"

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/vpa-crds.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/vpa-crds.tf
@@ -1,6 +1,6 @@
 locals {
   vpa_crd_yamls = {
-    vpa_crd = "https://raw.githubusercontent.com/kubernetes/autoscaler/vpa-release-1.0/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml"
+    vpa_crd  = "https://raw.githubusercontent.com/kubernetes/autoscaler/vpa-release-1.0/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml"
     vpa_rbac = "https://raw.githubusercontent.com/kubernetes/autoscaler/vpa-release-1.0/vertical-pod-autoscaler/deploy/vpa-rbac.yaml"
   }
   is_manager_workspace = terraform.workspace == "manager"

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/vpa-crds.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/vpa-crds.tf
@@ -1,0 +1,18 @@
+locals {
+  vpa_crd_yamls = {
+    vpa_crd = "https://raw.githubusercontent.com/kubernetes/autoscaler/vpa-release-1.0/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml"
+    vpa_rbac = "https://raw.githubusercontent.com/kubernetes/autoscaler/vpa-release-1.0/vertical-pod-autoscaler/deploy/vpa-rbac.yaml"
+  }
+  is_manager_workspace = terraform.workspace == "manager"
+}
+
+data "http" "vpa_crd_yamls" {
+  for_each = local.is_manager_workspace ? local.vpa_crd_yamls : {}
+  url      = each.value
+}
+
+resource "kubectl_manifest" "vpa_crds" {
+  server_side_apply = true
+  for_each          = data.http.vpa_crd_yamls
+  yaml_body         = each.value["body"]
+}


### PR DESCRIPTION
## Purpose

For `manager` workspace only in first iteration:

- install VPA CRDs
- deploy VPA recommender helm chart

[release](https://github.com/ministryofjustice/cloud-platform-terraform-cluster-autoscaler/releases/tag/1.14.0)