### PR TITLE
Putting managed firewall rule groups into passive and alert mode

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/firewall.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/firewall.tf
@@ -54,29 +54,29 @@ module "cloud-platform-firewall-policy" {
   }
 
   stateful_rule_group_reference = [
-    { 
-      priority = 1
+    {
+      priority     = 1
       resource_arn = "arn:aws:network-firewall:eu-west-2:aws-managed:stateful-rulegroup/AttackInfrastructureStrictOrder"
       override = {
         action = "DROP_TO_ALERT"
       }
     },
     {
-      priority = 2
+      priority     = 2
       resource_arn = "arn:aws:network-firewall:eu-west-2:aws-managed:stateful-rulegroup/MalwareDomainsStrictOrder"
       override = {
         action = "DROP_TO_ALERT"
       }
     },
     {
-      priority = 3
+      priority     = 3
       resource_arn = "arn:aws:network-firewall:eu-west-2:aws-managed:stateful-rulegroup/BotNetCommandAndControlDomainsStrictOrder"
       override = {
         action = "DROP_TO_ALERT"
       }
     },
     {
-      priority = 10
+      priority     = 10
       resource_arn = module.cloud-platform-firewall-rule-group.arn
     }
   ]


### PR DESCRIPTION
This PR changes the Network Firewall into passive mode. We have some [Managed Stateful Rule Groups](https://docs.aws.amazon.com/network-firewall/latest/developerguide/nwfw-managed-rule-groups.html) we have in place for the following threat detection:
[AttackInfrastructureStrictOrder](https://docs.aws.amazon.com/network-firewall/latest/developerguide/aws-managed-rule-groups-atd.html)
[MalwareDomainsStrictOrder](https://docs.aws.amazon.com/network-firewall/latest/developerguide/aws-managed-rule-groups-domain-list.html)
[BotNetCommandAndControlDomainsStrictOrder](https://docs.aws.amazon.com/network-firewall/latest/developerguide/aws-managed-rule-groups-domain-list.html)

By default these rules block any traffic that is deemed a threat by AWS when matching any of the rules above. This PR puts these managed rule groups into `Run in alert mode`, meaning in effect running in passive mode. This allows to do a dry-run of these rules with alert logs that shows what the resulting behaviour would look like.

Relates to https://github.com/ministryofjustice/cloud-platform/issues/7451