### PR TITLE
chore: 🤖 bump cert-manager module for 1.19.4 upgrade

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/cert_manager.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/cert_manager.tf
@@ -1,5 +1,5 @@
 module "cert_manager" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-certmanager?ref=1.18.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-certmanager?ref=1.19.0"
 
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   hostzone            = lookup(local.hostzones, terraform.workspace, local.hostzones["default"])


### PR DESCRIPTION
## Purpose

Brings us in line with supported release. Provides k8s test coverage up to and inc 1.35.

## Cert-man release notes
https://cert-manager.io/docs/releases/

## Module release
https://github.com/ministryofjustice/cloud-platform-terraform-certmanager/releases/tag/1.19.0

## Notes
https://cert-manager.io/docs/releases/upgrading/upgrading-1.18-1.19
