### PR TITLE
feat: add missing service area tag

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/main.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/main.tf
@@ -23,6 +23,7 @@ provider "aws" {
       is-production = "true"
       owner         = "Cloud Platform: platforms@digital.justice.gov.uk"
       source-code   = "github.com/ministryofjustice/cloud-platform-infrastructure"
+      service-area  = "Hosting"
     }
   }
 }


### PR DESCRIPTION
## Problem
EIPs, NAT Gateways, and other VPC resources in eu-west-2 are missing the `service-area` tag, which is required for compliance and cost allocation.

Current state:
- 39 EIPs have 4/5 mandatory tags (missing `service-area`)
- 33 NAT Gateways have 4/5 mandatory tags (missing `service-area`)
- Other VPC resources similarly affected

## Solution
Add `service-area = "Hosting"` to the AWS provider default_tags in the VPC configuration.

This ensures all resources created by this provider automatically receive the tag.

## Impact
- **Resources affected:** All VPC resources created via this provider (EIPs, NAT Gateways, Route Tables, etc.)
- **Change type:** Tag addition only (no resource recreation)
- **Downtime:** None
- [x] Consistent with existing tag pattern

## Compliance
Addresses mandatory tagging requirements:
- ✅ business-unit
- ✅ application
- ✅ service-area (added)
- ✅ owner
- ✅ is-production

relates to https://github.com/ministryofjustice/cloud-platform/issues/7124