### PR TITLE
upgraded coredns to v1.13.2-eksbuild.11 for eks 1.33

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
@@ -404,7 +404,7 @@ module "aws_eks_addons" {
   addon_tags              = local.tags
 
   addon_vpc_cni_version         = "v1.21.1-eksbuild.8"
-  addon_coredns_version         = "v1.13.2-eksbuild.7"
+  addon_coredns_version         = "v1.13.2-eksbuild.11"
   addon_kube_proxy_version      = "v1.33.10-eksbuild.5"
   addon_guardduty_agent_version = "v1.15.0-eksbuild.2"
 }


### PR DESCRIPTION
Upgrade coredns from v1.13.2-eksbuild.7 to v1.13.2-eksbuild.11 as per ticket 
https://github.com/orgs/ministryofjustice/projects/65/views/43?pane=issue&itemId=207736524&issue=ministryofjustice%7Ccloud-platform%7C8349