### PR TITLE
fix: 🐛 wait for cluster completion before ns label apply

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/namespace-labels.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/namespace-labels.tf
@@ -17,6 +17,8 @@ resource "kubernetes_annotations" "kube_system_ns" {
     "cloud-platform.justice.gov.uk/slack-channel" = "cloud-platform"
     "cloud-platform-out-of-hours-alert"           = "true"
   }
+
+  depends_on = [module.aws_eks_addons]
 }
 
 resource "kubernetes_labels" "kube_system_ns" {
@@ -33,6 +35,8 @@ resource "kubernetes_labels" "kube_system_ns" {
     "cloud-platform.justice.gov.uk/environment-name" = "production"
     "pod-security.kubernetes.io/enforce"             = "privileged"
   }
+
+  depends_on = [module.aws_eks_addons]
 }
 
 ################################
@@ -48,6 +52,8 @@ resource "kubernetes_labels" "default_ns" {
   labels = {
     "pod-security.kubernetes.io/enforce" = "restricted"
   }
+
+  depends_on = [module.aws_eks_addons]
 }
 
 resource "kubernetes_labels" "kube_public_ns" {
@@ -59,6 +65,8 @@ resource "kubernetes_labels" "kube_public_ns" {
   labels = {
     "pod-security.kubernetes.io/enforce" = "restricted"
   }
+  
+  depends_on = [module.aws_eks_addons]
 }
 
 resource "kubernetes_labels" "kube_node_lease_ns" {
@@ -70,4 +78,6 @@ resource "kubernetes_labels" "kube_node_lease_ns" {
   labels = {
     "pod-security.kubernetes.io/enforce" = "restricted"
   }
+  
+  depends_on = [module.aws_eks_addons]
 }

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/namespace-labels.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/namespace-labels.tf
@@ -65,7 +65,7 @@ resource "kubernetes_labels" "kube_public_ns" {
   labels = {
     "pod-security.kubernetes.io/enforce" = "restricted"
   }
-  
+
   depends_on = [module.aws_eks_addons]
 }
 
@@ -78,6 +78,6 @@ resource "kubernetes_labels" "kube_node_lease_ns" {
   labels = {
     "pod-security.kubernetes.io/enforce" = "restricted"
   }
-  
+
   depends_on = [module.aws_eks_addons]
 }


### PR DESCRIPTION
## Purpose

This PR mitigates the intermittent cluster build failure where dns propogation delays lead to cluster lookup timeout when trying to apply required labels and PSA annotations to system namespaces.

We are adding a `depends_on` to label resources in order to ensure full cluster build completion first. 

relates to ministryofjustice/cloud-platform#8127