### PR TITLE
Fix job smoketests wait on pod phase

### DIFF
--- a/test/helpers/jobs.go
+++ b/test/helpers/jobs.go
@@ -17,7 +17,7 @@ import (
 // It deliberately asserts on the pod's terminal phase (set by the kubelet the
 // moment the container exits 0) rather than the Job's Complete condition. The
 // Job condition is written by the job controller in kube-controller-manager,
-// whose finalizer-removal / status reconciliation can lag well beyond the wait
+// whose finalizer-removal/status reconciliation can lag well beyond the wait
 // budget on the cluster control plane, producing false test timeouts even though
 // the workload itself succeeded.
 func WaitForJobPodToSucceed(t testing.TestingT, options *k8s.KubectlOptions, jobName string, retries int, sleepBetweenRetries time.Duration) error {

--- a/test/helpers/jobs.go
+++ b/test/helpers/jobs.go
@@ -1,0 +1,37 @@
+package helpers
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/testing"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// WaitForJobPodToSucceed polls the pods created by the named Job (matched on the
+// batch.kubernetes.io/job-name label) until one reaches the Succeeded phase, or
+// the retry budget is exhausted.
+//
+// It deliberately asserts on the pod's terminal phase (set by the kubelet the
+// moment the container exits 0) rather than the Job's Complete condition. The
+// Job condition is written by the job controller in kube-controller-manager,
+// whose finalizer-removal / status reconciliation can lag well beyond the wait
+// budget on the cluster control plane, producing false test timeouts even though
+// the workload itself succeeded.
+func WaitForJobPodToSucceed(t testing.TestingT, options *k8s.KubectlOptions, jobName string, retries int, sleepBetweenRetries time.Duration) error {
+	filters := metav1.ListOptions{LabelSelector: "batch.kubernetes.io/job-name=" + jobName}
+	for i := 0; i < retries; i++ {
+		pods, err := k8s.ListPodsE(t, options, filters)
+		if err == nil {
+			for _, pod := range pods {
+				if pod.Status.Phase == corev1.PodSucceeded {
+					return nil
+				}
+			}
+		}
+		time.Sleep(sleepBetweenRetries)
+	}
+	return fmt.Errorf("no pod for job %s reached the Succeeded phase after %d retries", jobName, retries)
+}

--- a/test/helpers/jobs.go
+++ b/test/helpers/jobs.go
@@ -22,16 +22,25 @@ import (
 // the workload itself succeeded.
 func WaitForJobPodToSucceed(t testing.TestingT, options *k8s.KubectlOptions, jobName string, retries int, sleepBetweenRetries time.Duration) error {
 	filters := metav1.ListOptions{LabelSelector: "batch.kubernetes.io/job-name=" + jobName}
+	var lastErr error
 	for i := 0; i < retries; i++ {
 		pods, err := k8s.ListPodsE(t, options, filters)
-		if err == nil {
+		switch {
+		case err != nil:
+			lastErr = err
+		case len(pods) == 0:
+			lastErr = fmt.Errorf("no pods found for job %s yet", jobName)
+		default:
+			phases := make([]string, 0, len(pods))
 			for _, pod := range pods {
 				if pod.Status.Phase == corev1.PodSucceeded {
 					return nil
 				}
+				phases = append(phases, fmt.Sprintf("%s=%s", pod.Name, pod.Status.Phase))
 			}
+			lastErr = fmt.Errorf("pods not yet Succeeded: %v", phases)
 		}
 		time.Sleep(sleepBetweenRetries)
 	}
-	return fmt.Errorf("no pod for job %s reached the Succeeded phase after %d retries", jobName, retries)
+	return fmt.Errorf("no pod for job %s reached Succeeded after %d retries; last state: %w", jobName, retries, lastErr)
 }

--- a/test/internal_ingress_controller_test.go
+++ b/test/internal_ingress_controller_test.go
@@ -88,7 +88,7 @@ var _ = Describe("ingress-controllers", Serial, func() {
 			err = k8s.KubectlApplyFromStringE(GinkgoT(), options, tpl)
 			Expect(err).To(BeNil())
 
-			err = k8s.WaitUntilJobSucceedE(GinkgoT(), options, "smoketest-internal-ingress", 10, 20*time.Second)
+			err = helpers.WaitForJobPodToSucceed(GinkgoT(), options, "smoketest-internal-ingress", 10, 20*time.Second)
 			Expect(err).To(BeNil())
 		})
 	})

--- a/test/user_app_logging_test.go
+++ b/test/user_app_logging_test.go
@@ -68,7 +68,7 @@ var _ = Describe("logging", Ordered, Serial, func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// Wait for the job to complete
-			err = k8s.WaitUntilJobSucceedE(GinkgoT(), options, "logging-smoketest", 10, 20*time.Second)
+			err = helpers.WaitForJobPodToSucceed(GinkgoT(), options, "logging-smoketest", 10, 20*time.Second)
 			Expect(err).ToNot(HaveOccurred())
 		})
 


### PR DESCRIPTION
The internal-laa ingress and app-logging smoke tests waited on the Job `Complete` condition (WaitUntilJobSucceedE). The jobs lag well past the 200s wait budget, so the tests timed out even though their pods had already exited 0.

This reflects the real workload outcome and is not gated by job-controller status lag. Note: the underlying control-plane reconciliation lag is tracked separately; this only decouples the tests from it.

TL;DR: This separates pod completion tests (managed by us) from job completion (managed by the control plane via the kube-controller-manager which is the other half of this fix to be addressed shortly).

https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/reporting/jobs/live-integration-tests/builds/24176