### PR TITLE
chore: 🤖 fetch GH token for authenticated tflint init call

### DIFF
--- a/.github/workflows/terraform-tools.yml
+++ b/.github/workflows/terraform-tools.yml
@@ -22,6 +22,8 @@ jobs:
       - run: tflint --version
       - run: tflint --init
       - run: tflint -f compact --recursive -c $(realpath .tflint.hcl)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   tfsec:
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
to circumvent this action triggering rate limit exceeded issues from GH runner ips