### PR TITLE
chore: 🤖 update vpc-cni to latest eks 1.33 release

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
@@ -403,7 +403,7 @@ module "aws_eks_addons" {
   cluster_oidc_issuer_url = replace(module.eks.cluster_oidc_issuer_url, "https://", "")
   addon_tags              = local.tags
 
-  addon_vpc_cni_version         = "v1.20.5-eksbuild.1"
+  addon_vpc_cni_version         = "v1.21.1-eksbuild.8"
   addon_coredns_version         = "v1.12.4-eksbuild.1"
   addon_kube_proxy_version      = "v1.33.10-eksbuild.5"
   addon_guardduty_agent_version = "v1.12.1-eksbuild.2"


### PR DESCRIPTION
## Purpose

Latest release of vpc-cni add-on:

```
eksctl utils describe-addon-versions --kubernetes-version 1.33 --name vpc-cni | grep AddonVersion
			"AddonVersions": [
					"AddonVersion": "v1.21.1-eksbuild.8",
					"AddonVersion": "v1.21.1-eksbuild.7",
					"AddonVersion": "v1.21.1-eksbuild.5",
...
...
```

- all int tests passing