### PR TITLE
chore: 🤖 bump calico module for 3.29.6 release

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/calico.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/calico.tf
@@ -44,7 +44,7 @@ resource "kubectl_manifest" "calico_crds" {
 
 
 module "tigera_calico" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-tigera-calico?ref=0.2.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-tigera-calico?ref=0.3.0"
 
   depends_on = [
     kubectl_manifest.calico_crds


### PR DESCRIPTION
## Calico 3.29 upgrade Step 3

- Upgrade Calico Helm release to `3.29.6`

[Release notes](https://github.com/ministryofjustice/cloud-platform-terraform-tigera-calico/releases/tag/0.3.0)

relates to ministryofjustice/cloud-platform#7416