### PR TITLE
upgraded aws-guardduty agent to v1.16.0-eksbuild.2 for eks 1.34

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/cluster.tf
@@ -406,5 +406,5 @@ module "aws_eks_addons" {
   addon_vpc_cni_version         = "v1.22.3-eksbuild.1"
   addon_coredns_version         = "v1.13.2-eksbuild.11"
   addon_kube_proxy_version      = "v1.34.6-eksbuild.17"
-  addon_guardduty_agent_version = "v1.15.0-eksbuild.2"
+  addon_guardduty_agent_version = "v1.16.0-eksbuild.2"
 }


### PR DESCRIPTION
aws-guardduty agent update to the latest current version on EKS 1.34 as detailed in post EKS upgrade ticket https://github.com/orgs/ministryofjustice/projects/65/views/43?pane=issue&itemId=218998724&issue=ministryofjustice%7Ccloud-platform%7C8404

update completed on cluster cp-2907-0757

integration test completed successfully
https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/custom-cluster/jobs/custom-integration-tests/builds/216
