### PR TITLE
chore: 🤖 install new tiers and adminnwp CRDs

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/calico.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/calico.tf
@@ -26,8 +26,8 @@ locals {
     networkpolicies               = "https://raw.githubusercontent.com/projectcalico/calico/v3.29.6/libcalico-go/config/crd/crd.projectcalico.org_networkpolicies.yaml"
     networksets                   = "https://raw.githubusercontent.com/projectcalico/calico/v3.29.6/libcalico-go/config/crd/crd.projectcalico.org_networksets.yaml"
     bgpfilters                    = "https://raw.githubusercontent.com/projectcalico/calico/v3.29.6/libcalico-go/config/crd/crd.projectcalico.org_bgpfilters.yaml"
-    #tiers                         = "https://raw.githubusercontent.com/projectcalico/calico/v3.29.6/libcalico-go/config/crd/crd.projectcalico.org_tiers.yaml"
-    #adminnetworkpolicies          = "https://raw.githubusercontent.com/projectcalico/calico/v3.29.6/libcalico-go/config/crd/policy.networking.k8s.io_adminnetworkpolicies.yaml"
+    tiers                         = "https://raw.githubusercontent.com/projectcalico/calico/v3.29.6/libcalico-go/config/crd/crd.projectcalico.org_tiers.yaml"
+    adminnetworkpolicies          = "https://raw.githubusercontent.com/projectcalico/calico/v3.29.6/libcalico-go/config/crd/policy.networking.k8s.io_adminnetworkpolicies.yaml"
   }
 }
 


### PR DESCRIPTION
## Calico 3.29 upgrade Step 2

- Install `3.29.x` CRDS

```
crd.projectcalico.org_tiers
policy.networking.k8s.io_adminnetworkpolicies
```

relates to ministryofjustice/cloud-platform#7416