### PR TITLE
chore: 🤖 bump trivy to 0.30.0 chart

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/trivy_operator.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/trivy_operator.tf
@@ -1,5 +1,5 @@
 module "trivy-operator" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-trivy-operator?ref=0.13.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-trivy-operator?ref=0.14.0"
 
   cluster_domain_name         = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   eks_cluster_oidc_issuer_url = data.terraform_remote_state.cluster.outputs.cluster_oidc_issuer_url


### PR DESCRIPTION
[release notes](https://github.com/ministryofjustice/cloud-platform-terraform-trivy-operator/releases/tag/0.14.0)

relates to ministryofjustice/cloud-platform#7421