### PR TITLE
chore: 🤖 add explicit config for alekc kubectl provider

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/providers.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/providers.tf
@@ -33,3 +33,13 @@ provider "helm" {
     }
   }
 }
+
+provider "kubectl" {
+  host                   = data.aws_eks_cluster.cluster.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority[0].data)
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    args        = ["eks", "get-token", "--cluster-name", data.aws_eks_cluster.cluster.name]
+    command     = "aws"
+  }
+}


### PR DESCRIPTION
## Purpose

Bring `kubectl` provider in line with `helm` and `kubernetes` providers, calling AWS API via `exec` block.

This might fix our k8s manifest teardowns, and if not gives us the option to pass a [retry](https://registry.terraform.io/providers/alekc/kubectl/2.1.3/docs#retry-support) argument as a follow up.

relates to ministryofjustice/cloud-platform#8206