### PR TITLE
chore: 🤖 bump kube-proxy add-on to latest 1.33 release

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
@@ -650,6 +650,6 @@ module "aws_eks_addons" {
 
   addon_vpc_cni_version         = "v1.20.5-eksbuild.1"
   addon_coredns_version         = "v1.12.4-eksbuild.1"
-  addon_kube_proxy_version      = "v1.33.5-eksbuild.2"
+  addon_kube_proxy_version      = "v1.33.10-eksbuild.5"
   addon_guardduty_agent_version = "v1.12.1-eksbuild.2"
 }


### PR DESCRIPTION
## Purpose

kube-proxy log issue is flooding fluentbit/opensearch logging, due to this issue:

https://github.com/aws/containers-roadmap/issues/2519#issuecomment-3817312019

```
topology.go:195] "Ignoring same-zone topology hints for service since no hints were provided for zone" service="10.100.*.*/*TCP" zone="eu-west-2b"
```

`eksctl` version check verifies compatibility for our EKS version:

```
eksctl utils describe-addon-versions --kubernetes-version 1.33 --name kube-proxy | grep AddonVersion
                        "AddonVersions": [
                                        "AddonVersion": "v1.33.10-eksbuild.5",
                                        "AddonVersion": "v1.33.10-eksbuild.2",
                                        "AddonVersion": "v1.33.9-eksbuild.2",
                                        "AddonVersion": "v1.33.8-eksbuild.4",
                                        "AddonVersion": "v1.33.7-eksbuild.2",
                                        "AddonVersion": "v1.33.5-eksbuild.2"
```
