### PR TITLE
chore: 🤖 delete live NEW containment node group

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
@@ -425,53 +425,6 @@ locals {
     ]
   }
 
-  containment_ng_20_04_26 = {
-    desired_size = 3
-    max_size     = 10
-    min_size     = 3
-    block_device_mappings = {
-      xvda = {
-        device_name = "/dev/xvda"
-        ebs = {
-          volume_size           = 140
-          volume_type           = "gp3"
-          iops                  = 0
-          encrypted             = false
-          kms_key_id            = ""
-          delete_on_termination = true
-        }
-      }
-    }
-
-    subnet_ids = data.aws_subnets.eks_private.ids
-    name       = "${terraform.workspace}-containment-ng"
-
-    create_security_group   = false
-    create_launch_template  = true
-    pre_bootstrap_user_data = templatefile("${path.module}/templates/user-data-200426.tpl", {})
-
-    iam_role_additional_policies = ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"]
-    instance_types               = ["r8i.4xlarge", "r7i.4xlarge", "r6i.4xlarge"]
-    labels = {
-      Terraform                                      = "true"
-      "cloud-platform.justice.gov.uk/containment-ng" = "true"
-      Cluster                                        = terraform.workspace
-      Domain                                         = local.fqdn
-    }
-    tags = {
-      containment_ng = "true"
-      application    = "moj-cloud-platform"
-      business-unit  = "platforms"
-    }
-    taints = [
-      {
-        key    = "containment-node"
-        value  = true
-        effect = "NO_SCHEDULE"
-      }
-    ]
-  }
-
   thanos_ng_20_04_26 = {
     desired_size = 1
     max_size     = 1
@@ -531,7 +484,6 @@ locals {
     terraform.workspace == "manager" ? { thanos_ng_10_10_25 = local.thanos_ng_10_10_25 } : {},
     terraform.workspace == "manager" ? { thanos_ng_20_04_26 = local.thanos_ng_20_04_26 } : {},
     terraform.workspace == "live" ? { containment_ng_27_01_26 = local.containment_ng_27_01_26 } : {},
-    terraform.workspace == "live" ? { containment_ng_20_04_26 = local.containment_ng_20_04_26 } : {},
   )
 }
 


### PR DESCRIPTION
## Purpose

Step 1 of CP2 node group stabilisation plan

- Remove the NEW `containment_ng_20_04_26` 

- This node group has been drained back to OLD `containment` ng

- NO-OPs for `live-2` and `manager`

