### PR TITLE
upgrade kube-proxy addon post eks upgrade

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
@@ -405,6 +405,6 @@ module "aws_eks_addons" {
 
   addon_vpc_cni_version         = "v1.22.3-eksbuild.1"
   addon_coredns_version         = "v1.13.2-eksbuild.11"
-  addon_kube_proxy_version      = "v1.33.10-eksbuild.13"
+  addon_kube_proxy_version      = "v1.34.6-eksbuild.17"
   addon_guardduty_agent_version = "v1.15.0-eksbuild.2"
 }


### PR DESCRIPTION
Pr to update the kube-proxy addon post eks upgrade to 1.34 as per this issue https://github.com/orgs/ministryofjustice/projects/65/views/43?pane=issue&itemId=207736554&issue=ministryofjustice%7Ccloud-platform%7C8354

This change has been tested on a custom build cluster with a green integration test run https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/custom-cluster/jobs/custom-integration-tests/builds/213