### PR TITLE
Bump monitoring module to increasing nodes scale limits to decrease noise from alert

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/monitoring.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/monitoring.tf
@@ -1,5 +1,5 @@
 module "monitoring" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=3.30.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=3.30.3"
 
   alertmanager_slack_receivers  = local.enable_alerts ? var.alertmanager_slack_receivers : [{ severity = "dummy", webhook = "https://dummy.slack.com", channel = "#dummy-alarms" }]
   pagerduty_config              = local.enable_alerts ? data.aws_ssm_parameter.components["pagerduty_config"].value : "dummy"


### PR DESCRIPTION
Bump monitoring module to include the following changes to the Increase/Decrease in node count alert:
- increasing node scale limits from 3 in 30 mins, to 5 in 30 mins, to decrease noise from alerts triggering due to normal cluster behaviour.