### PR TITLE
feat: limit number of ingress validators on non live cluster

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/ingress-default.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/ingress-default.tf
@@ -27,7 +27,7 @@ module "ingress_controllers_v1" {
 module "default_ingress_controllers_validator" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-ingress-validation-controller?ref=0.1.1"
 
-  replica_count      = "6"
+  replica_count      = terraform.workspace == "live" ? "6" : "3"
   controller_name    = "default"
   memory_requests    = "3Gi"
   memory_limits      = "4Gi"


### PR DESCRIPTION
## Purpose

- Our test clusters don't have enough nodes to run 6 validators by default, defaulting to 3 on none live clusters.