### PR TITLE
chore: 🤖 bump logging module for internal ingress logs

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/logging.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/logging.tf
@@ -1,5 +1,5 @@
 module "logging" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-logging?ref=1.27.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-logging?ref=1.28.0"
 
   opensearch_app_host = lookup(var.opensearch_app_host_map, terraform.workspace, "placeholder-opensearch")
   elasticsearch_host  = lookup(var.elasticsearch_hosts_maps, terraform.workspace, "placeholder-elasticsearch")


### PR DESCRIPTION
[release notes](https://github.com/ministryofjustice/cloud-platform-terraform-logging/releases/tag/1.28.0)

relates to ministryofjustice/cloud-platform#7594