### PR TITLE
chore: 🤖 bump cert-manager module

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/cert_manager.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/cert_manager.tf
@@ -1,5 +1,5 @@
 module "cert_manager" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-certmanager?ref=1.19.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-certmanager?ref=1.20.0"
 
   cluster_domain_name = data.terraform_remote_state.cluster.outputs.cluster_domain_name
   hostzone            = lookup(local.hostzones, terraform.workspace, local.hostzones["default"])


### PR DESCRIPTION
## Purpose

- upgrade cert-manager module to latest release

[Release notes](https://github.com/ministryofjustice/cloud-platform-terraform-certmanager/releases/tag/1.20.0)