### PR TITLE
feat: bump ingress controller to 3.2.0

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/ingress-default-non-prod.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/ingress-default-non-prod.tf
@@ -1,5 +1,5 @@
 module "non_prod_ingress_controllers_v1" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=3.1.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=3.2.0"
   count  = terraform.workspace == "live" ? 1 : 0
 
   replica_count            = "15"

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/ingress-default.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/ingress-default.tf
@@ -1,5 +1,5 @@
 module "ingress_controllers_v1" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=3.1.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=3.2.0"
 
   replica_count            = terraform.workspace == "live" ? "30" : "3"
   controller_name          = "default"

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/ingress-internal-laa.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/ingress-internal-laa.tf
@@ -1,5 +1,5 @@
 module "ingress_controllers_laa" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=3.1.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=3.2.0"
 
   count = terraform.workspace == "live" ? 1 : 0
 

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/ingress-internal-non-prod.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/ingress-internal-non-prod.tf
@@ -1,5 +1,5 @@
 module "ingress_controllers_internal_non_prod" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=3.1.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=3.2.0"
 
   count = terraform.workspace == "live" ? 1 : 0
 

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/ingress-internal.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/ingress-internal.tf
@@ -1,5 +1,5 @@
 module "ingress_controllers_internal" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=3.1.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=3.2.0"
 
   count = terraform.workspace == "live" ? 1 : 0
 

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/ingress-modsec-non-prod.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/ingress-modsec-non-prod.tf
@@ -1,5 +1,5 @@
 module "non_prod_modsec_ingress_controllers_v1" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=3.1.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=3.2.0"
 
   count = terraform.workspace == "live" ? 1 : 0
 

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/ingress-modsec.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/ingress-modsec.tf
@@ -1,5 +1,5 @@
 module "modsec_ingress_controllers_v1" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=3.1.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-controller?ref=3.2.0"
 
   replica_count            = terraform.workspace == "live" ? "12" : "3"
   controller_name          = "modsec"


### PR DESCRIPTION
## Purpose

- Bumps ingress controller module to 3.2.0 - see [details](https://github.com/ministryofjustice/cloud-platform-terraform-ingress-controller/pull/185) for expected changes