### PR TITLE
fix: 🐛 create non-tls/secret ingress template for int tests

### DIFF
--- a/test/fixtures/helloworld-deployment-v1-default-cert.yaml.tmpl
+++ b/test/fixtures/helloworld-deployment-v1-default-cert.yaml.tmpl
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: integration-test-helloworld
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: integration-test-app
+  template:
+    metadata:
+      labels:
+        app: integration-test-app
+    spec:
+      containers:
+      - name: nginx
+        image: bitnamilegacy/nginx
+        ports:
+        - containerPort: 8080
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: integration-test-svc
+  labels:
+    app: integration-test-svc
+spec:
+  ports:
+  - port: 80
+    name: http
+    targetPort: 8080
+  selector:
+    app: integration-test-app
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: integration-test-app-ing
+  annotations:
+{{- range $key, $value := .ingress_annotations }}
+   {{ $key }}: {{ $value }}
+{{- end }}
+spec:
+  {{ if .class }}
+  ingressClassName: {{ .class }}
+  {{ end }}
+  rules:
+  - host: {{ .host }}
+    http:
+      paths:
+      - path: /
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: integration-test-svc
+            port:
+              number: 80

--- a/test/ingress_controller_test.go
+++ b/test/ingress_controller_test.go
@@ -58,7 +58,7 @@ var _ = Describe("ingress-controllers", Serial, func() {
 				"namespace": namespaceName,
 			}
 
-			tpl, err := helpers.TemplateFile("./fixtures/helloworld-deployment-v1.yaml.tmpl", "helloworld-deployment-v1.yaml.tmpl", TemplateVars)
+			tpl, err := helpers.TemplateFile("./fixtures/helloworld-deployment-v1-default-cert.yaml.tmpl", "helloworld-deployment-v1-default-cert.yaml.tmpl", TemplateVars)
 			if err != nil {
 				Fail("Failed to create helloworld deployment: " + err.Error())
 			}

--- a/test/modsec_controller_test.go
+++ b/test/modsec_controller_test.go
@@ -67,7 +67,7 @@ var _ = Describe("modsec-ingress-controller", Serial, func() {
 				"namespace": namespaceName,
 			}
 
-			tpl, err := helpers.TemplateFile("./fixtures/helloworld-deployment-v1.yaml.tmpl", "helloworld-deployment-v1.yaml.tmpl", TemplateVars)
+			tpl, err := helpers.TemplateFile("./fixtures/helloworld-deployment-v1-default-cert.yaml.tmpl", "helloworld-deployment-v1-default-cert.yaml.tmpl", TemplateVars)
 			if err != nil {
 				Expect(err).ToNot(HaveOccurred())
 			}

--- a/test/modsec_logging_test.go
+++ b/test/modsec_logging_test.go
@@ -83,7 +83,7 @@ var _ = Describe("logging", Ordered, Serial, func() {
 				},
 			}
 
-			tpl, err := helpers.TemplateFile("./fixtures/helloworld-deployment-v1.yaml.tmpl", "helloworld-deployment-v1.yaml.tmpl", helloVar)
+			tpl, err := helpers.TemplateFile("./fixtures/helloworld-deployment-v1-default-cert.yaml.tmpl", "helloworld-deployment-v1-default-cert.yaml.tmpl", helloVar)
 			Expect(err).ToNot(HaveOccurred())
 
 			err = k8s.KubectlApplyFromStringE(GinkgoT(), options, tpl)

--- a/test/user_app_ingress_logging_test.go
+++ b/test/user_app_ingress_logging_test.go
@@ -72,7 +72,7 @@ var _ = Describe("logging", Ordered, func() {
 				},
 			}
 
-			tpl, err := helpers.TemplateFile("./fixtures/helloworld-deployment-v1.yaml.tmpl", "helloworld-deployment-v1.yaml.tmpl", helloVar)
+			tpl, err := helpers.TemplateFile("./fixtures/helloworld-deployment-v1-default-cert.yaml.tmpl", "helloworld-deployment-v1-default-cert.yaml.tmpl", helloVar)
 			Expect(err).ToNot(HaveOccurred())
 
 			err = k8s.KubectlApplyFromStringE(GinkgoT(), options, tpl)


### PR DESCRIPTION
## Purpose

All of our integration tests that provision `Ingress` resources generate tens of thousands of ingress error logs:

```
Error getting SSL certificate "smoketest-xxx-secret": local SSL certificate  was not found. Using default certificate
```

This is because they use a shared helloworld template that includes a `tls.secretName` config which it doesn't require because we're using default wildcard certs for the associated dns records.

This PR adds a new non tls/secret fixture to use in these tests and fix the ingress errors