### PR TITLE
chore: 🤖 bring all ingress controller module call in line

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/ingress-default-non-prod.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/ingress-default-non-prod.tf
@@ -1,5 +1,5 @@
 module "non_prod_ingress_controllers_v1" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=3.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=3.1.2"
   count  = terraform.workspace == "live" ? 1 : 0
 
   replica_count            = "15"

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/ingress-default.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/ingress-default.tf
@@ -1,5 +1,5 @@
 module "ingress_controllers_v1" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=3.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=3.1.2"
 
   replica_count            = terraform.workspace == "live" ? "30" : "3"
   controller_name          = "default"

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/ingress-internal-laa.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/ingress-internal-laa.tf
@@ -1,5 +1,5 @@
 module "ingress_controllers_laa" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref="
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=3.1.2"
 
   count = terraform.workspace == "live" ? 1 : 0
 

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/ingress-internal-laa.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/ingress-internal-laa.tf
@@ -1,5 +1,5 @@
 module "ingress_controllers_laa" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=3.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref="
 
   count = terraform.workspace == "live" ? 1 : 0
 

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/ingress-internal-non-prod.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/ingress-internal-non-prod.tf
@@ -1,5 +1,5 @@
 module "ingress_controllers_internal_non_prod" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=3.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=3.1.2"
 
   count = terraform.workspace == "live" ? 1 : 0
 


### PR DESCRIPTION
## Purpose

Prior to `ingress-controllers` namespace module breakout, bring all ingress classes up to same release.

Changes here are just related to the modsec config rule exception introduced following CRS upgrade:
https://github.com/ministryofjustice/cloud-platform-terraform-ingress-controller/compare/3.1.0...3.1.2

