### PR TITLE
Update data call now that legacy call isn't needed

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/transit-gateway/data.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/transit-gateway/data.tf
@@ -22,19 +22,6 @@ data "aws_subnets" "transit" {
   }
 }
 
-# Gather subnets where naming convention hasn't been updated
-data "aws_subnets" "legacy_transit" {
-  for_each = local.vpcs_to_attach
-  filter {
-    name   = "vpc-id"
-    values = [data.aws_vpc.selected[each.key].id]
-  }
-  filter {
-    name   = "tag:Name"
-    values = ["transit-*"]
-  }
-}
-
 data "aws_subnet" "live_1" {
   for_each = toset(data.aws_subnets.transit["live-1"].ids)
   id       = each.key
@@ -46,6 +33,6 @@ data "aws_subnet" "live_2" {
 }
 
 data "aws_subnet" "inspection_vpc" {
-  for_each = toset(data.aws_subnets.legacy_transit["inspection-vpc"].ids)
+  for_each = toset(data.aws_subnets.transit["inspection-vpc"].ids)
   id       = each.key
 }


### PR DESCRIPTION
Now that the naming convention in the inspection VPC has been updated, the legacy call is no longer required.