### PR TITLE
chore: 🤖 bump ebs-csi-driver module

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/eks-csi.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/eks-csi.tf
@@ -1,4 +1,4 @@
 module "eks_csi" {
-  source      = "github.com/ministryofjustice/cloud-platform-terraform-eks-csi?ref=1.2.2"
+  source      = "github.com/ministryofjustice/cloud-platform-terraform-eks-csi?ref=1.3.0"
   eks_cluster = terraform.workspace
 }


### PR DESCRIPTION
## Purpose

Bump `ebs-csi-driver` Helm with app release upgrade to `v1.59.0`

[Release notes](https://github.com/ministryofjustice/cloud-platform-terraform-eks-csi/releases/tag/1.3.0)

relates to ministryofjustice/cloud-platform#8262