### PR TITLE
Bumping to recent module

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/monitoring.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/monitoring.tf
@@ -1,5 +1,5 @@
 module "monitoring" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=3.28.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=3.29.0"
 
   alertmanager_slack_receivers  = local.enable_alerts ? var.alertmanager_slack_receivers : [{ severity = "dummy", webhook = "https://dummy.slack.com", channel = "#dummy-alarms" }]
   pagerduty_config              = local.enable_alerts ? data.aws_ssm_parameter.components["pagerduty_config"].value : "dummy"


### PR DESCRIPTION
Bumping to most recent version of module.

Move scale up and down notification to #lower-priority-alerts
Create new alert that will alert when 3 or more nodes scale up/down within 30 minutes
Create new entry in README for change in node count

Done as a part of: [6997](https://github.com/ministryofjustice/cloud-platform/issues/6997)