### PR TITLE
chore: bump logging module to 1.29.4

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/logging.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/logging.tf
@@ -1,5 +1,5 @@
 module "logging" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-logging?ref=1.29.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-logging?ref=1.29.4"
 
   opensearch_app_host = lookup(var.opensearch_app_host_map, terraform.workspace, "placeholder-opensearch")
   elasticsearch_host  = lookup(var.elasticsearch_hosts_maps, terraform.workspace, "placeholder-elasticsearch")


### PR DESCRIPTION
## What

Bump `cloud-platform-terraform-logging` module from `1.29.3` to [`1.29.4`](https://github.com/ministryofjustice/cloud-platform-terraform-logging/releases/tag/1.29.4).

## Why

Increases the logging namespace pod quota from 150 to 170. The `KubeQuota-Exceeded` alert fired at 138/150 pods, all from the fluent-bit DaemonSet. This provides headroom for current cluster size.

Related: https://github.com/ministryofjustice/cloud-platform-terraform-logging/pull/202