### PR TITLE
Increase OpenSearch nodes to 18

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/account/app-opensearch.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/app-opensearch.tf
@@ -139,7 +139,7 @@ resource "aws_opensearch_domain" "live_app_logs" {
 
   cluster_config {
     instance_type            = "r6g.4xlarge.search"
-    instance_count           = "15"
+    instance_count           = "18"
     dedicated_master_enabled = true
     dedicated_master_type    = "m6g.large.search"
     dedicated_master_count   = "5"

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
@@ -75,14 +75,14 @@ locals {
   }
 
   temp_max_size = {
-    live    = "120"
+    live    = "150"
     live-2  = "120"
     manager = "1"
     default = "6"
   }
 
   temp_min_size = {
-    live    = "65"
+    live    = "120"
     live-2  = "2"
     manager = "1"
     default = "2"
@@ -322,8 +322,8 @@ locals {
 
   default_ng_20_04_26 = {
     desired_size = lookup(local.upgrade_desired_size, terraform.workspace, local.upgrade_desired_size["default"])
-    max_size     = 120
-    min_size     = lookup(local.upgrade_min_size, terraform.workspace, local.upgrade_min_size["default"])
+    max_size     = 3
+    min_size     = 3
 
     block_device_mappings = {
       xvda = {

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
@@ -88,6 +88,20 @@ locals {
     default = "2"
   }
 
+  temp_ng_20_04_26_max_size = {
+    live    = "3"
+    live-2  = "120"
+    manager = "120"
+    default = "6"
+  }
+
+  temp_ng_20_04_26_min_size = {
+    live    = "3"
+    live-2  = "2"
+    manager = "4"
+    default = "2"
+  }
+
   # To manage different cluster versions
   cluster_version = {
     live    = "1.33"
@@ -322,8 +336,8 @@ locals {
 
   default_ng_20_04_26 = {
     desired_size = lookup(local.upgrade_desired_size, terraform.workspace, local.upgrade_desired_size["default"])
-    max_size     = 3
-    min_size     = 3
+    max_size     = lookup(local.temp_ng_20_04_26_max_size, terraform.workspace, local.temp_ng_20_04_26_max_size["default"])
+    min_size     = lookup(local.temp_ng_20_04_26_min_size, terraform.workspace, local.temp_ng_20_04_26_min_size["default"])
 
     block_device_mappings = {
       xvda = {


### PR DESCRIPTION
Increase OpenSearch nodes from 15 to 18

Also brings in [PR 460](https://github.com/ministryofjustice/cloud-platform-infrastructure/pull/460)1  as this failed to apply on Friday

Also bring TF cluster sizes back in line with manual changes
Affects:
default_ng_10_12_25
default_ng_20_04_26