### PR TITLE
fix: 🐛 update issuer check condition on staging cert verify

### DIFF
--- a/.github/workflows/go-vet-lint-deps.yaml
+++ b/.github/workflows/go-vet-lint-deps.yaml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Install gofumpt
         run: |
-          go install mvdan.cc/gofumpt@latest
+          go install mvdan.cc/gofumpt@v0.9.2
 
       - name: Run gofumpt command
         run: |

--- a/test/certmanager_test.go
+++ b/test/certmanager_test.go
@@ -70,9 +70,7 @@ var _ = Describe("cert-manager", FlakeAttempts(2), func() {
 			namespace, host string
 			options         *k8s.KubectlOptions
 
-			err  error
-			cert []string
-			conn *tls.Conn
+			err error
 		)
 
 		BeforeEach(func() {
@@ -112,11 +110,16 @@ var _ = Describe("cert-manager", FlakeAttempts(2), func() {
 		})
 
 		It("should succeed and present a staging certificate", func() {
-			conn, err = tls.Dial("tcp", host+":443", &tls.Config{InsecureSkipVerify: true})
-			Expect(err).NotTo(HaveOccurred())
-			cert = conn.ConnectionState().PeerCertificates[0].Issuer.Organization
+			Eventually(func() (string, error) {
+				conn, err := tls.Dial("tcp", host+":443", &tls.Config{InsecureSkipVerify: true})
+				if err != nil {
+					return "", err
+				}
+				defer conn.Close()
+				issuer := conn.ConnectionState().PeerCertificates[0].Issuer
 
-			Eventually(cert[0]).WithTimeout(5 * time.Minute).WithPolling(30 * time.Second).Should(Equal("(STAGING) Let's Encrypt"))
+				return issuer.CommonName, nil
+			}).WithTimeout(5 * time.Minute).WithPolling(30 * time.Second).Should(ContainSubstring("(STAGING)"))
 		})
 	})
 })


### PR DESCRIPTION
## Purpose

Update successful staging cert issue with lookup on `CN` instead of Org, and look for `STAGING` substring for looser checking.

LetsEncrypt staging issuing has seen some changes rolling out since late last year re Root / intermediate CA Gens:
https://letsencrypt.org/2025/11/24/gen-y-hierarchy.html

On checking these now with a static hostname using staging cert we get this:

```
openssl s_client -connect smoketest-certman-7qqmpx.integrationtest.service.justice.gov.uk:443 -servername smoketest-certman-7qqmpx.integrationtest.service.justice.gov.uk 2>/dev/null | openssl x509 -noout -issuer
issuer=C=US, O=Let's Encrypt, CN=(STAGING) Dastardly Durum YR1
```

This update passes the validation immediately upon the issued Cert object evaluating to `TRUE`


## Other

Pin `gofumpt` binary in golang workflow to `0.9.2` - [new release two weeks back](https://github.com/mvdan/gofumpt/releases/tag/v0.10.0) breaks compatibility with go `1.24` - review this later possibly for a `1.25` bump