### PR TITLE
chore: update monitoring module version

### DIFF
--- a/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/monitoring.tf
+++ b/terraform/aws-accounts/cloud-platform-aws/vpc/eks/core/components/monitoring.tf
@@ -1,5 +1,5 @@
 module "monitoring" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=3.36.7"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-monitoring?ref=3.37.0"
 
   alertmanager_slack_receivers  = local.enable_alerts ? var.alertmanager_slack_receivers : [{ severity = "dummy", webhook = "https://dummy.slack.com", channel = "#dummy-alarms" }]
   pagerduty_config              = local.enable_alerts ? data.aws_ssm_parameter.components["pagerduty_config"].value : "dummy"


### PR DESCRIPTION
Update to use the latest version of the monitoring module. The new tag updates the version of kube state metrics we are using and pins it to 2.28.

Closes https://github.com/ministryofjustice/cloud-platform/issues/8357