### PR TITLE
update vpc-cni to v1.22.3-eksbuild.1 for eks 1.33

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
@@ -403,7 +403,7 @@ module "aws_eks_addons" {
   cluster_oidc_issuer_url = replace(module.eks.cluster_oidc_issuer_url, "https://", "")
   addon_tags              = local.tags
 
-  addon_vpc_cni_version         = "v1.21.1-eksbuild.8"
+  addon_vpc_cni_version         = "v1.22.3-eksbuild.1"
   addon_coredns_version         = "v1.13.2-eksbuild.11"
   addon_kube_proxy_version      = "v1.33.10-eksbuild.13"
   addon_guardduty_agent_version = "v1.15.0-eksbuild.2"


### PR DESCRIPTION
Update eks add-on vpc-cni from v1.21.1-eksbuild.8 to v1.22.3-eksbuild.1 for EKS 1.33, as per ticket:-

https://github.com/orgs/ministryofjustice/projects/65/views/43?pane=issue&itemId=207736518&issue=ministryofjustice%7Ccloud-platform%7C8347

