### PR TITLE
Depends on all the things

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
@@ -23,7 +23,7 @@ locals {
     live    = "85"
     live-2  = "7"
     manager = "4"
-    default = "3"
+    default = "5"
   }
 
   # Default node group minimum capacity

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/kuberos.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/kuberos.tf
@@ -12,6 +12,7 @@ module "kuberos" {
   depends_on = [
     module.ingress_controllers_v1,
     module.modsec_ingress_controllers_v1,
-    module.non_prod_ingress_controllers_v1
+    module.non_prod_ingress_controllers_v1,
+    module.modsec_ingress_controllers_validator
   ]
 }

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/monitoring.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/monitoring.tf
@@ -33,6 +33,8 @@ module "monitoring" {
 
   depends_on = [
     module.ingress_controllers_v1,
-    module.modsec_ingress_controllers_v1
+    module.modsec_ingress_controllers_v1,
+    module.default_ingress_controllers_validator,
+    module.modsec_ingress_controllers_validator
   ]
 }

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/starter_pack.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/starter_pack.tf
@@ -6,6 +6,8 @@ module "starter_pack" {
 
   depends_on = [
     module.ingress_controllers_v1,
-    module.modsec_ingress_controllers_v1
+    module.modsec_ingress_controllers_v1,
+    module.internal_ingress_controllers_validator,
+    module.modsec_ingress_controllers_validator
   ]
 }


### PR DESCRIPTION
## Purpose

- Fixes issues with helm charts not provisioning due to correct certs not being in place by adding even more `depends_on`
- Adds 2 extra default nodes to the default node group to prevent pvc issues with redis

## What to expect

- No changes at cluster level
- No changes at core level
- No changes at component level