### PR TITLE
Added routes and firewall rules for two new ECP VPC

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/inspection/firewall_rules.json
+++ b/terraform/aws-accounts/cloud-platform-aws/inspection/firewall_rules.json
@@ -1,33 +1,47 @@
 {
-  "001_allow_cp_to_ecp_2484": {
+  "001_allow_cp_to_ecp_db_lb_2484": {
+    "action": "PASS",
+    "source_ip": "$HOME_NET",
+    "destination_ip": "10.205.10.0/24",
+    "destination_port": "2484",
+    "protocol": "TCP"
+  },
+  "001_allow_cp_to_ecp_db3_2484": {
+    "action": "PASS",
+    "source_ip": "$HOME_NET",
+    "destination_ip": "10.205.11.0/24",
+    "destination_port": "2484",
+    "protocol": "TCP"
+  },
+  "001_allow_cp_to_ecp_db1_2484": {
     "action": "PASS",
     "source_ip": "$HOME_NET",
     "destination_ip": "10.205.14.0/24",
     "destination_port": "2484",
     "protocol": "TCP"
   },
-  "002_deny_cp_to_ecp": {
+  "0020_deny_cp_to_ecp": {
     "action": "DROP",
     "source_ip": "$HOME_NET",
     "destination_ip": "10.205.0.0/20",
     "destination_port": "ANY",
     "protocol": "IP"
   },
-  "003_drop_ecp_to_cp": {
+  "0030_drop_ecp_to_cp": {
     "action": "DROP",
     "source_ip": "10.205.0.0/20",
     "destination_ip": "$HOME_NET",
     "destination_port": "ANY",
     "protocol": "IP"
   },
-  "004_allow_cp_to_others": {
+  "0040_allow_cp_to_others": {
     "action": "PASS",
     "source_ip": "$HOME_NET",
     "destination_ip": "$EXTERNAL_NET",
     "destination_port": "ANY",
     "protocol": "IP"
   },
-  "005_allow_others_to_cp": {
+  "0050_allow_others_to_cp": {
     "action": "PASS",
     "source_ip": "$EXTERNAL_NET",
     "destination_ip": "$HOME_NET",

--- a/terraform/aws-accounts/cloud-platform-aws/transit-gateway/transit-gateway.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/transit-gateway/transit-gateway.tf
@@ -23,6 +23,8 @@ locals {
       "172.12.0.0/12" = data.aws_ec2_transit_gateway_peering_attachment.moj-tgw.id,
       "192.168.0.0/16" = data.aws_ec2_transit_gateway_peering_attachment.moj-tgw.id,
        */
+      "10.205.10.0/24" = aws_ec2_transit_gateway_peering_attachment_accepter.laa-ecp-prod-tgw.id,
+      "10.205.11.0/24" = aws_ec2_transit_gateway_peering_attachment_accepter.laa-ecp-prod-tgw.id,
       "10.205.14.0/24" = aws_ec2_transit_gateway_peering_attachment_accepter.laa-ecp-prod-tgw.id,
       "172.20.0.0/16"  = module.cloud-platform-transit-gateway.ec2_transit_gateway_vpc_attachment["live_1"].id,
       "10.195.0.0/16"  = module.cloud-platform-transit-gateway.ec2_transit_gateway_vpc_attachment["live_2"].id

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/transit-gateway-routes/routes.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/transit-gateway-routes/routes.tf
@@ -4,6 +4,8 @@ locals {
 
   cp_tgw_id = data.aws_ec2_transit_gateway.cloud-platform-transit-gateway.id
   ecp_tgw_destination_cidr_blocks = [
+    "10.205.10.0/24",
+    "10.205.11.0/24",
     "10.205.14.0/24"
   ]
 


### PR DESCRIPTION
To support a blue/green deployment approach for the CWA database on ECP, routes and firewall rules for two new VPCs are required.