### PR TITLE
Update ingress validation controller version to 0.1.1

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/ingress-default.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/ingress-default.tf
@@ -25,7 +25,7 @@ module "ingress_controllers_v1" {
 }
 
 module "default_ingress_controllers_validator" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-validation-controller?ref=0.1.0"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-validation-controller?ref=0.1.1"
 
   replica_count      = "6"
   controller_name    = "default"


### PR DESCRIPTION
Brings in default CPU requests = 3 , limit = 6