### PR TITLE
chore: 🤖 remove NEW monitoring and thanos nodegroups

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
@@ -82,7 +82,7 @@ locals {
   }
 
   temp_min_size = {
-    live    = "100"
+    live    = "85"
     live-2  = "3"
     manager = "7" # To accommodate concourse worker pods anti-affinity rules
     default = "2"
@@ -332,111 +332,12 @@ locals {
     ]
   }
 
-  # Remaining node groups to drain in manager and live-2 clusters 07/05/2026
-  monitoring_ng_20_04_26 = {
-    desired_size = lookup(local.upgrade_desired_size, terraform.workspace, local.upgrade_desired_size["default"])
-    max_size     = lookup(local.upgrade_max_size, terraform.workspace, local.upgrade_max_size["default"])
-    min_size     = lookup(local.upgrade_min_size, terraform.workspace, local.upgrade_min_size["default"])
-    block_device_mappings = {
-      xvda = {
-        device_name = "/dev/xvda"
-        ebs = {
-          volume_size           = 140
-          volume_type           = "gp3"
-          iops                  = 0
-          encrypted             = false
-          kms_key_id            = ""
-          delete_on_termination = true
-        }
-      }
-    }
-
-    subnet_ids = data.aws_subnets.eks_private.ids
-    name       = "${terraform.workspace}-mon-ng"
-
-    create_security_group   = false
-    create_launch_template  = true
-    pre_bootstrap_user_data = templatefile("${path.module}/templates/user-data-200426.tpl", {})
-
-    iam_role_additional_policies = ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"]
-    instance_types               = lookup(local.monitoring_node_size, terraform.workspace, local.monitoring_node_size["default"])
-    labels = {
-      Terraform                                     = "true"
-      "cloud-platform.justice.gov.uk/monitoring-ng" = "true"
-      Cluster                                       = terraform.workspace
-      Domain                                        = local.fqdn
-    }
-    tags = {
-      monitoring_ng = "true"
-      application   = "moj-cloud-platform"
-      business-unit = "platforms"
-    }
-    taints = [
-      {
-        key    = "monitoring-node"
-        value  = true
-        effect = "NO_SCHEDULE"
-      }
-    ]
-  }
-
-  thanos_ng_20_04_26 = {
-    desired_size = 1
-    max_size     = 1
-    min_size     = 1
-    block_device_mappings = {
-      xvda = {
-        device_name = "/dev/xvda"
-        ebs = {
-          volume_size           = 400
-          volume_type           = "gp3"
-          iops                  = 6000
-          throughput            = 300
-          encrypted             = false
-          kms_key_id            = ""
-          delete_on_termination = true
-        }
-      }
-    }
-
-    subnet_ids = data.aws_subnets.thanos_nodegroup_az.ids
-    name       = "${terraform.workspace}-thanos-ng"
-
-    create_security_group   = false
-    create_launch_template  = true
-    pre_bootstrap_user_data = templatefile("${path.module}/templates/user-data-200426.tpl", {})
-
-    iam_role_additional_policies = ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"]
-    instance_types               = lookup(local.thanos_node_size, terraform.workspace, local.thanos_node_size["default"])
-    labels = {
-      "topology.kubernetes.io/zone"             = "eu-west-2a"
-      Terraform                                 = "true"
-      "cloud-platform.justice.gov.uk/thanos-ng" = "true"
-      Cluster                                   = terraform.workspace
-      Domain                                    = local.fqdn
-    }
-    tags = {
-      monitoring_ng = "true"
-      application   = "moj-cloud-platform"
-      business-unit = "platforms"
-    }
-    taints = [
-      {
-        key    = "thanos-node"
-        value  = true
-        effect = "NO_SCHEDULE"
-      }
-    ]
-  }
-
   eks_managed_node_groups = merge(
     {
       default_ng_10_12_25    = local.default_ng_10_12_25,
       monitoring_ng_10_10_25 = local.monitoring_ng_10_10_25,
-      monitoring_ng_20_04_26 = local.monitoring_ng_20_04_26,
     },
     terraform.workspace == "manager" ? { thanos_ng_10_10_25 = local.thanos_ng_10_10_25 } : {},
-    terraform.workspace == "manager" ? { thanos_ng_20_04_26 = local.thanos_ng_20_04_26 } : {},
     terraform.workspace == "live" ? { containment_ng_27_01_26 = local.containment_ng_27_01_26 } : {},
   )
 }


### PR DESCRIPTION
## Purpose

PR covering Steps 4, 5 and 6 from node group stabilisation plan 

NOTE:
these nodegroup workloads are now all restored back to the old nodegroups, safe to remove