### PR TITLE
feat: 🎸 add new route53 zone for internal ingress controllers

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/main.tf
@@ -144,6 +144,25 @@ resource "aws_route53_record" "parent_zone_cluster_ns" {
   ]
 }
 
+resource "aws_route53_zone" "internal_ingress_controller_zone" {
+  name          = "internal.cloud-platform.service.justice.gov.uk."
+  force_destroy = true
+}
+
+resource "aws_route53_record" "parent_zone_internal_ns" {
+  zone_id = data.aws_route53_zone.cloud_platform_justice_gov_uk.zone_id
+  name    = aws_route53_zone.internal_ingress_controller_zone.name
+  type    = "NS"
+  ttl     = "30"
+
+  records = [
+    aws_route53_zone.internal_ingress_controller_zone.name_servers[0],
+    aws_route53_zone.internal_ingress_controller_zone.name_servers[1],
+    aws_route53_zone.internal_ingress_controller_zone.name_servers[2],
+    aws_route53_zone.internal_ingress_controller_zone.name_servers[3],
+  ]
+}
+
 resource "aws_route53_zone" "external-dns-route53-test-zone" {
   count = local.is_live_cluster ? 1 : 0
   name  = "ext-dns-test.cloud-platform.service.justice.gov.uk."


### PR DESCRIPTION
this creates a zone that will be designated domain for any production services utilising internal ingress controllers

we will have a gatekeeper policy that ensures any ingress resources pointing to the internal controller class uses a record managed within this zone.