### PR TITLE
chore: 🤖 make internal dev more ingress class name consistent

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/route53.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/route53.tf
@@ -82,24 +82,24 @@ resource "aws_route53_record" "external-dns-2-parent-zone-ns" {
   ]
 }
 
-resource "aws_route53_zone" "internal_dev_ingress_controller_zone" {
+resource "aws_route53_zone" "internal_non_prod_ingress_controller_zone" {
   count         = local.is_live_cluster ? 1 : 0
-  name          = "internal-dev.cloud-platform.service.justice.gov.uk."
+  name          = "internal-non-prod.cloud-platform.service.justice.gov.uk."
   force_destroy = true
 }
 
-resource "aws_route53_record" "parent_zone_internal_dev_ns" {
+resource "aws_route53_record" "parent_zone_internal_non_prod_ns" {
   count   = local.is_live_cluster ? 1 : 0
   zone_id = data.aws_route53_zone.cloud_platform_justice_gov_uk.zone_id
-  name    = aws_route53_zone.internal_dev_ingress_controller_zone[count.index].name
+  name    = aws_route53_zone.internal_non_prod_ingress_controller_zone[count.index].name
   type    = "NS"
   ttl     = "30"
 
   records = [
-    aws_route53_zone.internal_dev_ingress_controller_zone[count.index].name_servers[0],
-    aws_route53_zone.internal_dev_ingress_controller_zone[count.index].name_servers[1],
-    aws_route53_zone.internal_dev_ingress_controller_zone[count.index].name_servers[2],
-    aws_route53_zone.internal_dev_ingress_controller_zone[count.index].name_servers[3],
+    aws_route53_zone.internal_non_prod_ingress_controller_zone[count.index].name_servers[0],
+    aws_route53_zone.internal_non_prod_ingress_controller_zone[count.index].name_servers[1],
+    aws_route53_zone.internal_non_prod_ingress_controller_zone[count.index].name_servers[2],
+    aws_route53_zone.internal_non_prod_ingress_controller_zone[count.index].name_servers[3],
   ]
 }
 


### PR DESCRIPTION
our ingress className pattern is like "default", "default-non-prod" etc. Lets keep the same pattern for internal ingress classes and their associated hosted zones

relates to ministryofjustice/cloud-platform#7594