### PR TITLE
feat: 🎸 add internal ingress available test

### DIFF
--- a/scripts/iam-policy-usage/iam_policy_usage.go
+++ b/scripts/iam-policy-usage/iam_policy_usage.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/csv"
 	"fmt"
+
 	"unused-policies/utils"
 
 	"github.com/aws/aws-sdk-go-v2/config"

--- a/test/fixtures/internal-ingress-curl.yaml.tmpl
+++ b/test/fixtures/internal-ingress-curl.yaml.tmpl
@@ -8,9 +8,9 @@ spec:
     spec:
       restartPolicy: Never
       containers:
-      - name: helloworld
-        image: bitnamilegacy/nginx:1.25-debian-11
-        command: ["/bin/bash", "-c", "for i in {1..100}; do echo -n 'hello, world {{ .namespace }}' $(date +\"%Y-%m-%d %H:%M:%S,%3N\") '\n'; done"]
+      - name: smoketest-internal-ingress
+        image: ministryofjustice/curl-jq:1
+        command: ["/bin/sh", "-c", "curl -i https://{{ .host }}"]
         securityContext:
           allowPrivilegeEscalation: false
           runAsNonRoot: true

--- a/test/internal_ingress_controller_test.go
+++ b/test/internal_ingress_controller_test.go
@@ -71,7 +71,7 @@ var _ = Describe("ingress-controllers", Serial, func() {
 			GinkgoWriter.Printf("Checking that the ingress is available at %s\n", url)
 
 			jobVar := map[string]interface{}{
-				"jobName":    "smoketest-internal-ingress",
+				"jobName":   "smoketest-internal-ingress",
 				"host":      host,
 				"namespace": namespaceName,
 			}

--- a/test/internal_ingress_controller_test.go
+++ b/test/internal_ingress_controller_test.go
@@ -83,7 +83,7 @@ var _ = Describe("ingress-controllers", Serial, func() {
 
 			err = k8s.KubectlApplyFromStringE(GinkgoT(), options, tpl)
 			Expect(err).To(BeNil())
-e
+
 			err = k8s.WaitUntilJobSucceedE(GinkgoT(), options, "smoketest-internal-ingress", 10, 20*time.Second)
 			Expect(err).To(BeNil())
 		})

--- a/test/internal_ingress_controller_test.go
+++ b/test/internal_ingress_controller_test.go
@@ -1,0 +1,91 @@
+package integration_tests
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/random"
+	. "github.com/onsi/gomega"
+
+	"github.com/ministryofjustice/cloud-platform-infrastructure/test/helpers"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("ingress-controllers", Serial, func() {
+	var (
+		namespaceName, host, url string
+		options                  *k8s.KubectlOptions
+	)
+
+	BeforeEach(func() {
+		namespaceName = fmt.Sprintf("%s-ing-%s", c.Prefix, strings.ToLower(random.UniqueId()))
+		host = fmt.Sprintf("%s.apps.%s.%s", namespaceName, c.ClusterName, domain)
+		options = k8s.NewKubectlOptions("", "", namespaceName)
+		url = fmt.Sprintf("https://%s", host)
+
+		nsObject := metav1.ObjectMeta{
+			Name: namespaceName,
+			Labels: map[string]string{
+				"pod-security.kubernetes.io/enforce": "restricted",
+			},
+		}
+
+		err := k8s.CreateNamespaceWithMetadataE(GinkgoT(), options, nsObject)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		err := k8s.DeleteNamespaceE(GinkgoT(), options, namespaceName)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	Context("when an ingress resource is deployed using 'internal-laa' ingress controller", func() {
+		It("should expose the service in cluster vpc", func() {
+			setIdentifier := "integration-test-app-ing-" + namespaceName + "-green"
+			class := "internal-laa"
+
+			TemplateVars := map[string]interface{}{
+				"ingress_annotations": map[string]string{
+					"external-dns.alpha.kubernetes.io/aws-weight":     "\"100\"",
+					"external-dns.alpha.kubernetes.io/set-identifier": setIdentifier,
+				},
+				"host":      host,
+				"class":     class,
+				"namespace": namespaceName,
+			}
+
+			tpl, err := helpers.TemplateFile("./fixtures/helloworld-deployment-v1-default-cert.yaml.tmpl", "helloworld-deployment-v1-default-cert.yaml.tmpl", TemplateVars)
+			if err != nil {
+				Fail("Failed to create helloworld deployment: " + err.Error())
+			}
+
+			err = k8s.KubectlApplyFromStringE(GinkgoT(), options, tpl)
+			Expect(err).To(BeNil())
+
+			k8s.WaitUntilIngressAvailable(GinkgoT(), options, "integration-test-app-ing", 8, 20*time.Second)
+
+			GinkgoWriter.Printf("Checking that the ingress is available at %s\n", url)
+
+			jobVar := map[string]interface{}{
+				"jobName":    "smoketest-internal-ingress",
+				"host":      host,
+				"namespace": namespaceName,
+			}
+
+			tpl, err = helpers.TemplateFile("./fixtures/internal-ingress-curl.yaml.tmpl", "internal-ingress-curl.yaml.tmpl", jobVar)
+			if err != nil {
+				Fail("Failed to create internal ingress curl job: " + err.Error())
+			}
+
+			err = k8s.KubectlApplyFromStringE(GinkgoT(), options, tpl)
+			Expect(err).To(BeNil())
+e
+			err = k8s.WaitUntilJobSucceedE(GinkgoT(), options, "smoketest-internal-ingress", 10, 20*time.Second)
+			Expect(err).To(BeNil())
+		})
+	})
+})


### PR DESCRIPTION
## Purpose

This PR adds an integration test and supporting fixture for verifying internal ingress class works as expected.

- deploys usual smoketest ns, helloworld nginx service
- `internal-laa` class based ingress
- `curl-jq` job to check ingress routes internally via a cluster pod

Additional things here:

- fix line break for iam_policy_usage script (stops gofmt lint action fail)
- add `securityContext` fields to helloworld-job template to reduce the amount of warnings we get in other int test runs from gatekeeper violations

relates to ministryofjustice/cloud-platform#7594
