### PR TITLE
feat: 🎸 provision all new node groups pre upgrade

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
@@ -131,6 +131,53 @@ locals {
     }
   }
 
+    # TEMP: Hardcoded node counts to be amended post recycle
+    default_ng_19_06_26 = {
+    desired_size = 5
+    max_size     = 150
+    min_size     = 2
+
+    block_device_mappings = {
+      xvda = {
+        device_name = "/dev/xvda"
+        ebs = {
+          volume_size           = 200
+          volume_type           = "gp3"
+          iops                  = 0
+          encrypted             = false
+          kms_key_id            = ""
+          delete_on_termination = true
+        }
+      }
+    }
+
+    subnet_ids = data.aws_subnets.eks_private.ids
+    name       = "${terraform.workspace}-def-ng"
+
+    create_security_group  = false
+    create_launch_template = true
+
+    pre_bootstrap_user_data = templatefile("${path.module}/templates/user-data-200426.tpl", {
+      dockerhub_credentials = local.dockerhub_credentials
+    })
+
+    iam_role_additional_policies = ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"]
+
+    instance_types = lookup(local.node_size, terraform.workspace, local.node_size["default"])
+    labels = {
+      Terraform                                  = "true"
+      "cloud-platform.justice.gov.uk/default-ng" = "true"
+      Cluster                                    = terraform.workspace
+      Domain                                     = local.fqdn
+    }
+
+    tags = {
+      default_ng    = "true"
+      application   = "moj-cloud-platform"
+      business-unit = "platforms"
+    }
+  }
+
   monitoring_ng_10_10_25 = {
     desired_size = lookup(local.default_mon_desired_count, terraform.workspace, local.default_mon_desired_count["default"])
     max_size     = 6
@@ -180,6 +227,55 @@ locals {
     ]
   }
 
