### PR TITLE
bringing default ingress-controllers module versions in line to modsec

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/ingress.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/ingress.tf
@@ -1,5 +1,5 @@
 module "ingress_controllers_v1" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.14.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.15.11"
 
   replica_count            = terraform.workspace == "live" ? "30" : "3"
   controller_name          = "default"
@@ -24,7 +24,7 @@ module "ingress_controllers_v1" {
 }
 
 module "non_prod_ingress_controllers_v1" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.14.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=1.15.11"
   count  = terraform.workspace == "live" ? 1 : 0
 
   replica_count            = "6"


### PR DESCRIPTION
PR to align the module version of ingress-controllers

Should be a no ops apply