### PR TITLE
chore: 🤖 explicit config for alekc kubectl provider components

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/providers.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/providers.tf
@@ -1,0 +1,40 @@
+provider "aws" {
+  region = "eu-west-2"
+
+  default_tags {
+    tags = local.default_tags
+  }
+}
+
+provider "kubernetes" {
+  host                   = data.aws_eks_cluster.cluster.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority[0].data)
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    args        = ["eks", "get-token", "--cluster-name", data.aws_eks_cluster.cluster.name]
+    command     = "aws"
+  }
+}
+
+
+provider "helm" {
+  kubernetes = {
+    host                   = data.aws_eks_cluster.cluster.endpoint
+    cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority[0].data)
+    exec = {
+      api_version = "client.authentication.k8s.io/v1beta1"
+      args        = ["eks", "get-token", "--cluster-name", data.aws_eks_cluster.cluster.name]
+      command     = "aws"
+    }
+  }
+}
+
+provider "kubectl" {
+  host                   = data.aws_eks_cluster.cluster.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority[0].data)
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    args        = ["eks", "get-token", "--cluster-name", data.aws_eks_cluster.cluster.name]
+    command     = "aws"
+  }
+}


### PR DESCRIPTION
## Purpose

As per this [core level PR](https://github.com/ministryofjustice/cloud-platform-infrastructure/pull/4628) set `kubectl` provider config explicitly.

Also shift provider blocks to separate file to match `core` `tf` file pattern.