+    monitoring_ng_19_06_26 = {
+    desired_size = lookup(local.default_mon_desired_count, terraform.workspace, local.default_mon_desired_count["default"])
+    max_size     = 6
+    min_size     = lookup(local.default_mon_min_count, terraform.workspace, local.default_mon_min_count["default"])
+    block_device_mappings = {
+      xvda = {
+        device_name = "/dev/xvda"
+        ebs = {
+          volume_size           = 140
+          volume_type           = "gp3"
+          iops                  = 0
+          encrypted             = false
+          kms_key_id            = ""
+          delete_on_termination = true
+        }
+      }
+    }
+
+    subnet_ids = data.aws_subnets.eks_private.ids
+    name       = "${terraform.workspace}-mon-ng"
+
+    create_security_group  = false
+    create_launch_template = true
+    pre_bootstrap_user_data = templatefile("${path.module}/templates/user-data-200426.tpl", {
+      dockerhub_credentials = local.dockerhub_credentials
+    })
+
+    iam_role_additional_policies = ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"]
+    instance_types               = lookup(local.monitoring_node_size, terraform.workspace, local.monitoring_node_size["default"])
+    labels = {
+      Terraform                                     = "true"
+      "cloud-platform.justice.gov.uk/monitoring-ng" = "true"
+      Cluster                                       = terraform.workspace
+      Domain                                        = local.fqdn
+    }
+    tags = {
+      monitoring_ng = "true"
+      application   = "moj-cloud-platform"
+      business-unit = "platforms"
+    }
+    taints = [
+      {
+        key    = "monitoring-node"
+        value  = true
+        effect = "NO_SCHEDULE"
+      }
+    ]
+  }
+
   containment_ng_27_01_26 = {
     desired_size = 6
     max_size     = 10
@@ -204,6 +300,55 @@ locals {
     create_security_group  = false
     create_launch_template = true
     pre_bootstrap_user_data = templatefile("${path.module}/templates/user-data-101025.tpl", {
+      dockerhub_credentials = local.dockerhub_credentials
+    })
+
+    iam_role_additional_policies = ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"]
+    instance_types               = ["r8i.4xlarge", "r7i.4xlarge", "r6i.4xlarge"]
+    labels = {
+      Terraform                                      = "true"
+      "cloud-platform.justice.gov.uk/containment-ng" = "true"
+      Cluster                                        = terraform.workspace
+      Domain                                         = local.fqdn
+    }
+    tags = {
+      containment_ng = "true"
+      application    = "moj-cloud-platform"
+      business-unit  = "platforms"
+    }
+    taints = [
+      {
+        key    = "containment-node"
+        value  = true
+        effect = "NO_SCHEDULE"
+      }
+    ]
+  }
+
+    containment_ng_19_06_26 = {
+    desired_size = 6
+    max_size     = 10
+    min_size     = 3
+    block_device_mappings = {
+      xvda = {
+        device_name = "/dev/xvda"
+        ebs = {
+          volume_size           = 140
+          volume_type           = "gp3"
+          iops                  = 0
+          encrypted             = false
+          kms_key_id            = ""
+          delete_on_termination = true
+        }
+      }
+    }
+
+    subnet_ids = data.aws_subnets.eks_private.ids
+    name       = "${terraform.workspace}-containment-ng"
+
+    create_security_group  = false
+    create_launch_template = true
+    pre_bootstrap_user_data = templatefile("${path.module}/templates/user-data-200426.tpl", {
       dockerhub_credentials = local.dockerhub_credentials
     })
 
@@ -280,13 +425,66 @@ locals {
     ]
   }
 
+    thanos_ng_19_06_26 = {
+    desired_size = 1
+    max_size     = 1
+    min_size     = 1
+    block_device_mappings = {
+      xvda = {
+        device_name = "/dev/xvda"
+        ebs = {
+          volume_size           = 400
+          volume_type           = "gp3"
+          iops                  = 6000
+          throughput            = 300
+          encrypted             = false
+          kms_key_id            = ""
+          delete_on_termination = true
+        }
+      }
+    }
+
+    subnet_ids = data.aws_subnets.thanos_nodegroup_az.ids
+    name       = "${terraform.workspace}-thanos-ng"
+
+    create_security_group  = false
+    create_launch_template = true
+    pre_bootstrap_user_data = templatefile("${path.module}/templates/user-data-200426.tpl", {
+      dockerhub_credentials = local.dockerhub_credentials
+    })
+
+    iam_role_additional_policies = ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"]
+    instance_types               = lookup(local.thanos_node_size, terraform.workspace, local.thanos_node_size["default"])
+    labels = {
+      "topology.kubernetes.io/zone"             = "eu-west-2a"
+      Terraform                                 = "true"
+      "cloud-platform.justice.gov.uk/thanos-ng" = "true"
+      Cluster                                   = terraform.workspace
+      Domain                                    = local.fqdn
+    }
+    tags = {
+      monitoring_ng = "true"
+      application   = "moj-cloud-platform"
+      business-unit = "platforms"
+    }
+    taints = [
+      {
+        key    = "thanos-node"
+        value  = true
+        effect = "NO_SCHEDULE"
+      }
+    ]
+  }
+
   eks_managed_node_groups = merge(
     {
       default_ng_10_12_25    = local.default_ng_10_12_25,
+      default_ng_19_06_26    = local.default_ng_19_06_26,
       monitoring_ng_10_10_25 = local.monitoring_ng_10_10_25,
+      monitoring_ng_19_06_26 = local.monitoring_ng_19_06_26,
     },
-    terraform.workspace == "manager" ? { thanos_ng_10_10_25 = local.thanos_ng_10_10_25 } : {},
-    terraform.workspace == "live" ? { containment_ng_27_01_26 = local.containment_ng_27_01_26 } : {},
+    terraform.workspace == "manager" ? { thanos_ng_10_10_25 = local.thanos_ng_10_10_25, thanos_ng_19_06_26 = local.thanos_ng_19_06_26 } : {},
+    terraform.workspace == "live" ? { containment_ng_27_01_26 = local.containment_ng_27_01_26, containment_ng_19_06_26 = local.containment_ng_19_06_26 } : {},
   )
 }
 

--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
@@ -131,8 +131,8 @@ locals {
     }
   }
 
-    # TEMP: Hardcoded node counts to be amended post recycle
-    default_ng_19_06_26 = {
+  # TEMP: Hardcoded node counts to be amended post recycle
+  default_ng_19_06_26 = {
     desired_size = 5
     max_size     = 150
     min_size     = 2
@@ -227,7 +227,7 @@ locals {
     ]
   }
 
-    monitoring_ng_19_06_26 = {
+  monitoring_ng_19_06_26 = {
     desired_size = lookup(local.default_mon_desired_count, terraform.workspace, local.default_mon_desired_count["default"])
     max_size     = 6
     min_size     = lookup(local.default_mon_min_count, terraform.workspace, local.default_mon_min_count["default"])
@@ -325,7 +325,7 @@ locals {
     ]
   }
 
-    containment_ng_19_06_26 = {
+  containment_ng_19_06_26 = {
     desired_size = 6
     max_size     = 10
     min_size     = 3
@@ -425,7 +425,7 @@ locals {
     ]
   }
 
-    thanos_ng_19_06_26 = {
+  thanos_ng_19_06_26 = {
     desired_size = 1
     max_size     = 1
     min_size     = 1


### PR DESCRIPTION
## Purpose

- new node group configurations for all production CP2 cluster node group variants
- utilise new launch template with aws SSM param store sourced dockerhub credentials
- hardcoded `default` node group count for initial deployment, to be amended post recycle

relates to ministryofjustice/cloud-platform#8298