### PR TITLE
chore: 🤖 bump velero module, double default validator replicas

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/ingress-default.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/ingress-default.tf
@@ -27,7 +27,7 @@ module "ingress_controllers_v1" {
 module "default_ingress_controllers_validator" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-validation-controller?ref=0.1.0"
 
-  replica_count      = "3"
+  replica_count      = "6"
   controller_name    = "default"
   memory_requests    = "3Gi"
   memory_limits      = "4Gi"

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/velero.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/velero.tf
@@ -1,5 +1,5 @@
 module "velero" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-velero?ref=2.7.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-velero?ref=2.8.0"
 
   enable_velero               = lookup(local.prod_2_workspace, terraform.workspace, false)
   cluster_domain_name         = data.terraform_remote_state.cluster.outputs.cluster_domain_name


### PR DESCRIPTION
## Purpose

- bump velero module for `ingress-controllers` namespace exclusion
- increase default validation controller replicaset from 3 to 6

[release notes](https://github.com/ministryofjustice/cloud-platform-terraform-velero/releases/tag/2.8.0)