### PR TITLE
chore: 🤖 temporarily disabling dependabot for long infra pause

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,112 +3,112 @@
 # Please see the documentation for all configuration options:
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
-version: 2
-updates:
-  - package-ecosystem: "github-actions" # See documentation for possible values
-    directory: "/" # Location of package manifests
-    schedule:
-      interval: "weekly"
-      day: "sunday"
-      time: "09:00" # UTC
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "sunday"
-      time: "09:00"
-    groups:
-      go:
-        patterns:
-          - "*"
-  - package-ecosystem: "terraform"
-    directory: "/terraform/aws-accounts/cloud-platform-aws/account"
-    schedule:
-      interval: "weekly"
-      day: "sunday"
-      time: "09:00"
-    groups:
-      cloud-platform-aws-account:
-        patterns:
-          - "*"
-  - package-ecosystem: "terraform"
-    directory: "/terraform/aws-accounts/cloud-platform-aws/vpc"
-    schedule:
-      interval: "weekly"
-      day: "sunday"
-      time: "09:00"
-    groups:
-      cloud-platform-aws-vpc:
-        patterns:
-          - "*"
-  - package-ecosystem: "terraform"
-    directory: "/terraform/aws-accounts/cloud-platform-aws/vpc/eks"
-    schedule:
-      interval: "weekly"
-      day: "sunday"
-      time: "09:00"
-    groups:
-      cloud-platform-aws-vpc-eks:
-        patterns:
-          - "*"
-    ignore:
-    - dependency-name: "terraform-aws-modules/eks/aws"
-      update-types: ["version-update:semver-major"]
-  - package-ecosystem: "terraform"
-    directory: "/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components"
-    schedule:
-      interval: "weekly"
-      day: "sunday"
-      time: "09:00"
-    groups:
-      cloud-platform-aws-vpc-eks-components:
-        patterns:
-          - "*"
-  - package-ecosystem: "terraform"
-    directory: "/terraform/aws-accounts/cloud-platform-dsd"
-    schedule:
-      interval: "weekly"
-      day: "sunday"
-      time: "09:00"
-    groups:
-      cloud-platform-dsd:
-        patterns:
-          - "*"
-  - package-ecosystem: "terraform"
-    directory: "/terraform/aws-accounts/cloud-platform-ephemeral-test/account"
-    open-pull-requests-limit: 0
-    schedule:
-      interval: "weekly"
-      day: "sunday"
-      time: "09:00"
-  - package-ecosystem: "terraform"
-    directory: "/terraform/aws-accounts/cloud-platform-ephemeral-test/vpc"
-    open-pull-requests-limit: 0
-    schedule:
-      interval: "weekly"
-      day: "sunday"
-      time: "09:00"
-  - package-ecosystem: "terraform"
-    directory: "/terraform/aws-accounts/cloud-platform-ephemeral-test/vpc/eks"
-    open-pull-requests-limit: 0
-    schedule:
-      interval: "weekly"
-      day: "sunday"
-      time: "09:00"
-  - package-ecosystem: "terraform"
-    directory: "/terraform/aws-accounts/cloud-platform-ephemeral-test/vpc/eks/components"
-    open-pull-requests-limit: 0
-    schedule:
-      interval: "weekly"
-      day: "sunday"
-      time: "09:00"
-  - package-ecosystem: "terraform"
-    directory: "/terraform/global-resources"
-    schedule:
-      interval: "weekly"
-      day: "sunday"
-      time: "09:00"
-    groups:
-      global-resources:
-        patterns:
-          - "*"
+# version: 2
+# updates:
+#   - package-ecosystem: "github-actions" # See documentation for possible values
+#     directory: "/" # Location of package manifests
+#     schedule:
+#       interval: "weekly"
+#       day: "sunday"
+#       time: "09:00" # UTC
+#   - package-ecosystem: "gomod"
+#     directory: "/"
+#     schedule:
+#       interval: "weekly"
+#       day: "sunday"
+#       time: "09:00"
+#     groups:
+#       go:
+#         patterns:
+#           - "*"
+#   - package-ecosystem: "terraform"
+#     directory: "/terraform/aws-accounts/cloud-platform-aws/account"
+#     schedule:
+#       interval: "weekly"
+#       day: "sunday"
+#       time: "09:00"
+#     groups:
+#       cloud-platform-aws-account:
+#         patterns:
+#           - "*"
+#   - package-ecosystem: "terraform"
+#     directory: "/terraform/aws-accounts/cloud-platform-aws/vpc"
+#     schedule:
+#       interval: "weekly"
+#       day: "sunday"
+#       time: "09:00"
+#     groups:
+#       cloud-platform-aws-vpc:
+#         patterns:
+#           - "*"
+#   - package-ecosystem: "terraform"
+#     directory: "/terraform/aws-accounts/cloud-platform-aws/vpc/eks"
+#     schedule:
+#       interval: "weekly"
+#       day: "sunday"
+#       time: "09:00"
+#     groups:
+#       cloud-platform-aws-vpc-eks:
+#         patterns:
+#           - "*"
+#     ignore:
+#     - dependency-name: "terraform-aws-modules/eks/aws"
+#       update-types: ["version-update:semver-major"]
+#   - package-ecosystem: "terraform"
+#     directory: "/terraform/aws-accounts/cloud-platform-aws/vpc/eks/components"
+#     schedule:
+#       interval: "weekly"
+#       day: "sunday"
+#       time: "09:00"
+#     groups:
+#       cloud-platform-aws-vpc-eks-components:
+#         patterns:
+#           - "*"
+#   - package-ecosystem: "terraform"
+#     directory: "/terraform/aws-accounts/cloud-platform-dsd"
+#     schedule:
+#       interval: "weekly"
+#       day: "sunday"
+#       time: "09:00"
+#     groups:
+#       cloud-platform-dsd:
+#         patterns:
+#           - "*"
+#   - package-ecosystem: "terraform"
+#     directory: "/terraform/aws-accounts/cloud-platform-ephemeral-test/account"
+#     open-pull-requests-limit: 0
+#     schedule:
+#       interval: "weekly"
+#       day: "sunday"
+#       time: "09:00"
+#   - package-ecosystem: "terraform"
+#     directory: "/terraform/aws-accounts/cloud-platform-ephemeral-test/vpc"
+#     open-pull-requests-limit: 0
+#     schedule:
+#       interval: "weekly"
+#       day: "sunday"
+#       time: "09:00"
+#   - package-ecosystem: "terraform"
+#     directory: "/terraform/aws-accounts/cloud-platform-ephemeral-test/vpc/eks"
+#     open-pull-requests-limit: 0
+#     schedule:
+#       interval: "weekly"
+#       day: "sunday"
+#       time: "09:00"
+#   - package-ecosystem: "terraform"
+#     directory: "/terraform/aws-accounts/cloud-platform-ephemeral-test/vpc/eks/components"
+#     open-pull-requests-limit: 0
+#     schedule:
+#       interval: "weekly"
+#       day: "sunday"
+#       time: "09:00"
+#   - package-ecosystem: "terraform"
+#     directory: "/terraform/global-resources"
+#     schedule:
+#       interval: "weekly"
+#       day: "sunday"
+#       time: "09:00"
+#     groups:
+#       global-resources:
+#         patterns:
+#           - "*"


### PR DESCRIPTION
this is so we can leave infra pipe paused over weekend in advance of node recycle and avoid state lock clashes on monday