### PR TITLE
chore: remove deny rules

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/public-nacl-rules.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/public-nacl-rules.tf
@@ -12,28 +12,6 @@
 #  to_port        = 0
 #}
 
-resource "aws_network_acl_rule" "deny_inbound_14" {
-  network_acl_id = module.vpc.public_network_acl_id
-  rule_number    = 14
-  egress         = false
-  protocol       = "-1" # -1 means all protocols
-  rule_action    = "deny"
-  cidr_block     = "20.198.114.210/32"
-  from_port      = 0
-  to_port        = 0
-}
-
-resource "aws_network_acl_rule" "deny_inbound_15" {
-  network_acl_id = module.vpc.public_network_acl_id
-  rule_number    = 15
-  egress         = false
-  protocol       = "-1" # -1 means all protocols
-  rule_action    = "deny"
-  cidr_block     = "20.219.1.235/32"
-  from_port      = 0
-  to_port        = 0
-}
-
 # resource "aws_network_acl_rule" "deny_outbound_1" {
 #   network_acl_id = module.vpc.public_network_acl_id
 #   rule_number    = 10


### PR DESCRIPTION
The standard 1 week deny period recommended by SOC elapsed today. Unblocking these IPs then monitor activity afterwards.

Reverts https://github.com/ministryofjustice/cloud-platform-infrastructure/pull/4684