### PR TITLE
upgraded guardduty to v1.15.0-eksbuild.2 for eks 1.33

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
@@ -406,5 +406,5 @@ module "aws_eks_addons" {
   addon_vpc_cni_version         = "v1.21.1-eksbuild.8"
   addon_coredns_version         = "v1.13.2-eksbuild.7"
   addon_kube_proxy_version      = "v1.33.10-eksbuild.5"
-  addon_guardduty_agent_version = "v1.12.1-eksbuild.2"
+  addon_guardduty_agent_version = "v1.15.0-eksbuild.2"
 }


### PR DESCRIPTION
https://github.com/orgs/ministryofjustice/projects/65/views/43?pane=issue&itemId=189424679&issue=ministryofjustice%7Ccloud-platform%7C8262

Updating EKS add-on guardduty agent to latest version:-
eksctl utils describe-addon-versions --kubernetes-version 1.33 --name aws-guardduty-agent | grep AddonVersion
			"AddonVersions": [
					"AddonVersion": "**v1.15.0-eksbuild.2**",
					"AddonVersion": "v1.15.0-eksbuild.1",
					"AddonVersion": "v1.12.2-eksbuild.2",
					"AddonVersion": "v1.12.2-eksbuild.1",
					"AddonVersion": "v1.12.1-eksbuild.4",
					"AddonVersion": "v1.12.1-eksbuild.3",
					"AddonVersion": "v1.12.1-eksbuild.2",
					"AddonVersion": "v1.12.1-eksbuild.1",
					"AddonVersion": "v1.11.0-eksbuild.4",
					"AddonVersion": "v1.11.0-eksbuild.3",
					"AddonVersion": "v1.11.0-eksbuild.2",
					"AddonVersion": "v1.11.0-eksbuild.1",
					"AddonVersion": "v1.10.0-eksbuild.2",
					"AddonVersion": "v1.10.0-eksbuild.1",
