### PR TITLE
fix: 🐛 only run internal ingress test in live cluster

### DIFF
--- a/test/internal_ingress_controller_test.go
+++ b/test/internal_ingress_controller_test.go
@@ -22,6 +22,10 @@ var _ = Describe("ingress-controllers", Serial, func() {
 	)
 
 	BeforeEach(func() {
+		if !(c.ClusterName == "live") {
+			Skip(fmt.Sprintf("Internal ingress class is not deployed on cluster: %s", c.ClusterName))
+		}
+
 		namespaceName = fmt.Sprintf("%s-ing-%s", c.Prefix, strings.ToLower(random.UniqueId()))
 		host = fmt.Sprintf("%s.apps.%s.%s", namespaceName, c.ClusterName, domain)
 		options = k8s.NewKubectlOptions("", "", namespaceName)


### PR DESCRIPTION
relates to ministryofjustice/cloud-platform#7594