### PR TITLE
feat(TF): rollback index change due to Service software version upgrade blocking config changes

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/account/app-opensearch-index-templates.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/account/app-opensearch-index-templates.tf
@@ -9,7 +9,7 @@ resource "opensearch_index_template" "live_kubernetes_cluster" {
   "template": {
     "settings": {
       "index": {
-        "number_of_shards": "20",
+        "number_of_shards": "15",
         "number_of_replicas": "1"
       }
     },


### PR DESCRIPTION
│ Error: updating OpenSearch Domain (***:domain/cp-live-app-logs): operation error OpenSearch: UpdateDomainConfig, https response error StatusCode: 400, RequestID: ***, ValidationException: The requested instance type ultrawarm1.medium.elasticsearch is not supported by your domain's current service software version. Please update your domain's service software before changing the instance type or enable UseLatestServiceSoftwareForBlueGreen setting in Software Update Options with current change to proceed.