### PR TITLE
feat: 🎸 add vpa resource generation tf and some initial objects

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/manager-vpas.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/manager-vpas.tf
@@ -1,0 +1,53 @@
+## Defining a map of namespace and deployment/statefulset resources for which to create some VPA resources to monitor
+## Concourse cluster resources requests/usage
+
+# This is a temporary home for VPA resources. Future is perhaps a module for CP infrastructure estate??
+
+locals {
+	vpa_targets = {
+		"ingress-controllers" = [
+			{ name = "nginx-ingress-default-controller", kind = "Deployment" }
+		]
+		"concourse" = [
+			{ name = "concourse-web", kind = "Deployment" },
+			{ name = "concourse-worker", kind = "StatefulSet" },
+			{ name = "concourse-postgresql", kind = "StatefulSet" }
+		]
+        "monitoring" = [
+            { name = "thanos-compactor", kind = "Deployment" }
+        ]
+	}
+	is_manager_workspace = terraform.workspace == "manager"
+	vpa_objects = local.is_manager_workspace ? flatten([
+		for ns, targets in local.vpa_targets : [
+			for target in targets : {
+				namespace  = ns
+				name       = target.name
+				kind       = target.kind
+			}
+		]
+	]) : []
+}
+
+resource "kubernetes_manifest" "vpa" {
+	for_each = { for obj in local.vpa_objects : "${obj.namespace}/${obj.kind}/${obj.name}" => obj }
+
+	manifest = {
+		apiVersion = "autoscaling.k8s.io/v1"
+		kind       = "VerticalPodAutoscaler"
+		metadata = {
+			name      = each.value.name
+			namespace = each.value.namespace
+		}
+		spec = {
+			targetRef = {
+				apiVersion = "apps/v1"
+				kind       = each.value.kind
+				name       = each.value.name
+			}
+			updatePolicy = {
+				updateMode = "Off"
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Purpose

- For evaluating some manager workload requests

As we extend VPA recommender across to `live` we can move VPA resources into a separate module and build up the collection there, add some grafana dashboards etc etc