### PR TITLE
bump cluster autoscaler to new module ref

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/cluster_autoscaler.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/cluster_autoscaler.tf
@@ -1,5 +1,5 @@
 module "cluster_autoscaler" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-cluster-autoscaler?ref=1.15.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-cluster-autoscaler?ref=1.15.2"
 
   enable_overprovision        = lookup(local.prod_workspace, terraform.workspace, false)
   cluster_domain_name         = data.terraform_remote_state.cluster.outputs.cluster_domain_name


### PR DESCRIPTION
bump to cluster autoscaler as per this issue https://github.com/ministryofjustice/cloud-platform/issues/8358

release notes https://github.com/ministryofjustice/cloud-platform-terraform-cluster-autoscaler/releases/tag/1.15.2