### PR TITLE
Block inbound traffic from single IP address

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/public-nacl-rules.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/public-nacl-rules.tf
@@ -1,16 +1,16 @@
 /// The following are placeholders to create network ACL deny rules for the public subnet to stop traffic to and from the EKS cluster boundary.
 /// Please view the runbook for more information: https://runbooks.cloud-platform.service.justice.gov.uk/block-public-ip-address.html
 
-#resource "aws_network_acl_rule" "deny_inbound_1" {
-#  network_acl_id = module.vpc.public_network_acl_id
-#  rule_number    = 10
-#  egress         = false
-#  protocol       = "-1" # -1 means all protocols
-#  rule_action    = "deny"
-#  cidr_block     = "##.##.##.##/32"
-#  from_port      = 0
-#  to_port        = 0
-#}
+resource "aws_network_acl_rule" "deny_inbound_1" {
+  network_acl_id = module.vpc.public_network_acl_id
+  rule_number    = 10
+  egress         = false
+  protocol       = "-1" # -1 means all protocols
+  rule_action    = "deny"
+  cidr_block     = "157.245.197.40/32"
+  from_port      = 0
+  to_port        = 0
+}
 
 # resource "aws_network_acl_rule" "deny_outbound_1" {
 #   network_acl_id = module.vpc.public_network_acl_id


### PR DESCRIPTION
Updated the public NACL rules to include a specific CIDR block for inbound traffic denial.

See slack: https://mojdt.slack.com/archives/C57UPMZLY/p1779441728743419