### PR TITLE
chore: 🤖 delete NEW default node group

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
@@ -333,51 +333,6 @@ locals {
   }
 
   # New node groups
-
-  default_ng_20_04_26 = {
-    desired_size = lookup(local.upgrade_desired_size, terraform.workspace, local.upgrade_desired_size["default"])
-    max_size     = lookup(local.temp_ng_20_04_26_max_size, terraform.workspace, local.temp_ng_20_04_26_max_size["default"])
-    min_size     = lookup(local.temp_ng_20_04_26_min_size, terraform.workspace, local.temp_ng_20_04_26_min_size["default"])
-
-    block_device_mappings = {
-      xvda = {
-        device_name = "/dev/xvda"
-        ebs = {
-          volume_size           = 200
-          volume_type           = "gp3"
-          iops                  = 0
-          encrypted             = false
-          kms_key_id            = ""
-          delete_on_termination = true
-        }
-      }
-    }
-
-    subnet_ids = data.aws_subnets.eks_private.ids
-    name       = "${terraform.workspace}-def-ng"
-
-    create_security_group  = false
-    create_launch_template = true
-
-    pre_bootstrap_user_data = templatefile("${path.module}/templates/user-data-200426.tpl", {})
-
-    iam_role_additional_policies = ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"]
-
-    instance_types = lookup(local.node_size, terraform.workspace, local.node_size["default"])
-    labels = {
-      Terraform                                  = "true"
-      "cloud-platform.justice.gov.uk/default-ng" = "true"
-      Cluster                                    = terraform.workspace
-      Domain                                     = local.fqdn
-    }
-
-    tags = {
-      default_ng    = "true"
-      application   = "moj-cloud-platform"
-      business-unit = "platforms"
-    }
-  }
-
   monitoring_ng_20_04_26 = {
     desired_size = lookup(local.upgrade_desired_size, terraform.workspace, local.upgrade_desired_size["default"])
     max_size     = lookup(local.upgrade_max_size, terraform.workspace, local.upgrade_max_size["default"])
@@ -477,7 +432,6 @@ locals {
   eks_managed_node_groups = merge(
     {
       default_ng_10_12_25    = local.default_ng_10_12_25,
-      default_ng_20_04_26    = local.default_ng_20_04_26,
       monitoring_ng_10_10_25 = local.monitoring_ng_10_10_25,
       monitoring_ng_20_04_26 = local.monitoring_ng_20_04_26,
     },


### PR DESCRIPTION
## Purpose

Step 3 of CP2 node group stabilisation plan

- NEW `default` ng are all drained back to OLD default ng on `live/manager/live-2`
- delete NEW `default` nodegroup